### PR TITLE
fix: match Claude Code's project key encoding for special characters

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -709,7 +709,7 @@ function loadSessions() {
   // Enrich Claude sessions with detail file info
   for (const [sid, s] of Object.entries(sessions)) {
     if (s.tool !== 'claude') continue;
-    const projectKey = s.project.replace(/[\/\.]/g, '-');
+    const projectKey = s.project.replace(/[^a-zA-Z0-9-]/g, '-');
     const sessionFile = path.join(PROJECTS_DIR, projectKey, `${sid}.jsonl`);
     if (fs.existsSync(sessionFile)) {
       s.has_detail = true;
@@ -866,7 +866,7 @@ function deleteSession(sessionId, project) {
   const deleted = [];
 
   // 1. Remove session JSONL file from project dir
-  const projectKey = project.replace(/[\/\.]/g, '-');
+  const projectKey = project.replace(/[^a-zA-Z0-9-]/g, '-');
   const sessionFile = path.join(PROJECTS_DIR, projectKey, `${sessionId}.jsonl`);
   if (fs.existsSync(sessionFile)) {
     fs.unlinkSync(sessionFile);
@@ -935,7 +935,7 @@ function getGitCommits(projectDir, fromTs, toTs) {
 }
 
 function exportSessionMarkdown(sessionId, project) {
-  const projectKey = project.replace(/[\/\.]/g, '-');
+  const projectKey = project.replace(/[^a-zA-Z0-9-]/g, '-');
   const sessionFile = path.join(PROJECTS_DIR, projectKey, `${sessionId}.jsonl`);
 
   if (!fs.existsSync(sessionFile)) {
@@ -971,7 +971,7 @@ function exportSessionMarkdown(sessionId, project) {
 function findSessionFile(sessionId, project) {
   // Try Claude projects dir
   if (project) {
-    const projectKey = project.replace(/[\/\.]/g, '-');
+    const projectKey = project.replace(/[^a-zA-Z0-9-]/g, '-');
     const claudeFile = path.join(PROJECTS_DIR, projectKey, `${sessionId}.jsonl`);
     if (fs.existsSync(claudeFile)) return { file: claudeFile, format: 'claude' };
   }


### PR DESCRIPTION
## Summary

- **Bug:** Session detail files were not found for projects with underscores (or other special characters) in their paths, showing "No detail file available for this session" in the UI.
- **Root cause:** Claude Code encodes project paths by replacing **all** non-alphanumeric characters (except `-`) with `-` (e.g. `personal_projects` → `personal-projects`). CodeDash only replaced `/` and `.`, leaving `_` and other special chars intact, so the computed key didn't match the actual directory name.
- **Fix:** Changed regex from `/[\/\.]/g` to `/[^a-zA-Z0-9-]/g` in all 4 places where project keys are computed (`loadSessions`, `deleteSession`, `exportSessionMarkdown`, `findSessionFile`).

## Example

| Path | Before (broken) | After (correct) |
|---|---|---|
| `/home/user/personal_projects` | `-home-user-personal_projects` | `-home-user-personal-projects` |
| `/home/user/hackathon_april` | `-home-user-hackathon_april` | `-home-user-hackathon-april` |

## Test plan

- [x] Verified locally: 122 sessions with `_` in path now correctly resolve detail files (was 0 before fix)
- [x] Sessions without special chars continue to work as before
- [x] `codedash list` and web UI both show correct data