### PR TITLE
feat: аналитика токенов — разбивка стоимости, сравнение подписок, поддержка OpenCode

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1300,6 +1300,8 @@ function getSessionReplay(sessionId, project) {
   };
 }
 
+const CONTEXT_WINDOW = 200_000; // Claude's max context window (tokens)
+
 // ── Pricing per model (per token, April 2026) ─────────────
 
 const MODEL_PRICING = {
@@ -1329,12 +1331,60 @@ function getModelPricing(model) {
 
 function computeSessionCost(sessionId, project) {
   const found = findSessionFile(sessionId, project);
-  if (!found) return { cost: 0, inputTokens: 0, outputTokens: 0, model: '' };
+  if (!found) return { cost: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: '' };
 
   let totalCost = 0;
   let totalInput = 0;
   let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCacheCreate = 0;
+  let contextPctSum = 0;  // sum of per-turn context % (to average across all turns, not just peak)
+  let contextTurnCount = 0;
   let model = '';
+
+  // OpenCode: query SQLite directly for token data
+  if (found.format === 'opencode') {
+    // Validate sessionId to prevent shell/SQL injection (OpenCode IDs are ses_<alphanum>)
+    const safeId = /^[a-zA-Z0-9_-]+$/.test(found.sessionId) ? found.sessionId : '';
+    if (!safeId) return { cost: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: '' };
+    try {
+      const rows = execSync(
+        `sqlite3 "${OPENCODE_DB}" "SELECT data FROM message WHERE session_id = '${safeId}' AND json_extract(data, '$.role') = 'assistant' ORDER BY time_created"`,
+        { encoding: 'utf8', timeout: 10000 }
+      ).trim();
+      if (rows) {
+        for (const row of rows.split('\n')) {
+          try {
+            const msgData = JSON.parse(row);
+            const t = msgData.tokens || {};
+            if (!model && msgData.modelID) model = msgData.modelID;
+            const inp = t.input || 0;
+            const out = (t.output || 0) + (t.reasoning || 0);
+            const cacheRead = (t.cache && t.cache.read) || 0;
+            const cacheCreate = (t.cache && t.cache.write) || 0;
+            if (inp === 0 && out === 0) continue;
+
+            const pricing = getModelPricing(msgData.modelID || model);
+            totalInput += inp;
+            totalOutput += out;
+            totalCacheRead += cacheRead;
+            totalCacheCreate += cacheCreate;
+            totalCost += inp * pricing.input
+                       + cacheCreate * pricing.cache_create
+                       + cacheRead * pricing.cache_read
+                       + out * pricing.output;
+
+            const contextThisTurn = inp + cacheCreate + cacheRead;
+            if (contextThisTurn > 0) {
+              contextPctSum += (contextThisTurn / CONTEXT_WINDOW) * 100;
+              contextTurnCount++;
+            }
+          } catch {}
+        }
+      }
+    } catch {}
+    return { cost: totalCost, inputTokens: totalInput, outputTokens: totalOutput, cacheReadTokens: totalCacheRead, cacheCreateTokens: totalCacheCreate, contextPctSum, contextTurnCount, model };
+  }
 
   try {
     const lines = readLines(found.file);
@@ -1353,12 +1403,21 @@ function computeSessionCost(sessionId, project) {
           const cacheRead = u.cache_read_input_tokens || 0;
           const out = u.output_tokens || 0;
 
-          totalInput += inp + cacheCreate + cacheRead;
+          totalInput += inp;
           totalOutput += out;
+          totalCacheRead += cacheRead;
+          totalCacheCreate += cacheCreate;
           totalCost += inp * pricing.input
                      + cacheCreate * pricing.cache_create
                      + cacheRead * pricing.cache_read
                      + out * pricing.output;
+
+          // Track average context window usage across ALL turns (not just peak)
+          const contextThisTurn = inp + cacheCreate + cacheRead;
+          if (contextThisTurn > 0) {
+            contextPctSum += (contextThisTurn / CONTEXT_WINDOW) * 100;
+            contextTurnCount++;
+          }
         }
         // Codex: estimate from file size (no token usage in session files)
       } catch {}
@@ -1377,7 +1436,7 @@ function computeSessionCost(sessionId, project) {
     } catch {}
   }
 
-  return { cost: totalCost, inputTokens: totalInput, outputTokens: totalOutput, model };
+  return { cost: totalCost, inputTokens: totalInput, outputTokens: totalOutput, cacheReadTokens: totalCacheRead, cacheCreateTokens: totalCacheCreate, contextPctSum, contextTurnCount, model };
 }
 
 // ── Cost analytics ────────────────────────────────────────
@@ -1386,20 +1445,110 @@ function getCostAnalytics(sessions) {
   const byDay = {};
   const byProject = {};
   const byWeek = {};
+  // byAgent tracks which agents contribute cost and which are excluded
+  // 'claude'/'opencode' have real token data; 'codex' is estimated; 'cursor'/'kiro' have none
+  const byAgent = {};
   let totalCost = 0;
   let totalTokens = 0;
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let totalCacheReadTokens = 0;
+  let totalCacheCreateTokens = 0;
+  let globalContextPctSum = 0;   // sum of per-turn context% across all sessions
+  let globalContextTurnCount = 0; // total turns with context data
+  let firstDate = null;
+  let lastDate = null;
+  let sessionsWithData = 0;       // sessions that have actual token/cost data
+  // Count sessions without cost data per agent for UI transparency
+  const agentNoCostData = {};
+  for (const s of sessions) {
+    if (!byAgent[s.tool]) byAgent[s.tool] = { cost: 0, sessions: 0, tokens: 0, estimated: false };
+  }
   const sessionCosts = [];
 
+  // Pre-compute OpenCode costs in one batch query (avoids O(n) execSync calls)
+  const opencodeCostCache = {};
+  const opencodeSessions = sessions.filter(s => s.tool === 'opencode');
+  if (opencodeSessions.length > 0 && fs.existsSync(OPENCODE_DB)) {
+    try {
+      const batchRows = execSync(
+        `sqlite3 "${OPENCODE_DB}" "SELECT session_id, data FROM message WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created"`,
+        { encoding: 'utf8', timeout: 30000 }
+      ).trim();
+      if (batchRows) {
+        for (const row of batchRows.split('\n')) {
+          const sepIdx = row.indexOf('|');
+          if (sepIdx < 0) continue;
+          const sessId = row.slice(0, sepIdx);
+          const jsonStr = row.slice(sepIdx + 1);
+          try {
+            const msgData = JSON.parse(jsonStr);
+            const t = msgData.tokens || {};
+            const inp = t.input || 0;
+            const out = (t.output || 0) + (t.reasoning || 0);
+            const cacheRead = (t.cache && t.cache.read) || 0;
+            const cacheCreate = (t.cache && t.cache.write) || 0;
+            if (inp === 0 && out === 0) continue;
+            if (!opencodeCostCache[sessId]) opencodeCostCache[sessId] = { cost: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: '' };
+            const c = opencodeCostCache[sessId];
+            if (!c.model && msgData.modelID) c.model = msgData.modelID;
+            const pricing = getModelPricing(msgData.modelID || c.model);
+            c.inputTokens += inp;
+            c.outputTokens += out;
+            c.cacheReadTokens += cacheRead;
+            c.cacheCreateTokens += cacheCreate;
+            c.cost += inp * pricing.input + cacheCreate * pricing.cache_create + cacheRead * pricing.cache_read + out * pricing.output;
+            const ctx = inp + cacheCreate + cacheRead;
+            if (ctx > 0) { c.contextPctSum += (ctx / CONTEXT_WINDOW) * 100; c.contextTurnCount++; }
+          } catch {}
+        }
+      }
+    } catch {}
+  }
+
   for (const s of sessions) {
-    const costData = computeSessionCost(s.id, s.project);
+    // Use batch cache for OpenCode sessions, individual computation for others
+    const costData = (s.tool === 'opencode' && opencodeCostCache[s.id])
+      ? opencodeCostCache[s.id]
+      : computeSessionCost(s.id, s.project);
     const cost = costData.cost;
-    const tokens = costData.inputTokens + costData.outputTokens;
-    if (cost === 0 && tokens === 0) continue;
+    const tokens = costData.inputTokens + costData.outputTokens + costData.cacheReadTokens + costData.cacheCreateTokens;
+    if (cost === 0 && tokens === 0) {
+      // Track agents that contribute no data (Cursor, OpenCode, Kiro)
+      if (!agentNoCostData[s.tool]) agentNoCostData[s.tool] = 0;
+      agentNoCostData[s.tool]++;
+      continue;
+    }
+    sessionsWithData++;
     totalCost += cost;
     totalTokens += tokens;
+    totalInputTokens += costData.inputTokens;
+    totalOutputTokens += costData.outputTokens;
+    totalCacheReadTokens += costData.cacheReadTokens;
+    totalCacheCreateTokens += costData.cacheCreateTokens;
 
-    // By day
+    // Track per-agent breakdown
+    const agent = s.tool || 'unknown';
+    if (!byAgent[agent]) byAgent[agent] = { cost: 0, sessions: 0, tokens: 0, estimated: false };
+    byAgent[agent].cost += cost;
+    byAgent[agent].sessions++;
+    byAgent[agent].tokens += tokens;
+    // Codex cost is estimated from file size, not real token data
+    // OpenCode without model info falls back to default pricing — mark as estimated
+    if (agent === 'codex') byAgent[agent].estimated = true;
+    if (agent === 'opencode' && !costData.model) byAgent[agent].estimated = true;
+
+    // Average context % across ALL turns (same method as per-turn averaging)
+    globalContextPctSum += costData.contextPctSum;
+    globalContextTurnCount += costData.contextTurnCount;
+
+    // Track date range for subscription calculations
     const day = s.date || 'unknown';
+    if (s.date) {
+      if (!firstDate || s.date < firstDate) firstDate = s.date;
+      if (!lastDate || s.date > lastDate) lastDate = s.date;
+    }
+
     if (!byDay[day]) byDay[day] = { cost: 0, sessions: 0, tokens: 0 };
     byDay[day].cost += cost;
     byDay[day].sessions++;
@@ -1429,14 +1578,30 @@ function getCostAnalytics(sessions) {
   // Sort top sessions by cost
   sessionCosts.sort((a, b) => b.cost - a.cost);
 
+  // Days in range for daily rate
+  const days = firstDate && lastDate
+    ? Math.max(1, Math.round((new Date(lastDate) - new Date(firstDate)) / 86400000) + 1)
+    : 1;
+
   return {
     totalCost,
     totalTokens,
-    totalSessions: sessions.length,
+    totalInputTokens,
+    totalOutputTokens,
+    totalCacheReadTokens,
+    totalCacheCreateTokens,
+    avgContextPct: globalContextTurnCount > 0 ? Math.round(globalContextPctSum / globalContextTurnCount) : 0,
+    dailyRate: totalCost / days,
+    firstDate,
+    lastDate,
+    days,
+    totalSessions: sessionsWithData,  // only sessions with actual token data
     byDay,
     byWeek,
     byProject,
     topSessions: sessionCosts.slice(0, 10),
+    byAgent,
+    agentNoCostData,
   };
 }
 

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1277,10 +1277,13 @@ async function openDetail(s) {
     var row = document.getElementById('detail-real-cost');
     if (row) {
       row.style.display = '';
+      var cacheStr = '';
+      if ((costData.cacheReadTokens || 0) + (costData.cacheCreateTokens || 0) > 0)
+        cacheStr = ' / ' + formatTokens((costData.cacheReadTokens||0) + (costData.cacheCreateTokens||0)) + ' cache';
       row.querySelector('span:last-child').innerHTML =
         '<span class="cost-badge" style="background:rgba(74,222,128,0.2);color:var(--accent-green)">$' + costData.cost.toFixed(2) + '</span>' +
         ' <span style="font-size:11px;color:var(--text-muted)">' +
-        formatTokens(costData.inputTokens) + ' in / ' + formatTokens(costData.outputTokens) + ' out' +
+        formatTokens(costData.inputTokens) + ' in / ' + formatTokens(costData.outputTokens) + ' out' + cacheStr +
         (costData.model ? ' (' + costData.model + ')' : '') + '</span>';
     }
     // Update estimated badge to show it was estimated
@@ -1811,6 +1814,24 @@ function formatDuration(ms) {
 
 // ── Cost Analytics ────────────────────────────────────────────
 
+// Subscription config — stored in localStorage as { entries: [{plan, paid, from}] }
+// Each entry = one billing period: "from this date I paid $X/mo for plan Y"
+function getSubscriptionConfig() {
+  try {
+    var raw = JSON.parse(localStorage.getItem('codedash-subscription') || 'null');
+    if (!raw) return { entries: [] };
+    // Migrate old single-entry format { plan, paid } → new format
+    if (!raw.entries) return { entries: [{ plan: raw.plan || 'Subscription', paid: raw.paid || 0, from: '' }] };
+    return raw;
+  } catch { return { entries: [] }; }
+}
+function saveSubscriptionConfig(cfg) {
+  localStorage.setItem('codedash-subscription', JSON.stringify(cfg));
+}
+function subTotalPaid(entries) {
+  return entries.reduce(function(s, e) { return s + (parseFloat(e.paid) || 0); }, 0);
+}
+
 async function renderAnalytics(container) {
   container.innerHTML = '<div class="loading">Loading analytics...</div>';
 
@@ -1826,17 +1847,124 @@ async function renderAnalytics(container) {
     var html = '<div class="analytics-container">';
     html += '<h2 class="heatmap-title">Cost Analytics</h2>';
 
-    // Summary cards
+    // ── Summary cards ──────────────────────────────────────────
     html += '<div class="analytics-summary">';
-    html += '<div class="analytics-card"><span class="analytics-val">~$' + data.totalCost.toFixed(2) + '</span><span class="analytics-label">Total estimated cost</span></div>';
+    html += '<div class="analytics-card"><span class="analytics-val">$' + data.totalCost.toFixed(2) + '</span><span class="analytics-label">Total cost (API-equivalent)</span></div>';
     html += '<div class="analytics-card"><span class="analytics-val">' + formatTokens(data.totalTokens) + '</span><span class="analytics-label">Total tokens</span></div>';
+    html += '<div class="analytics-card"><span class="analytics-val">$' + (data.dailyRate || 0).toFixed(2) + '</span><span class="analytics-label">Avg per day (' + (data.days || 1) + ' days)</span></div>';
     html += '<div class="analytics-card"><span class="analytics-val">' + data.totalSessions + '</span><span class="analytics-label">Sessions</span></div>';
-    html += '<div class="analytics-card"><span class="analytics-val">~$' + (data.totalCost / Math.max(data.totalSessions, 1)).toFixed(2) + '</span><span class="analytics-label">Avg per session</span></div>';
     html += '</div>';
 
-    // Cost by day chart (bar chart)
-    var days = Object.keys(data.byDay).sort();
-    var last30 = days.slice(-30);
+    // ── Data coverage note ────────────────────────────────────
+    if (data.byAgent || data.agentNoCostData) {
+      var coverageparts = [];
+      var byAgent = data.byAgent || {};
+      var noCost = data.agentNoCostData || {};
+      // Agents with real data
+      if (byAgent['claude'] && byAgent['claude'].sessions > 0)
+        coverageparts.push('<span class="coverage-ok">Claude Code ✓</span>');
+      if (byAgent['claude-ext'] && byAgent['claude-ext'].sessions > 0)
+        coverageparts.push('<span class="coverage-ok">Claude Extension ✓</span>');
+      if (byAgent['codex'] && byAgent['codex'].sessions > 0)
+        coverageparts.push('<span class="coverage-est">Codex ~est.</span>');
+      if (byAgent['opencode'] && byAgent['opencode'].sessions > 0)
+        coverageparts.push(byAgent['opencode'].estimated
+          ? '<span class="coverage-est">OpenCode ~est.</span>'
+          : '<span class="coverage-ok">OpenCode ✓</span>');
+      // Agents without cost data
+      ['cursor', 'kiro'].forEach(function(a) {
+        if (noCost[a] > 0)
+          coverageparts.push('<span class="coverage-none">' + a + ' ✗ (no token data)</span>');
+      });
+      if (noCost['opencode'] > 0 && !(byAgent['opencode'] && byAgent['opencode'].sessions > 0))
+        coverageparts.push('<span class="coverage-none">opencode ✗ (no token data)</span>');
+      if (coverageparts.length > 0) {
+        html += '<div class="analytics-coverage">Cost data: ' + coverageparts.join(' · ') + '</div>';
+      }
+    }
+
+    // ── Token breakdown ────────────────────────────────────────
+    if (data.totalInputTokens !== undefined) {
+      var totalTok = data.totalInputTokens + data.totalOutputTokens + data.totalCacheReadTokens + data.totalCacheCreateTokens;
+      var pctOf = function(n) { return totalTok > 0 ? Math.round(n / totalTok * 100) : 0; };
+      html += '<div class="chart-section analytics-token-breakdown">';
+      html += '<h3>Token Breakdown</h3>';
+      html += '<div class="token-breakdown-grid">';
+      html += '<div class="token-type-card"><span class="token-type-val">' + formatTokens(data.totalInputTokens) + '</span><span class="token-type-label">Input</span><span class="token-type-pct">' + pctOf(data.totalInputTokens) + '%</span></div>';
+      html += '<div class="token-type-card"><span class="token-type-val">' + formatTokens(data.totalOutputTokens) + '</span><span class="token-type-label">Output</span><span class="token-type-pct">' + pctOf(data.totalOutputTokens) + '%</span></div>';
+      html += '<div class="token-type-card token-cache-read"><span class="token-type-val">' + formatTokens(data.totalCacheReadTokens) + '</span><span class="token-type-label">Cache read</span><span class="token-type-pct">' + pctOf(data.totalCacheReadTokens) + '%</span></div>';
+      html += '<div class="token-type-card token-cache-create"><span class="token-type-val">' + formatTokens(data.totalCacheCreateTokens) + '</span><span class="token-type-label">Cache write</span><span class="token-type-pct">' + pctOf(data.totalCacheCreateTokens) + '%</span></div>';
+      if (data.avgContextPct > 0) {
+        html += '<div class="token-type-card token-context"><span class="token-type-val">' + data.avgContextPct + '%</span><span class="token-type-label">Avg context used</span><span class="token-type-pct">of 200K</span></div>';
+      }
+      html += '</div>';
+      html += '</div>';
+    }
+
+    // ── Subscription vs API ────────────────────────────────────
+    var sub = getSubscriptionConfig();
+    var subEntries = (sub && sub.entries) || [];
+    var totalPaid = subTotalPaid(subEntries);
+    html += '<div class="chart-section subscription-section">';
+    html += '<h3>Subscription vs API</h3>';
+
+    // Comparison cards — only when at least one entry exists
+    if (totalPaid > 0) {
+      var savings = data.totalCost - totalPaid;
+      var multiplier = data.totalCost / totalPaid;
+      var savingsPositive = savings > 0;
+      // Breakdown label: "Pro $20 + Max $100"
+      var breakdown = subEntries.map(function(e) {
+        return escHtml(e.plan || 'Sub') + ' $' + parseFloat(e.paid).toFixed(0);
+      }).join(' + ');
+      html += '<div class="sub-comparison">';
+      html += '<div class="sub-card sub-paid">';
+      html += '<span class="sub-val">$' + totalPaid.toFixed(2) + '</span>';
+      html += '<span class="sub-label">Paid (' + breakdown + ')</span>';
+      html += '</div>';
+      html += '<div class="sub-card sub-api">';
+      html += '<span class="sub-val">$' + data.totalCost.toFixed(2) + '</span>';
+      html += '<span class="sub-label">Would cost at API rates</span>';
+      html += '</div>';
+      html += '<div class="sub-card ' + (savingsPositive ? 'sub-savings' : 'sub-loss') + '">';
+      html += '<span class="sub-val">' + (savingsPositive ? '+' : '') + '$' + Math.abs(savings).toFixed(2) + '</span>';
+      html += '<span class="sub-label">' + (savingsPositive ? 'Saved (' + multiplier.toFixed(1) + '× ROI)' : 'API would be cheaper') + '</span>';
+      html += '</div>';
+      html += '</div>';
+      var barPct = Math.min(100, data.totalCost > 0 ? (totalPaid / data.totalCost * 100) : 100);
+      html += '<div class="sub-bar-track" title="$' + totalPaid.toFixed(2) + ' paid of $' + data.totalCost.toFixed(2) + ' API equivalent">';
+      html += '<div class="sub-bar-fill" style="width:' + barPct + '%"></div>';
+      html += '</div>';
+    } else {
+      html += '<p class="sub-hint">Add your subscription periods below to see how much you\'re saving vs API rates.</p>';
+    }
+
+    // Period list
+    html += '<div class="sub-entries">';
+    if (subEntries.length > 0) {
+      subEntries.forEach(function(e, i) {
+        html += '<div class="sub-entry-row">';
+        html += '<span class="sub-entry-plan">' + escHtml(e.plan || '—') + '</span>';
+        html += '<span class="sub-entry-paid">$' + parseFloat(e.paid || 0).toFixed(2) + '</span>';
+        html += '<span class="sub-entry-from">' + (e.from ? 'from ' + e.from : 'no date') + '</span>';
+        html += '<button class="sub-entry-remove" onclick="removeSubEntry(' + i + ')" title="Remove">×</button>';
+        html += '</div>';
+      });
+    }
+    html += '</div>';
+
+    // Add new period form
+    html += '<div class="sub-add-form">';
+    html += '<input id="sub-new-plan" type="text" placeholder="Plan (Pro, Max…)" />';
+    html += '<input id="sub-new-paid" type="number" min="0" step="0.01" placeholder="Amount ($)" />';
+    html += '<input id="sub-new-from" type="date" title="Start date of this billing period" />';
+    html += '<button onclick="addSubEntry()">+ Add period</button>';
+    html += '</div>';
+    html += '</div>';
+
+    // ── Daily cost chart ───────────────────────────────────────
+    var dayKeys = Object.keys(data.byDay).sort();
+    var last30 = dayKeys.slice(-30);
     if (last30.length > 0) {
       var maxCost = Math.max.apply(null, last30.map(function(d) { return data.byDay[d].cost; }));
       html += '<div class="chart-section"><h3>Daily Cost (last 30 days)</h3>';
@@ -1845,7 +1973,7 @@ async function renderAnalytics(container) {
         var c = data.byDay[d];
         var pct = maxCost > 0 ? (c.cost / maxCost * 100) : 0;
         var label = d.slice(5); // MM-DD
-        html += '<div class="bar-col" title="' + d + ': ~$' + c.cost.toFixed(2) + ' (' + c.sessions + ' sessions)">';
+        html += '<div class="bar-col" title="' + d + ': $' + c.cost.toFixed(2) + ' (' + c.sessions + ' sessions)">';
         html += '<div class="bar-fill" style="height:' + pct + '%"></div>';
         html += '<div class="bar-label">' + label + '</div>';
         html += '</div>';
@@ -1853,7 +1981,7 @@ async function renderAnalytics(container) {
       html += '</div></div>';
     }
 
-    // Cost by project (horizontal bars)
+    // ── Cost by project ────────────────────────────────────────
     var projects = Object.entries(data.byProject).sort(function(a, b) { return b[1].cost - a[1].cost; });
     var topProjects = projects.slice(0, 10);
     if (topProjects.length > 0) {
@@ -1867,22 +1995,43 @@ async function renderAnalytics(container) {
         html += '<div class="hbar-row">';
         html += '<span class="hbar-name">' + escHtml(name) + '</span>';
         html += '<div class="hbar-track"><div class="hbar-fill" style="width:' + pct + '%"></div></div>';
-        html += '<span class="hbar-val">~$' + info.cost.toFixed(2) + '</span>';
+        html += '<span class="hbar-val">$' + info.cost.toFixed(2) + '</span>';
         html += '</div>';
       });
       html += '</div></div>';
     }
 
-    // Top expensive sessions
+    // ── Top expensive sessions ─────────────────────────────────
     if (data.topSessions && data.topSessions.length > 0) {
       html += '<div class="chart-section"><h3>Most Expensive Sessions</h3>';
       html += '<div class="top-sessions">';
       data.topSessions.forEach(function(s) {
         html += '<div class="top-session-row" onclick="onCardClick(\'' + s.id + '\', event)">';
-        html += '<span class="top-session-cost">~$' + s.cost.toFixed(2) + '</span>';
+        html += '<span class="top-session-cost">$' + s.cost.toFixed(2) + '</span>';
         html += '<span class="top-session-project">' + escHtml(s.project) + '</span>';
         html += '<span class="top-session-date">' + (s.date || '') + '</span>';
         html += '<span class="top-session-id">' + s.id.slice(0, 8) + '</span>';
+        html += '</div>';
+      });
+      html += '</div></div>';
+    }
+
+    // ── Cost by agent ──────────────────────────────────────────
+    var agentEntries = Object.entries(data.byAgent || {}).filter(function(e) { return e[1].sessions > 0; });
+    if (agentEntries.length > 1) {
+      agentEntries.sort(function(a, b) { return b[1].cost - a[1].cost; });
+      html += '<div class="chart-section"><h3>Cost by Agent</h3>';
+      html += '<div class="hbar-chart">';
+      var maxAgentCost = agentEntries[0][1].cost || 1;
+      agentEntries.forEach(function(entry) {
+        var name = entry[0]; var info = entry[1];
+        var pct = maxAgentCost > 0 ? (info.cost / maxAgentCost * 100) : 0;
+        var label = { 'claude': 'Claude Code', 'claude-ext': 'Claude Ext', 'codex': 'Codex', 'opencode': 'OpenCode', 'cursor': 'Cursor', 'kiro': 'Kiro' }[name] || name;
+        var estMark = info.estimated ? ' <span style="font-size:10px;opacity:0.6">~est.</span>' : '';
+        html += '<div class="hbar-row">';
+        html += '<span class="hbar-name">' + label + estMark + '</span>';
+        html += '<div class="hbar-track"><div class="hbar-fill" style="width:' + pct + '%"></div></div>';
+        html += '<span class="hbar-val">$' + info.cost.toFixed(2) + ' <span style="font-size:10px;opacity:0.6">(' + info.sessions + ' sess.)</span></span>';
         html += '</div>';
       });
       html += '</div></div>';
@@ -1893,6 +2042,26 @@ async function renderAnalytics(container) {
   } catch (e) {
     container.innerHTML = '<div class="empty-state">Failed to load analytics.</div>';
   }
+}
+
+function addSubEntry() {
+  var plan = (document.getElementById('sub-new-plan').value || '').trim();
+  var paid = parseFloat(document.getElementById('sub-new-paid').value) || 0;
+  var from = (document.getElementById('sub-new-from').value || '').trim();
+  if (!paid) return;
+  var cfg = getSubscriptionConfig();
+  cfg.entries.push({ plan: plan || 'Subscription', paid: paid, from: from });
+  // Keep entries sorted by date
+  cfg.entries.sort(function(a, b) { return (a.from || '').localeCompare(b.from || ''); });
+  saveSubscriptionConfig(cfg);
+  render();
+}
+
+function removeSubEntry(idx) {
+  var cfg = getSubscriptionConfig();
+  cfg.entries.splice(idx, 1);
+  saveSubscriptionConfig(cfg);
+  render();
 }
 
 function formatTokens(n) {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2073,6 +2073,206 @@ body {
 .top-session-date { color: var(--text-muted); font-size: 12px; }
 .top-session-id { font-family: monospace; font-size: 11px; color: var(--text-muted); }
 
+/* ── Data coverage note ──────────────────────────────────────── */
+
+.analytics-coverage {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.coverage-ok   { color: var(--accent-green); }
+.coverage-est  { color: #f59e0b; }
+.coverage-none { color: #f87171; }
+
+/* ── Token breakdown ─────────────────────────────────────────── */
+
+.token-breakdown-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 10px;
+}
+
+.token-type-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.token-type-val {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.token-type-label {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.token-type-pct {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.token-cache-read .token-type-val  { color: var(--accent-green); }
+.token-cache-create .token-type-val { color: var(--accent-blue); }
+.token-context .token-type-val     { color: var(--accent-purple); }
+
+/* ── Subscription vs API ─────────────────────────────────────── */
+
+.subscription-section { }
+
+.sub-hint {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin: 0 0 12px;
+}
+
+.sub-comparison {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.sub-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sub-val {
+    font-size: 22px;
+    font-weight: 700;
+}
+
+.sub-label {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.sub-paid .sub-val   { color: var(--text-secondary); }
+.sub-api .sub-val    { color: var(--accent-blue); }
+.sub-savings .sub-val { color: var(--accent-green); }
+.sub-loss .sub-val   { color: #f87171; }
+
+.sub-bar-track {
+    height: 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 99px;
+    overflow: hidden;
+    margin-bottom: 10px;
+}
+
+.sub-bar-fill {
+    height: 100%;
+    background: linear-gradient(to right, var(--accent-blue), var(--accent-green));
+    border-radius: 99px;
+    transition: width 0.6s ease;
+}
+
+/* Subscription period list */
+.sub-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.sub-entry-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-size: 13px;
+}
+
+.sub-entry-plan {
+    font-weight: 600;
+    min-width: 60px;
+}
+
+.sub-entry-paid {
+    color: var(--accent-green);
+    font-weight: 600;
+    min-width: 60px;
+}
+
+.sub-entry-from {
+    color: var(--text-muted);
+    flex: 1;
+}
+
+.sub-entry-remove {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 4px;
+    transition: color 0.15s;
+}
+.sub-entry-remove:hover { color: #f87171; }
+
+/* Add period form */
+.sub-add-form {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 4px;
+}
+
+.sub-add-form input {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 6px 10px;
+    color: var(--text-primary);
+    font-size: 13px;
+}
+
+.sub-add-form input[type="text"]   { width: 130px; }
+.sub-add-form input[type="number"] { width: 100px; }
+.sub-add-form input[type="date"]   { width: 140px; }
+
+.sub-add-form input:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+}
+
+.sub-add-form button {
+    padding: 6px 14px;
+    background: var(--accent-blue);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+}
+.sub-add-form button:hover { opacity: 0.85; }
+
 /* ── Update banner ──────────────────────────────────────────── */
 
 .update-banner {


### PR DESCRIPTION
# feat: аналитика токенов — разбивка стоимости, сравнение подписок, поддержка OpenCode

## Что сделано

- Разбивка по типам токенов (input/output/cache_read/cache_write) с процентами во вкладке Cost Analytics
- Метрика утилизации контекстного окна (средний % по всем ходам, база 200K)
- Мультипериодное сравнение подписки vs API с ROI и прогресс-баром
- Диаграмма стоимости по агентам с индикаторами качества данных
- Поддержка реальных данных OpenCode через batch-запрос к SQLite
- Защита от SQL-инъекций для OpenCode session ID
- Бейджи прозрачности данных (реальные ✓ / оценка ~est. / нет данных ✗)

## Что изменилось

### `src/data.js` (+183 строки)

**`computeSessionCost()`** — расширенная сигнатура возврата:
```js
{ cost, inputTokens, outputTokens, cacheReadTokens, cacheCreateTokens, contextPctSum, contextTurnCount, model }
```
- Кэш-токены теперь трекаются отдельно (раньше входили в input)
- Context % считается per-turn (раньше — пик за сессию)
- Новая ветка OpenCode: запрос к SQLite за `tokens.input/output`, `tokens.cache.read/write`
- Session ID валидируется через `/^[a-zA-Z0-9_-]+$/` перед shell-выполнением

**`getCostAnalytics()`** — новые поля агрегации:
- `totalInputTokens`, `totalOutputTokens`, `totalCacheReadTokens`, `totalCacheCreateTokens`
- `avgContextPct`, `dailyRate`, `firstDate`, `lastDate`, `days`
- `byAgent` (стоимость/сессии/токены/estimated по каждому агенту), `agentNoCostData`
- `sessionsWithData` заменяет `sessions.length` для `totalSessions`
- Batch pre-computation для OpenCode: один `execSync` на все сессии вместо O(n)

### `src/frontend/app.js` (+193 строки)

- **Детали сессии**: кэш-токены отображаются рядом с input/output
- **Система подписок**: `getSubscriptionConfig()` с миграцией из старого формата `{plan, paid}` → новый `{entries: [{plan, paid, from}]}`; `addSubEntry()` / `removeSubEntry()` с сортировкой по дате
- **renderAnalytics()**: сетка токенов, карточки сравнения подписок + управление периодами, бейджи покрытия, диаграмма "Cost by Agent"
- Бейдж OpenCode: ✓ (реальные данные) или ~est. (нет модели) или ✗ (нет токенов)

### `src/frontend/styles.css` (+200 строк)

- Сетка и карточки для разбивки токенов
- Карточки сравнения подписок, прогресс-бар, список периодов
- Индикаторы покрытия (`.coverage-ok`, `.coverage-est`, `.coverage-none`)
- Адаптивные инпуты для формы добавления периодов подписки

## Как это работает

### Разбивка токенов
Каждое assistant-сообщение в Claude Code JSONL содержит `usage.input_tokens`, `usage.output_tokens`, `usage.cache_creation_input_tokens`, `usage.cache_read_input_tokens`. Теперь они трекаются раздельно и отображаются в виде сетки из 5 карточек с процентами.

### Токены OpenCode
`loadOpenCodeDetail()` уже читает `msgData.tokens` из SQLite, но не использует для расчёта стоимости. Новый код читает `tokens.input`, `tokens.output`, `tokens.reasoning`, `tokens.cache.read`, `tokens.cache.write` и применяет ценообразование через `msgData.modelID`.

Для аналитики один batch-запрос выбирает ВСЕ assistant-сообщения OpenCode разом:
```sql
SELECT session_id, data FROM message
WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created
```
Результаты кэшируются в `opencodeCostCache` и переиспользуются в основном цикле.

### Сравнение с подпиской
Пользователь добавляет периоды оплаты через localStorage (`codedash-subscription`):
```json
{ "entries": [{ "plan": "Pro", "paid": 20, "from": "2025-01-01" }, { "plan": "Max", "paid": 100, "from": "2025-03-01" }] }
```
UI показывает: сумму оплаченного vs API-эквивалент, экономию/переплату, множитель ROI, прогресс-бар.

### Контекстное окно
`avgContextPct = sum(per-turn context%) / turnCount`, где per-turn context = `input + cache_create + cache_read` как процент от 200K.

## Ограничения

- Cursor/Kiro: данные о токенах в их форматах хранения отсутствуют
- Codex: только оценка по размеру файла, помечена как ~est.
- OpenCode без `modelID`: фоллбэк на дефолтный прайсинг, помечен как ~est.
- Контекстное окно захардкожено на 200K (все модели Claude)
- Фильтрация подписок по датам не реализована (итого = сумма всех периодов)
- Доработка тем dark/monokai не требуется (наследует существующие CSS-переменные)

## Тест-план

- [ ] Запустить `node bin/cli.js run --port=3333`, убедиться что вкладка Cost Analytics загружается
- [ ] Проверить что разбивка токенов показывает корректные проценты (сумма = 100%)
- [ ] Добавить период подписки, проверить сохранение после перезагрузки страницы
- [ ] Удалить период подписки, проверить обновление UI
- [ ] Проверить соответствие бейджей покрытия установленным агентам
- [ ] Тест с установленным OpenCode: реальные счётчики токенов появляются
- [ ] Тест без OpenCode: нет ошибок, OpenCode отсутствует или показывает ✗
- [ ] Проверить что в деталях сессии отображаются кэш-токены (если есть)
- [ ] Проверить что диаграмма "Cost by Agent" появляется только при 2+ агентах с данными
- [ ] Убедиться в отсутствии ошибок в консоли браузера (DevTools)

Closes #18