### PR TITLE
feat: enable remote access and Node.js-free Docker runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supported flags:
 - `--all` enables every supported mount
 
 The base container always listens on `0.0.0.0:3847`, so it can be reached via the host machine LAN IP when Docker publishes that port.
+Mounted agent data sources are writable inside the container so CodeDash actions like delete, convert, and settings updates work the same way as a host run.
 
 ## Supported Agents
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ npm i -g codedash-app
 codedash run
 ```
 
+## Docker
+
+Docker files live under `docker/`. Use `./in-docker.sh` to select which host agent data sources should be mounted into the container.
+
+```bash
+./in-docker.sh --claude --codex
+./in-docker.sh --cursor -- up -d
+./in-docker.sh --all -- up --build
+```
+
+Supported flags:
+- `--claude` mounts `~/.claude` to `/root/.claude`
+- `--codex` mounts `~/.codex` to `/root/.codex`
+- `--cursor` mounts `~/.cursor` to `/root/.cursor`
+- `--opencode` mounts `~/.local/share/opencode/opencode.db`
+- `--kiro` mounts `~/Library/Application Support/kiro-cli/data.sqlite3`
+- `--all` enables every supported mount
+
+The base container always listens on `0.0.0.0:3847`, so it can be reached via the host machine LAN IP when Docker publishes that port.
+
 ## Supported Agents
 
 | Agent | Sessions | Preview | Search | Live Status | Convert | Handoff | Launch |
@@ -72,6 +92,13 @@ codedash restart
 codedash stop
 ```
 
+Bind host can be configured with `CODEDASH_HOST`:
+
+```bash
+codedash run
+CODEDASH_HOST=0.0.0.0 codedash run
+```
+
 **Keyboard Shortcuts**: `/` search, `j/k` navigate, `Enter` open, `x` star, `d` delete, `s` select, `g` group, `r` refresh, `Esc` close
 
 ## Data Sources
@@ -84,7 +111,7 @@ codedash stop
 ~/Library/Application Support/kiro-cli/ Kiro CLI (SQLite)
 ```
 
-Zero dependencies. Everything runs on `localhost`.
+Zero dependencies. By default everything runs on `localhost`. Set `CODEDASH_HOST=0.0.0.0` to listen on all interfaces, including your host machine LAN IP.
 
 ## Install Agents
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+RUN apk add --no-cache sqlite
+
+WORKDIR /app
+
+COPY package.json ./
+COPY bin ./bin
+COPY src ./src
+
+EXPOSE 3847
+
+CMD ["node", "bin/cli.js", "run", "--no-browser", "--port=3847"]

--- a/docker/docker-compose.claude.yml
+++ b/docker/docker-compose.claude.yml
@@ -1,0 +1,7 @@
+services:
+  codedash:
+    volumes:
+      - type: bind
+        source: ${HOST_CLAUDE_DIR}
+        target: /root/.claude
+        read_only: true

--- a/docker/docker-compose.claude.yml
+++ b/docker/docker-compose.claude.yml
@@ -4,4 +4,3 @@ services:
       - type: bind
         source: ${HOST_CLAUDE_DIR}
         target: /root/.claude
-        read_only: true

--- a/docker/docker-compose.codex.yml
+++ b/docker/docker-compose.codex.yml
@@ -1,0 +1,7 @@
+services:
+  codedash:
+    volumes:
+      - type: bind
+        source: ${HOST_CODEX_DIR}
+        target: /root/.codex
+        read_only: true

--- a/docker/docker-compose.codex.yml
+++ b/docker/docker-compose.codex.yml
@@ -4,4 +4,3 @@ services:
       - type: bind
         source: ${HOST_CODEX_DIR}
         target: /root/.codex
-        read_only: true

--- a/docker/docker-compose.cursor.yml
+++ b/docker/docker-compose.cursor.yml
@@ -4,4 +4,3 @@ services:
       - type: bind
         source: ${HOST_CURSOR_DIR}
         target: /root/.cursor
-        read_only: true

--- a/docker/docker-compose.cursor.yml
+++ b/docker/docker-compose.cursor.yml
@@ -1,0 +1,7 @@
+services:
+  codedash:
+    volumes:
+      - type: bind
+        source: ${HOST_CURSOR_DIR}
+        target: /root/.cursor
+        read_only: true

--- a/docker/docker-compose.kiro.yml
+++ b/docker/docker-compose.kiro.yml
@@ -4,4 +4,3 @@ services:
       - type: bind
         source: ${HOST_KIRO_DB}
         target: /root/Library/Application Support/kiro-cli/data.sqlite3
-        read_only: true

--- a/docker/docker-compose.kiro.yml
+++ b/docker/docker-compose.kiro.yml
@@ -1,0 +1,7 @@
+services:
+  codedash:
+    volumes:
+      - type: bind
+        source: ${HOST_KIRO_DB}
+        target: /root/Library/Application Support/kiro-cli/data.sqlite3
+        read_only: true

--- a/docker/docker-compose.opencode.yml
+++ b/docker/docker-compose.opencode.yml
@@ -4,4 +4,3 @@ services:
       - type: bind
         source: ${HOST_OPENCODE_DB}
         target: /root/.local/share/opencode/opencode.db
-        read_only: true

--- a/docker/docker-compose.opencode.yml
+++ b/docker/docker-compose.opencode.yml
@@ -1,0 +1,7 @@
+services:
+  codedash:
+    volumes:
+      - type: bind
+        source: ${HOST_OPENCODE_DB}
+        target: /root/.local/share/opencode/opencode.db
+        read_only: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  codedash:
+    image: ghcr.io/vakovalskii/codedash
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: codedash
+    restart: unless-stopped
+    environment:
+      HOME: /root
+      CODEDASH_HOST: 0.0.0.0
+      CODEDASH_LOG: "1"
+    ports:
+      - "3847:3847"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CodeDash is a zero-dependency Node.js dashboard for AI coding agent sessions. Supports 6 agents: Claude Code, Claude Extension, Codex, Cursor, OpenCode, Kiro. Single process serves a web UI at `localhost:3847`.
+CodeDash is a zero-dependency Node.js dashboard for AI coding agent sessions. Supports 6 agents: Claude Code, Claude Extension, Codex, Cursor, OpenCode, Kiro. Single process serves a web UI at `localhost:3847` by default, or another bind host via `CODEDASH_HOST`.
 
 ```
 Browser (localhost:3847)            Node.js Server

--- a/in-docker.sh
+++ b/in-docker.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+DOCKER_DIR="$SCRIPT_DIR/docker"
+
+BASE_COMPOSE="$DOCKER_DIR/docker-compose.yml"
+
+USE_CLAUDE=0
+USE_CODEX=0
+USE_CURSOR=0
+USE_KIRO=0
+USE_OPENCODE=0
+
+print_usage() {
+  cat <<'EOF'
+Usage: ./in-docker.sh [options] [-- docker-compose-args...]
+
+Options:
+  --claude      Mount ~/.claude
+  --codex       Mount ~/.codex
+  --cursor      Mount ~/.cursor
+  --kiro        Mount ~/Library/Application Support/kiro-cli/data.sqlite3
+  --opencode    Mount ~/.local/share/opencode/opencode.db
+  --all         Enable all supported mounts
+  -h, --help    Show this help
+
+Examples:
+  ./in-docker.sh --claude --codex
+  ./in-docker.sh --all -- up --build
+  ./in-docker.sh --cursor -- up -d
+
+If no docker-compose args are provided, the script runs:
+  docker compose ... up --build
+EOF
+}
+
+require_path() {
+  label=$1
+  path_value=$2
+  if [ ! -e "$path_value" ]; then
+    printf '%s\n' "Missing $label path: $path_value" >&2
+    exit 1
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --claude)
+      USE_CLAUDE=1
+      shift
+      ;;
+    --codex)
+      USE_CODEX=1
+      shift
+      ;;
+    --cursor)
+      USE_CURSOR=1
+      shift
+      ;;
+    --kiro)
+      USE_KIRO=1
+      shift
+      ;;
+    --opencode)
+      USE_OPENCODE=1
+      shift
+      ;;
+    --all)
+      USE_CLAUDE=1
+      USE_CODEX=1
+      USE_CURSOR=1
+      USE_KIRO=1
+      USE_OPENCODE=1
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+compose_files=(-f "$BASE_COMPOSE")
+compose_args=("$@")
+
+if [ "${#compose_args[@]}" -eq 0 ]; then
+  compose_args=(up --build)
+fi
+
+if [ "$USE_CLAUDE" -eq 1 ]; then
+  HOST_CLAUDE_DIR="${HOST_CLAUDE_DIR:-$HOME/.claude}"
+  require_path "Claude" "$HOST_CLAUDE_DIR"
+  export HOST_CLAUDE_DIR
+  compose_files+=(-f "$DOCKER_DIR/docker-compose.claude.yml")
+fi
+
+if [ "$USE_CODEX" -eq 1 ]; then
+  HOST_CODEX_DIR="${HOST_CODEX_DIR:-$HOME/.codex}"
+  require_path "Codex" "$HOST_CODEX_DIR"
+  export HOST_CODEX_DIR
+  compose_files+=(-f "$DOCKER_DIR/docker-compose.codex.yml")
+fi
+
+if [ "$USE_CURSOR" -eq 1 ]; then
+  HOST_CURSOR_DIR="${HOST_CURSOR_DIR:-$HOME/.cursor}"
+  require_path "Cursor" "$HOST_CURSOR_DIR"
+  export HOST_CURSOR_DIR
+  compose_files+=(-f "$DOCKER_DIR/docker-compose.cursor.yml")
+fi
+
+if [ "$USE_KIRO" -eq 1 ]; then
+  HOST_KIRO_DB="${HOST_KIRO_DB:-$HOME/Library/Application Support/kiro-cli/data.sqlite3}"
+  require_path "Kiro" "$HOST_KIRO_DB"
+  export HOST_KIRO_DB
+  compose_files+=(-f "$DOCKER_DIR/docker-compose.kiro.yml")
+fi
+
+if [ "$USE_OPENCODE" -eq 1 ]; then
+  HOST_OPENCODE_DB="${HOST_OPENCODE_DB:-$HOME/.local/share/opencode/opencode.db}"
+  require_path "OpenCode" "$HOST_OPENCODE_DB"
+  export HOST_OPENCODE_DB
+  compose_files+=(-f "$DOCKER_DIR/docker-compose.opencode.yml")
+fi
+
+exec docker compose "${compose_files[@]}" "${compose_args[@]}"

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -87,6 +87,43 @@ function showToast(msg) {
   setTimeout(() => el.classList.remove('show'), 2500);
 }
 
+function fallbackCopyText(text) {
+  try {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '-9999px';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    var ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch (e) {
+    return false;
+  }
+}
+
+function copyText(text, successMsg) {
+  var done = function() {
+    showToast(successMsg || ('Copied: ' + text));
+    return true;
+  };
+  var fail = function() {
+    if (fallbackCopyText(text)) return done();
+    prompt('Copy this command:', text);
+    showToast(window.isSecureContext ? 'Clipboard copy failed' : 'Clipboard unavailable on non-secure origin');
+    return false;
+  };
+
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    return navigator.clipboard.writeText(text).then(done).catch(fail);
+  }
+  return Promise.resolve(fail());
+}
+
 function formatBytes(bytes) {
   if (!bytes || bytes < 1024) return (bytes || 0) + ' B';
   if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
@@ -1358,12 +1395,7 @@ function copyResume(sessionId, tool) {
   } else {
     cmd = 'claude --resume ' + sessionId;
   }
-  navigator.clipboard.writeText(cmd).then(function() {
-    showToast('Copied: ' + cmd);
-  }).catch(function() {
-    // Fallback
-    prompt('Copy this command:', cmd);
-  });
+  copyText(cmd, 'Copied: ' + cmd);
 }
 
 function exportMd(sessionId, project) {
@@ -2038,7 +2070,7 @@ function installAgent(agent) {
 
   var overlay = document.getElementById('confirmOverlay');
   document.getElementById('confirmTitle').textContent = 'Install ' + info.name;
-  var html = '<code style="display:block;margin:8px 0;padding:10px;background:var(--bg-card);border-radius:6px;font-size:13px;cursor:pointer" onclick="navigator.clipboard.writeText(\'' + info.cmd.replace(/'/g, "\\'") + '\');document.querySelector(\'#toast\').textContent=\'Copied!\';document.querySelector(\'#toast\').classList.add(\'show\');setTimeout(function(){document.querySelector(\'#toast\').classList.remove(\'show\')},1500)">' + escHtml(info.cmd) + '</code>';
+  var html = '<code style="display:block;margin:8px 0;padding:10px;background:var(--bg-card);border-radius:6px;font-size:13px;cursor:pointer" onclick="copyText(\'' + info.cmd.replace(/'/g, "\\'") + '\', \'Copied!\')">' + escHtml(info.cmd) + '</code>';
   if (info.alt) {
     html += '<span style="font-size:11px;color:var(--text-muted)">or: <code>' + escHtml(info.alt) + '</code></span><br>';
   }
@@ -2048,9 +2080,7 @@ function installAgent(agent) {
   document.getElementById('confirmAction').textContent = 'Copy Install Command';
   document.getElementById('confirmAction').className = 'launch-btn btn-primary';
   document.getElementById('confirmAction').onclick = function() {
-    navigator.clipboard.writeText(info.cmd).then(function() {
-      showToast('Copied: ' + info.cmd);
-    });
+    copyText(info.cmd, 'Copied: ' + info.cmd);
     closeConfirm();
   };
   if (overlay) overlay.style.display = 'flex';
@@ -2072,9 +2102,7 @@ function showExportDialog() {
   document.getElementById('confirmAction').textContent = 'Copy Export Command';
   document.getElementById('confirmAction').className = 'launch-btn btn-primary';
   document.getElementById('confirmAction').onclick = function() {
-    navigator.clipboard.writeText('codedash export').then(function() {
-      showToast('Copied: codedash export');
-    });
+    copyText('codedash export', 'Copied: codedash export');
     closeConfirm();
   };
   if (overlay) overlay.style.display = 'flex';
@@ -2105,9 +2133,7 @@ async function checkForUpdates() {
         badge.classList.add('update-available');
         badge.title = 'Click to copy update command';
         badge.onclick = function() {
-          navigator.clipboard.writeText('npm i -g codedash-app@latest').then(function() {
-            showToast('Copied: npm i -g codedash-app@latest');
-          });
+          copyText('npm i -g codedash-app@latest', 'Copied: npm i -g codedash-app@latest');
         };
       }
       var banner = document.getElementById('updateBanner');
@@ -2123,9 +2149,7 @@ async function checkForUpdates() {
 
 function copyUpdate() {
   var cmd = 'codedash update && codedash restart';
-  navigator.clipboard.writeText(cmd).then(function() {
-    showToast('Copied: ' + cmd + '  (run in terminal)');
-  });
+  copyText(cmd, 'Copied: ' + cmd + '  (run in terminal)');
 }
 
 function dismissUpdate() {

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,7 @@
 const http = require('http');
 const https = require('https');
 const { URL } = require('url');
-const { exec } = require('child_process');
+const { exec, execFile } = require('child_process');
 const { loadSessions, loadSessionDetail, deleteSession, getGitCommits, exportSessionMarkdown, getSessionPreview, searchFullText, getActiveSessions, getSessionReplay, getCostAnalytics, computeSessionCost } = require('./data');
 const { detectTerminals, openInTerminal, focusTerminalByPid } = require('./terminals');
 const { convertSession } = require('./convert');
@@ -28,6 +28,7 @@ function log(tag, msg, data) {
 
 function startServer(port, openBrowser = true) {
   const host = process.env.CODEDASH_HOST || DEFAULT_HOST;
+  const browserUrl = getBrowserUrl(host, port);
   const server = http.createServer((req, res) => {
     const parsed = new URL(req.url, `http://localhost:${port}`);
     const pathname = parsed.pathname;
@@ -376,15 +377,15 @@ function startServer(port, openBrowser = true) {
     console.log('');
     console.log('  \x1b[36m\x1b[1mcodedash\x1b[0m — Claude & Codex Sessions Dashboard');
     console.log(`  \x1b[2mbind ${host}:${port}\x1b[0m`);
-    console.log(`  \x1b[2mhttp://localhost:${port}\x1b[0m`);
+    console.log(`  \x1b[2m${browserUrl}\x1b[0m`);
     console.log('  \x1b[2mPress Ctrl+C to stop\x1b[0m');
     console.log('');
 
     if (openBrowser) {
       if (process.platform === 'darwin') {
-        exec(`open http://localhost:${port}`);
+        execFile('open', [browserUrl]);
       } else if (process.platform === 'linux') {
-        exec(`xdg-open http://localhost:${port}`);
+        execFile('xdg-open', [browserUrl]);
       }
     }
   });
@@ -400,6 +401,26 @@ function readBody(req, cb) {
   let body = '';
   req.on('data', chunk => body += chunk);
   req.on('end', () => cb(body));
+}
+
+function getBrowserUrl(host, port) {
+  const browserHost = getBrowserHost(host);
+  const wrappedHost = browserHost.includes(':') && !browserHost.startsWith('[')
+    ? `[${browserHost}]`
+    : browserHost;
+  return `http://${wrappedHost}:${port}`;
+}
+
+function getBrowserHost(host) {
+  if (!host || host === DEFAULT_HOST || host === 'localhost' || host === '::1') {
+    return 'localhost';
+  }
+  if (host === '0.0.0.0' || host === '::' || host === '[::]') {
+    // This URL is only used to show/open the app locally on the machine that started it.
+    // Wildcard bind addresses are valid listen targets, but they are not usable browser hosts.
+    return 'localhost';
+  }
+  return host;
 }
 
 // ── npm version check ───────────────────

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ const { getHTML } = require('./html');
 
 // ── Logging ──────────────────────────────────
 const LOG_VERBOSE = process.env.CODEDASH_LOG !== '0';
+const DEFAULT_HOST = '127.0.0.1';
 
 function log(tag, msg, data) {
   if (!LOG_VERBOSE && tag !== 'ERROR') return;
@@ -26,6 +27,7 @@ function log(tag, msg, data) {
 }
 
 function startServer(port, openBrowser = true) {
+  const host = process.env.CODEDASH_HOST || DEFAULT_HOST;
   const server = http.createServer((req, res) => {
     const parsed = new URL(req.url, `http://localhost:${port}`);
     const pathname = parsed.pathname;
@@ -370,9 +372,10 @@ function startServer(port, openBrowser = true) {
     }
   });
 
-  server.listen(port, '127.0.0.1', () => {
+  server.listen(port, host, () => {
     console.log('');
     console.log('  \x1b[36m\x1b[1mcodedash\x1b[0m — Claude & Codex Sessions Dashboard');
+    console.log(`  \x1b[2mbind ${host}:${port}\x1b[0m`);
     console.log(`  \x1b[2mhttp://localhost:${port}\x1b[0m`);
     console.log('  \x1b[2mPress Ctrl+C to stop\x1b[0m');
     console.log('');

--- a/src/server.js
+++ b/src/server.js
@@ -29,6 +29,8 @@ function log(tag, msg, data) {
 function startServer(host, port, openBrowser = true) {
   const browserUrl = getBrowserUrl(host, port);
   const server = http.createServer((req, res) => {
+    // req.url is usually relative, so this base is only for URL parsing.
+    // Keep it stable instead of reusing the bind host, which may be a wildcard listen address.
     const parsed = new URL(req.url, `http://localhost:${port}`);
     const pathname = parsed.pathname;
     const reqStart = Date.now();


### PR DESCRIPTION
## Summary

This PR improves remote access for CodeDash in three connected ways:

- adds configurable bind host support through `CODEDASH_HOST`, while keeping localhost as the default
- introduces a Docker-based way to run CodeDash without requiring Node.js on the host
- fixes clipboard-based copy actions so they still work, or at least fail gracefully, when CodeDash is accessed from non-secure LAN origins

Together, these changes make it practical to run CodeDash on one machine and use it from another device on the same network, while keeping the default single-machine behavior unchanged.

## Why this change is needed

Before this work:

- the server bound only to `127.0.0.1`, which blocked simple LAN access
- running CodeDash still assumed a local Node.js environment on the host machine
- frontend copy actions such as `Copy Command` could fail silently on non-secure origins like `http://<lan-ip>:3847`

Those limitations made remote browser access awkward even though the app otherwise works well in that model.

This PR addresses that with an intentionally lightweight approach:

- remote exposure is opt-in through `CODEDASH_HOST=0.0.0.0`
- Docker provides a practical runtime path for machines without host Node.js
- clipboard fallbacks make key UI actions usable when browser clipboard APIs are restricted

This is aimed at local-network convenience, not hardened internet-facing deployment.

## What changed

- Added `CODEDASH_HOST` support in the server startup path
- Kept the default bind host as `127.0.0.1`
- Updated `server.listen(...)` to use the configured host
- Updated startup logs to show the effective bind target and browser URL separately
- Kept wildcard binds browser-friendly by advertising `http://localhost:<port>`, while concrete configured hosts are advertised directly
- Documented the new host-binding behavior in `README.md`
- Updated `docs/ARCHITECTURE.md` to reflect that localhost is the default, not the only mode

- Added a Docker image and Compose setup under `docker/`
- Added optional Compose override files for `claude`, `codex`, `cursor`, `opencode`, and `kiro`
- Added a root `in-docker.sh` helper that assembles the right `docker compose -f ...` combination from flags such as `--claude`, `--codex`, and `--all`
- Added README guidance for running CodeDash in Docker
- Kept the container mounts narrower than a broad home-directory mount by only attaching the requested agent data sources
- Kept Claude and Codex mounts writable so delete, convert, and CodeDash LLM settings work in Docker, while leaving read-only mounts in place for data sources that CodeDash only reads

- Added a shared `copyText()` helper for clipboard actions in the frontend
- Added a textarea-based fallback for cases where `navigator.clipboard` is unavailable
- Added a final manual-copy fallback via `prompt(...)` when browser clipboard access still fails
- Updated `Copy Command` to use the shared helper
- Updated the other existing copy actions to use the same helper for consistent behavior

## Why this does not break existing usage

- Default behavior is unchanged. If `CODEDASH_HOST` is not set, CodeDash still binds to `127.0.0.1`.
- Existing CLI usage is unchanged. `codedash run`, `codedash restart`, and `--no-browser` keep the same interface and semantics.
- Browser auto-open behavior remains browser-friendly for local use: wildcard binds still open `localhost`, while concrete configured hosts open that host directly.
- The Docker path is additive. It provides another way to run CodeDash but does not replace the existing host-based workflow.
- Clipboard behavior in secure contexts is unchanged because the app still tries `navigator.clipboard.writeText()` first.
- The new copy fallback logic only affects cases that were already failing or unreliable.
- No server APIs, stored data, session parsing, search, previews, conversions, or handoff logic are changed.

## User impact

Before:

- CodeDash could only be reached from the same machine where it was started
- running on a machine without Node.js on the host was less practical
- `Copy Command` and similar actions could silently fail when accessed over LAN or other non-secure origins

After:

- local single-machine usage behaves the same as before
- users can optionally expose CodeDash on their local network by setting `CODEDASH_HOST=0.0.0.0`
- users can run CodeDash in Docker for browser-based access without host Node.js
- startup output is clearer about what address the server is bound to
- startup output and browser auto-open use a real browser URL instead of always hard-coding `localhost`
- copy actions are more resilient in remote-access environments and still provide a manual fallback if needed

## Risk assessment

Low risk.

The changes are narrow and mostly isolated to:

- server startup configuration
- containerized launch scaffolding and documentation
- frontend clipboard behavior

The only network exposure change is opt-in, the Docker path is additive, Claude/Codex mounts stay writable where CodeDash already mutates data, and the clipboard updates are fallback-oriented rather than a replacement of the normal success path.

## What to test

Please test remote access carefully.

- Start CodeDash normally and confirm it still behaves as localhost-only
- Start CodeDash with `CODEDASH_HOST=0.0.0.0` and confirm it binds successfully
- Open CodeDash locally at `http://localhost:3847`
- Open CodeDash from another device using the host machine IP on the same LAN
- Verify `Copy Command` works on localhost and still shows a success toast
- Verify `Copy Command` no longer fails silently from a non-secure / non-localhost origin
- Verify the other copy actions still work and show expected feedback
- Start CodeDash through Docker with `CODEDASH_HOST=0.0.0.0`
- Verify it is reachable from another machine on the same LAN using the host machine IP and port `3847`
- Confirm the expected agent sources appear when enabled through `in-docker.sh`
- Confirm omitted sources are not mounted and do not appear in the UI
- Verify the setup works on a machine that does not have Node.js installed on the host

## Example commands

```bash
CODEDASH_HOST=0.0.0.0 codedash run
./in-docker.sh --claude --codex
./in-docker.sh --cursor -- up -d
./in-docker.sh --all -- up --build
```

## Notes

- This remote-access mode should be treated as LAN convenience, not a hardened deployment model.
- The Docker path is aimed at browser access and data inspection.
- Terminal launch / focus behavior should be treated as degraded or unsupported in the containerized environment.
