### PR TITLE
feat: add --host flag to configure server bind address

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,6 +7,7 @@ const { convertSession } = require('../src/convert');
 const { generateHandoff, quickHandoff } = require('../src/handoff');
 
 const DEFAULT_PORT = 3847;
+const DEFAULT_HOST = 'localhost';
 const args = process.argv.slice(2);
 const command = args[0] || 'help';
 
@@ -15,8 +16,10 @@ switch (command) {
   case 'start': {
     const portArg = args.find(a => a.startsWith('--port='));
     const port = portArg ? parseInt(portArg.split('=')[1]) : (parseInt(args[1]) || DEFAULT_PORT);
+    const hostArg = args.find(a => a.startsWith('--host='));
+    const host = hostArg ? hostArg.split('=')[1] : (process.env.CODEDASH_HOST || DEFAULT_HOST);
     const noBrowser = args.includes('--no-browser');
-    startServer(port, !noBrowser);
+    startServer(host, port, !noBrowser);
     break;
   }
 
@@ -253,6 +256,8 @@ switch (command) {
     const { execSync } = require('child_process');
     const portArg = args.find(a => a.startsWith('--port='));
     const port = portArg ? parseInt(portArg.split('=')[1]) : DEFAULT_PORT;
+    const hostArg = args.find(a => a.startsWith('--host='));
+    const host = hostArg ? hostArg.split('=')[1] : (process.env.CODEDASH_HOST || DEFAULT_HOST);
     console.log(`\n  Stopping codedash on port ${port}...`);
     try {
       execSync(`lsof -ti:${port} | xargs kill -9 2>/dev/null`, { stdio: 'pipe' });
@@ -263,7 +268,7 @@ switch (command) {
     setTimeout(() => {
       console.log('  Starting...\n');
       const noBrowser = args.includes('--no-browser');
-      startServer(port, !noBrowser);
+      startServer(host, port, !noBrowser);
     }, 500);
     break;
   }
@@ -328,9 +333,18 @@ switch (command) {
     codedash help                        Show this help
     codedash version                     Show version
 
+  \x1b[1mServer options:\x1b[0m
+    --port=N                             Listen on port N (default: ${DEFAULT_PORT})
+    --host=ADDR                          Bind to address (default: localhost)
+    --no-browser                         Don't open browser on start
+
+  \x1b[1mEnvironment variables:\x1b[0m
+    CODEDASH_HOST                        Bind address (same as --host)
+
   \x1b[1mExamples:\x1b[0m
     codedash run                         Start on port ${DEFAULT_PORT}
     codedash run --port=4000             Start on port 4000
+    codedash run --host=0.0.0.0          Listen on all interfaces
     codedash run --no-browser            Start without opening browser
     codedash list 50                     Show last 50 sessions
     codedash ls                          Alias for list

--- a/src/server.js
+++ b/src/server.js
@@ -25,9 +25,9 @@ function log(tag, msg, data) {
   console.log(line);
 }
 
-function startServer(port, openBrowser = true) {
+function startServer(host, port, openBrowser = true) {
   const server = http.createServer((req, res) => {
-    const parsed = new URL(req.url, `http://localhost:${port}`);
+    const parsed = new URL(req.url, `http://${host}:${port}`);
     const pathname = parsed.pathname;
     const reqStart = Date.now();
 
@@ -370,18 +370,26 @@ function startServer(port, openBrowser = true) {
     }
   });
 
-  server.listen(port, '127.0.0.1', () => {
+  const bindAddr = host === 'localhost' ? '127.0.0.1' : host;
+  const displayHost = host === '0.0.0.0' ? 'localhost' : host;
+  const displayUrl = `http://${displayHost}:${port}`;
+
+  server.listen(port, bindAddr, () => {
     console.log('');
     console.log('  \x1b[36m\x1b[1mcodedash\x1b[0m — Claude & Codex Sessions Dashboard');
-    console.log(`  \x1b[2mhttp://localhost:${port}\x1b[0m`);
+    console.log(`  \x1b[2m${displayUrl}\x1b[0m`);
+    if (host === '0.0.0.0') {
+      console.log('  \x1b[2mListening on all interfaces\x1b[0m');
+    }
     console.log('  \x1b[2mPress Ctrl+C to stop\x1b[0m');
     console.log('');
 
     if (openBrowser) {
+      const browserUrl = `http://localhost:${port}`;
       if (process.platform === 'darwin') {
-        exec(`open http://localhost:${port}`);
+        exec(`open ${browserUrl}`);
       } else if (process.platform === 'linux') {
-        exec(`xdg-open http://localhost:${port}`);
+        exec(`xdg-open ${browserUrl}`);
       }
     }
   });


### PR DESCRIPTION
## Summary

  - Add `--host=ADDR` CLI flag for `run`/`start`/`restart` commands to bind the server to a specific network interface
  - Add `CODEDASH_HOST` environment variable as an alternative to the CLI flag
  - Default remains `localhost` (127.0.0.1) — fully backward compatible, no breaking changes

  ## Motivation

  Currently the server is hardcoded to `localhost`, making it impossible to access from other machines on the network. This is needed for:
  - Remote access (e.g., running codedash on a headless server)
  - Docker/container environments where `0.0.0.0` binding is required
  - Local network access from other devices (phone, tablet, another machine)

  ## Usage

  ```bash
  # Default behavior (unchanged)
  codedash run

  # Listen on all interfaces
  codedash run --host=0.0.0.0

  # Bind to a specific IP
  codedash run --host=192.168.1.100

  # Via environment variable
  CODEDASH_HOST=0.0.0.0 codedash run

  # Combined with port
  codedash run --host=0.0.0.0 --port=4000
  ```