### PR TITLE
fix: use tab separator for sqlite3 queries to handle pipes in session titles

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -209,16 +209,17 @@ function scanOpenCodeSessions() {
   if (!fs.existsSync(OPENCODE_DB)) return sessions;
 
   try {
-    // Use sqlite3 CLI to avoid Node version dependency
+    // Use sqlite3 CLI with tab separator — session titles can contain pipes
+    // (e.g. "review changes [commit|branch|pr]") which break the default | separator
     const rows = execSync(
-      `sqlite3 "${OPENCODE_DB}" "SELECT s.id, s.title, s.directory, s.time_created, s.time_updated, COUNT(m.id) as msg_count FROM session s LEFT JOIN message m ON m.session_id = s.id GROUP BY s.id ORDER BY s.time_updated DESC"`,
+      `sqlite3 -separator $'\\t' "${OPENCODE_DB}" "SELECT s.id, s.title, s.directory, s.time_created, s.time_updated, COUNT(m.id) as msg_count FROM session s LEFT JOIN message m ON m.session_id = s.id GROUP BY s.id ORDER BY s.time_updated DESC"`,
       { encoding: 'utf8', timeout: 5000 }
     ).trim();
 
     if (!rows) return sessions;
 
     for (const row of rows.split('\n')) {
-      const parts = row.split('|');
+      const parts = row.split('\t');
       if (parts.length < 6) continue;
       const [id, title, directory, timeCreated, timeUpdated, msgCount] = parts;
 
@@ -318,14 +319,14 @@ function scanKiroSessions() {
 
   try {
     const rows = execSync(
-      `sqlite3 "${KIRO_DB}" "SELECT key, conversation_id, created_at, updated_at, substr(value, 1, 500), length(value) FROM conversations_v2 ORDER BY updated_at DESC"`,
+      `sqlite3 -separator $'\\t' "${KIRO_DB}" "SELECT key, conversation_id, created_at, updated_at, substr(value, 1, 500), length(value) FROM conversations_v2 ORDER BY updated_at DESC"`,
       { encoding: 'utf8', timeout: 5000 }
     ).trim();
 
     if (!rows) return sessions;
 
     for (const row of rows.split('\n')) {
-      const parts = row.split('|');
+      const parts = row.split('\t');
       if (parts.length < 5) continue;
       const [directory, convId, createdAt, updatedAt, valuePeek, valueLen] = parts;
 


### PR DESCRIPTION
## Bug

OpenCode session titles can contain `|` characters — for example `review changes [commit|branch|pr], defaults to uncommitted (@Sisyphus subagent)`. With the default pipe separator in the sqlite3 CLI, parsing breaks and the row splits into 8+ columns instead of 6.

### Impact

The word `branch` from the title ends up in the `directory` field, which creates a fake "branch" project in the UI. As a result, API calls break:

```
GET /api/session/ses_xxx?project=branch
GET /api/cost/ses_xxx?project=branch
```

Sessions with such titles display incorrectly — the project shows "branch" instead of the real project path.

![Broken sessions grouped under fake "branch" project](https://github.com/izzzzzi/codedash/releases/download/pr44-screenshot/7.png)

## Fix

Use `-separator $'\t'` (tab) instead of the default `|`. Tab characters practically never appear in the data (unlike pipes), so parsing is guaranteed to be correct.

## What changes

- `scanOpenCodeSessions()` — sqlite3 CLI call + `.split('\t')`
- `scanKiroSessions()` — same (preventively; Kiro data can also contain pipes)

## Test plan

- [x] OpenCode sessions with pipes in the title parse correctly
- [x] Project displays correctly (real path, not "branch")
- [x] API calls receive the correct `project` parameter
- [x] Regular sessions (without pipes) continue to work