### PR TITLE
fix: одинаковая высота карточек сессий в сетке

### DIFF
--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -369,7 +369,7 @@ body {
     flex-shrink: 0;
 }
 
-.card-body { flex: 1; min-width: 0; }
+.card-body { flex: 1; min-width: 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
 
 .card-title {
     font-size: 14px;
@@ -1633,12 +1633,15 @@ body {
     position: relative;
     border-radius: 12px;
     padding: 2px;
+    display: flex;
+    flex-direction: column;
 }
 
 .card-live-wrap > .card {
     border: none;
     position: relative;
     z-index: 1;
+    flex: 1;
 }
 
 .card-live-wrap .live-border {


### PR DESCRIPTION
Закрывает #51

## Что изменено
**Файл:** `src/frontend/styles.css` — 3 правки, +4 строки

| Селектор | Изменение |
|---|---|
| `.card-live-wrap` | Добавлено `display:flex; flex-direction:column` |
| `.card-live-wrap > .card` | Добавлено `flex:1` |
| `.card-body` | Добавлено `-webkit-line-clamp:3` + `overflow:hidden` |

## Почему

CSS Grid по умолчанию растягивает все ячейки строки до одинаковой высоты (`align-items:stretch`). Для обычных `.card` это работает автоматически — они прямые дети грида. Но LIVE/WAITING сессии обёрнуты в `.card-live-wrap` (нужен для анимированной conic-gradient рамки), и без `display:flex` на обёртке вложенная `.card` не наследует растянутую высоту — отсюда кривота.

Ограничение строк через `line-clamp` выравнивает высоту строк сетки, убирая разброс из-за длины описания.

## Эффект

До: карточки в одной строке разной высоты, LIVE/WAITING-карточки короче соседних.  
После: все карточки в строке одинаковой высоты, текст обрезан на 3 строках с многоточием.

## Как проверить

1. Открыть **Timeline** или **All Sessions** (режим сетки).
2. Строки с LIVE/WAITING и обычными карточками вперемешку → одинаковая высота.
3. Длинные описания → обрезаются на 3 строках, без переполнения.
4. Темы dark / light / monokai — без регрессий.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
