### PR TITLE
fix: убрать claude-ext сессии из фильтра Cursor

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -478,8 +478,7 @@ function applyFilters() {
 
     // Tool filter
     if (toolFilter) {
-      // claude-ext sessions show under both 'claude' and 'cursor' filters
-      var toolMatch = s.tool === toolFilter || (s.tool === 'claude-ext' && (toolFilter === 'cursor' || toolFilter === 'claude'));
+      var toolMatch = s.tool === toolFilter || (s.tool === 'claude-ext' && toolFilter === 'claude');
       if (!toolMatch) continue;
     }
 


### PR DESCRIPTION
Закрывает #53

## Что изменено
**Файл:** `src/frontend/app.js` — 1 строка

```diff
- // claude-ext sessions show under both 'claude' and 'cursor' filters
- var toolMatch = s.tool === toolFilter || (s.tool === 'claude-ext' && (toolFilter === 'cursor' || toolFilter === 'claude'));
+ var toolMatch = s.tool === toolFilter || (s.tool === 'claude-ext' && toolFilter === 'claude');
```

## Почему

Claude Extension (`claude-ext`) — это Claude, запущенный внутри IDE. Он не имеет отношения к Cursor IDE. Включение claude-ext в Cursor-фильтр раздувает счётчик сессий Cursor и сбивает с толку пользователей, которые не пользуются Cursor.

## Эффект

До: фильтр Cursor показывает `N(cursor) + N(claude-ext)` сессий.  
После: фильтр Cursor показывает только `N(cursor)` сессий. Claude Extension сессии отображаются только под фильтром Claude.

## Как проверить

1. Нажать **Cursor** в боковой панели.
2. Все карточки должны иметь бейдж `CURSOR`, не `CLAUDE EXT`.
3. Нажать **Claude Code** — должны отображаться и `CLAUDE`, и `CLAUDE EXT` сессии.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
