### PR TITLE
feat: add sort-by options (messages, hours, cost) to leaderboard

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -2656,10 +2656,18 @@ async function syncLeaderboard() {
 
 var _lbRemoteData = null;
 var _lbCurrentTab = 'today';
+var _lbSortBy = 'messages';
 
 function switchLbTab(tab, btn) {
   _lbCurrentTab = tab;
   document.querySelectorAll('.lb-tab').forEach(function(t) { t.classList.remove('active'); });
+  if (btn) btn.classList.add('active');
+  renderGlobalBoard();
+}
+
+function switchLbSort(sortBy, btn) {
+  _lbSortBy = sortBy;
+  document.querySelectorAll('.lb-sort').forEach(function(t) { t.classList.remove('active'); });
   if (btn) btn.classList.add('active');
   renderGlobalBoard();
 }
@@ -2673,14 +2681,15 @@ function renderGlobalBoard() {
     return;
   }
 
-  // Sort by tab
+  // Sort by tab + sort metric
   var sorted = data.users.slice();
+  var sortKey = _lbSortBy || 'messages';
   if (_lbCurrentTab === 'today') {
-    sorted.sort(function(a,b) { return (b.stats?.today?.messages||0) - (a.stats?.today?.messages||0); });
+    sorted.sort(function(a,b) { return (b.stats?.today?.[sortKey]||0) - (a.stats?.today?.[sortKey]||0); });
   } else if (_lbCurrentTab === 'week') {
-    sorted.sort(function(a,b) { return (b.stats?.week?.messages||0) - (a.stats?.week?.messages||0); });
+    sorted.sort(function(a,b) { return (b.stats?.week?.[sortKey]||0) - (a.stats?.week?.[sortKey]||0); });
   } else {
-    sorted.sort(function(a,b) { return (b.stats?.totals?.messages||0) - (a.stats?.totals?.messages||0); });
+    sorted.sort(function(a,b) { return (b.stats?.totals?.[sortKey]||0) - (a.stats?.totals?.[sortKey]||0); });
   }
 
   var html = '';
@@ -2714,9 +2723,9 @@ function renderGlobalBoard() {
     }
     html += '</div>';
     html += '<div class="lb-global-stats">';
-    html += '<span title="Prompts ' + label + '"><strong>' + msgs.toLocaleString() + '</strong> prompts</span>';
-    html += '<span title="Agent hours ' + label + '"><strong>' + hours.toFixed(1) + 'h</strong> coded</span>';
-    html += '<span title="API cost ' + label + '"><strong>$' + cost.toFixed(0) + '</strong> spent</span>';
+    html += '<span class="' + (sortKey === 'messages' ? 'lb-sort-active' : '') + '" title="Prompts ' + label + '"><strong>' + msgs.toLocaleString() + '</strong> prompts</span>';
+    html += '<span class="' + (sortKey === 'hours' ? 'lb-sort-active' : '') + '" title="Agent hours ' + label + '"><strong>' + hours.toFixed(1) + 'h</strong> coded</span>';
+    html += '<span class="' + (sortKey === 'cost' ? 'lb-sort-active' : '') + '" title="API cost ' + label + '"><strong>$' + cost.toFixed(0) + '</strong> spent</span>';
     if (u.stats?.streak > 1) html += '<span class="lb-streak-badge" title="Coding streak — days in a row with activity">&#128293; ' + u.stats.streak + 'd streak</span>';
     html += '</div></div>';
   });
@@ -2895,10 +2904,18 @@ async function renderLeaderboard(container) {
 
     // Global leaderboard with tabs
     html += '<div class="lb-section-title">Global Leaderboard</div>';
+    html += '<div class="lb-tabs-row">';
     html += '<div class="lb-tabs">';
     html += '<button class="lb-tab active" onclick="switchLbTab(\'today\',this)">Today</button>';
     html += '<button class="lb-tab" onclick="switchLbTab(\'week\',this)">Week</button>';
     html += '<button class="lb-tab" onclick="switchLbTab(\'alltime\',this)">All Time</button>';
+    html += '</div>';
+    html += '<div class="lb-tabs lb-sort-tabs">';
+    html += '<span class="lb-sort-label">Sort by:</span>';
+    html += '<button class="lb-sort active" onclick="switchLbSort(\'messages\',this)">Prompts</button>';
+    html += '<button class="lb-sort" onclick="switchLbSort(\'hours\',this)">Hours</button>';
+    html += '<button class="lb-sort" onclick="switchLbSort(\'cost\',this)">Cost</button>';
+    html += '</div>';
     html += '</div>';
     html += '<div id="globalBoard"><div class="loading">Loading...</div></div>';
 

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2154,6 +2154,20 @@ body {
 .lb-tab.active { background: var(--accent-blue); color: #fff; border-color: var(--accent-blue); }
 .lb-tab:hover:not(.active) { border-color: var(--accent-blue); color: var(--text-primary); }
 
+.lb-tabs-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; }
+.lb-tabs-row .lb-tabs { margin-bottom: 0; }
+.lb-sort-tabs { display: flex; align-items: center; gap: 4px; }
+.lb-sort-label { font-size: 12px; color: var(--text-muted); margin-right: 2px; }
+.lb-sort {
+    padding: 4px 12px; border: 1px solid var(--border); border-radius: 6px;
+    background: none; color: var(--text-muted); cursor: pointer; font-size: 12px; font-weight: 600;
+    transition: all 0.15s;
+}
+.lb-sort.active { background: var(--accent-purple); color: #fff; border-color: var(--accent-purple); }
+.lb-sort:hover:not(.active) { border-color: var(--accent-purple); color: var(--text-primary); }
+.lb-sort-active { color: var(--accent-purple); }
+.lb-sort-active strong { border-bottom: 2px solid var(--accent-purple); padding-bottom: 1px; }
+
 .lb-global-name a { color: var(--text-primary); text-decoration: none; }
 .lb-global-name a:hover { color: var(--accent-blue); text-decoration: underline; }
 


### PR DESCRIPTION
## Summary

- Adds sort-by buttons (**Prompts** / **Hours** / **Cost**) to the global leaderboard, displayed next to the existing time-period tabs (Today / Week / All Time)
- Active sort metric is visually highlighted (purple underline) in each leaderboard row
- Sort buttons use purple accent to visually distinguish them from blue period tabs

## Changes

- `src/frontend/app.js` — added `_lbSortBy` state, `switchLbSort()` function, updated `renderGlobalBoard()` sorting logic to use dynamic sort key, added sort buttons to leaderboard HTML, added `.lb-sort-active` class to active metric in stats
- `src/frontend/styles.css` — added styles for `.lb-tabs-row`, `.lb-sort-tabs`, `.lb-sort-label`, `.lb-sort`, `.lb-sort-active`

## How it works

The sort selector works in combination with time-period tabs:
- Period tabs (Today/Week/All Time) control **which time window** to display
- Sort buttons (Prompts/Hours/Cost) control **which metric** to rank by

Closes #123

## Test plan

- [ ] Open Leaderboard view
- [ ] Verify "Sort by: Prompts | Hours | Cost" buttons appear to the right of period tabs
- [ ] Click each sort button — leaderboard re-sorts by selected metric
- [ ] Verify active sort metric is highlighted with purple underline in each row
- [ ] Switch period tabs — sort selection persists across tab changes
- [ ] Check dark, light, and monokai themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)