### PR TITLE
perf: async analytics/leaderboard + SQLite FTS5 + live partial results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,999 @@
+{
+  "name": "codedash-app",
+  "version": "6.15.11",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codedash-app",
+      "version": "6.15.11",
+      "license": "MIT",
+      "dependencies": {
+        "@huggingface/transformers": "^4.0.1"
+      },
+      "bin": {
+        "codedash": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.6.tgz",
+      "integrity": "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.0.1.tgz",
+      "integrity": "sha512-tAQYEy+cnW0ku/NxBSjFXCymi+DZa1/JkoGf4McxjzO36CZZIL/J4TF6X7i/tzs75yTjshUDgsvSz03s2xym2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2",
+        "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.25.0-dev.20260327-722743c0e2",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.25.0-dev.20260327-722743c0e2.tgz",
+      "integrity": "sha512-8PXdZy4Ekhg10CLg+cFFt39b4tFDGMRJB6lGjnQL6eA+2boUQYDymZ0gtxiS+H6oIWoCjQp/ziyirvFbaFKfiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codedash-app",
-  "version": "6.15.10",
+  "version": "6.15.11",
   "description": "Dashboard + CLI for Claude Code, Codex & OpenCode sessions. View, search, resume, convert, handoff between agents.",
   "bin": {
     "codedash": "./bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=18"
+  },
+  "dependencies": {
+    "@huggingface/transformers": "^4.0.1"
   }
 }

--- a/src/copilot-client.js
+++ b/src/copilot-client.js
@@ -1,0 +1,414 @@
+/**
+ * @module copilot-client
+ *
+ * Auto-discovers GitHub Copilot OAuth tokens and exchanges them for session
+ * tokens to call LLM APIs via the Copilot chat/completions endpoint.
+ *
+ * Ported from the Rust implementation at codex-rs/github-copilot/src/
+ * (auth.rs, token_exchange.rs).
+ *
+ * Flow:
+ *   1. Load OAuth token (gho_...) from ~/.copilot/auth/credential.json
+ *      Fallback: ~/.config/github-copilot/apps.json
+ *   2. Exchange for short-lived session token via GitHub internal endpoint
+ *   3. Cache session token until expiry (refresh 60s before)
+ *   4. Call chat/completions on the dynamic Copilot API base
+ *
+ * Zero dependencies — uses only Node.js stdlib (https, fs, path, os).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const https = require('https');
+
+// ── Constants ────────────────────────────────────────────────────
+
+/** Copilot internal token exchange endpoint. */
+const COPILOT_TOKEN_ENDPOINT = 'https://api.github.com/copilot_internal/v2/token';
+
+/** Default Copilot API base (individual accounts). */
+const DEFAULT_API_BASE = 'https://api.individual.githubcopilot.com';
+
+/** Default model for chat completions. */
+const DEFAULT_MODEL = 'gpt-4.1';
+
+/** User-Agent header matching the official Copilot CLI. */
+const USER_AGENT = `copilot/1.0.14 (client/github/cli ${process.platform} v24.11.1) term/${process.env.TERM_PROGRAM || 'xterm'}`;
+
+/** Refresh session token 60 seconds before actual expiry. */
+const TOKEN_REFRESH_MARGIN_SEC = 60;
+
+// ── Credential file paths ────────────────────────────────────────
+
+/**
+ * Returns the path to ~/.copilot/auth/credential.json
+ * @returns {string}
+ */
+function copilotCliCredentialPath() {
+  return path.join(os.homedir(), '.copilot', 'auth', 'credential.json');
+}
+
+/**
+ * Returns the path to ~/.config/github-copilot/apps.json (legacy VS Code / Copilot extension)
+ * @returns {string}
+ */
+function copilotAppsJsonPath() {
+  return path.join(os.homedir(), '.config', 'github-copilot', 'apps.json');
+}
+
+// ── Cached session state ─────────────────────────────────────────
+
+/** @type {string|null} Cached OAuth token (gho_...) */
+let _oauthToken = null;
+
+/** @type {string|null} Cached session token (short-lived) */
+let _sessionToken = null;
+
+/** @type {number} Unix seconds when session token expires */
+let _sessionExpiresAt = 0;
+
+/** @type {string} Dynamic API base URL from token exchange */
+let _apiBase = DEFAULT_API_BASE;
+
+// ── HTTP helper ──────────────────────────────────────────────────
+
+/**
+ * Makes an HTTPS request using Node.js stdlib.
+ * @param {string} url - Full URL
+ * @param {Object} opts - Options
+ * @param {string} [opts.method='GET'] - HTTP method
+ * @param {Object} [opts.headers={}] - Request headers
+ * @param {string|null} [opts.body=null] - Request body (for POST)
+ * @returns {Promise<{statusCode: number, body: string, json: function}>}
+ */
+function httpsRequest(url, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const reqOpts = {
+      hostname: parsed.hostname,
+      port: parsed.port || 443,
+      path: parsed.pathname + parsed.search,
+      method: opts.method || 'GET',
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json',
+        ...(opts.headers || {}),
+      },
+    };
+
+    const req = https.request(reqOpts, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        resolve({
+          statusCode: res.statusCode,
+          body,
+          json() {
+            return JSON.parse(body);
+          },
+        });
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(30000, () => {
+      req.destroy(new Error('Request timed out'));
+    });
+
+    if (opts.body) {
+      req.write(opts.body);
+    }
+    req.end();
+  });
+}
+
+// ── OAuth token discovery ────────────────────────────────────────
+
+/**
+ * Attempts to load the OAuth token from known credential locations.
+ *
+ * Priority:
+ *   1. ~/.copilot/auth/credential.json  (field: "token")
+ *   2. ~/.config/github-copilot/apps.json  (field: oauth_token under github.com key)
+ *
+ * @returns {string|null} The gho_... OAuth token, or null if not found.
+ */
+function loadOAuthToken() {
+  // Collect ALL candidate tokens, return as array (caller tries each)
+  return loadAllOAuthTokens()[0] || null;
+}
+
+/**
+ * Loads all available OAuth tokens from known credential locations.
+ * Returns tokens most-likely-to-work first: apps.json (actively refreshed
+ * by VS Code/Copilot extension) before credential.json (can go stale).
+ * @returns {string[]}
+ */
+function loadAllOAuthTokens() {
+  const tokens = [];
+
+  // 1. apps.json (preferred — refreshed by VS Code Copilot extension)
+  try {
+    const appsPath = copilotAppsJsonPath();
+    if (fs.existsSync(appsPath)) {
+      const data = JSON.parse(fs.readFileSync(appsPath, 'utf8'));
+      for (const key of Object.keys(data)) {
+        if (key.startsWith('github.com') && data[key] && data[key].oauth_token) {
+          tokens.push(data[key].oauth_token);
+        }
+      }
+    }
+  } catch (_) {}
+
+  // 2. Copilot CLI credential file (can be stale)
+  try {
+    const credPath = copilotCliCredentialPath();
+    if (fs.existsSync(credPath)) {
+      const data = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+      if (data.token && typeof data.token === 'string' && data.token.length > 0) {
+        if (!tokens.includes(data.token)) tokens.push(data.token);
+      }
+    }
+  } catch (_) {}
+
+  return tokens;
+}
+
+// ── Token exchange ───────────────────────────────────────────────
+
+/**
+ * Exchange a persistent OAuth token (gho_...) for a short-lived Copilot API
+ * session token via the internal GitHub endpoint.
+ *
+ * The response includes:
+ *   - token: session token for Bearer auth
+ *   - expires_at: unix seconds
+ *   - endpoints.api: dynamic API base URL
+ *
+ * @param {string} oauthToken - The gho_... OAuth token
+ * @returns {Promise<{token: string, expires_at: number, endpoints?: {api?: string}}>}
+ * @throws {Error} If the exchange fails
+ */
+async function exchangeToken(oauthToken) {
+  const res = await httpsRequest(COPILOT_TOKEN_ENDPOINT, {
+    method: 'GET',
+    headers: {
+      Authorization: `token ${oauthToken}`,
+    },
+  });
+
+  if (res.statusCode !== 200) {
+    throw new Error(
+      `Copilot token exchange failed (HTTP ${res.statusCode}): ${res.body}`
+    );
+  }
+
+  const data = res.json();
+  if (!data.token) {
+    throw new Error('Copilot token exchange returned empty token');
+  }
+
+  return data;
+}
+
+/**
+ * Ensures we have a valid session token, exchanging/refreshing as needed.
+ * Caches the token and refreshes 60 seconds before expiry.
+ *
+ * @returns {Promise<string>} The session token
+ * @throws {Error} If no OAuth token is available or exchange fails
+ */
+async function ensureSessionToken() {
+  const now = Math.floor(Date.now() / 1000);
+
+  // Return cached token if still valid
+  if (_sessionToken && _sessionExpiresAt > now + TOKEN_REFRESH_MARGIN_SEC) {
+    return _sessionToken;
+  }
+
+  // Try all available OAuth tokens until one exchanges successfully.
+  // apps.json tokens (refreshed by VS Code) are tried first; credential.json
+  // (Copilot CLI, can go stale) is tried last.
+  const allTokens = loadAllOAuthTokens();
+  if (allTokens.length === 0) {
+    throw new Error(
+      'No GitHub Copilot OAuth token found. ' +
+      'Expected at ~/.copilot/auth/credential.json or ~/.config/github-copilot/apps.json'
+    );
+  }
+
+  let lastErr = null;
+  for (const token of allTokens) {
+    try {
+      const result = await exchangeToken(token);
+      _oauthToken = token;
+      _sessionToken = result.token;
+      _sessionExpiresAt = result.expires_at || 0;
+      if (result.endpoints && result.endpoints.api) {
+        _apiBase = result.endpoints.api;
+      } else {
+        _apiBase = DEFAULT_API_BASE;
+      }
+      return _sessionToken;
+    } catch (e) {
+      lastErr = e;
+      // Try next token
+    }
+  }
+  throw lastErr || new Error('All OAuth tokens failed exchange');
+}
+
+// ── Public API ───────────────────────────────────────────────────
+
+/**
+ * Synchronous check whether a Copilot credential file exists on disk.
+ * Does NOT validate the token — just checks file presence.
+ *
+ * @returns {boolean} True if a credential file exists
+ */
+function isAvailable() {
+  try {
+    if (fs.existsSync(copilotCliCredentialPath())) return true;
+  } catch (_) { /* ignore */ }
+
+  try {
+    if (fs.existsSync(copilotAppsJsonPath())) return true;
+  } catch (_) { /* ignore */ }
+
+  return false;
+}
+
+/**
+ * Call the Copilot chat/completions endpoint.
+ *
+ * @param {Array<{role: string, content: string}>} messages - Chat messages
+ * @param {Object} [opts={}] - Options
+ * @param {string} [opts.model='gpt-4.1'] - Model ID
+ * @param {number} [opts.max_tokens=4000] - Max tokens in response
+ * @param {string} [opts.reasoning_effort] - Reasoning effort level (e.g. 'xhigh' for gpt-5-mini)
+ * @returns {Promise<{content: string, model: string, usage: Object}>}
+ * @throws {Error} If authentication fails or the API returns an error
+ */
+async function chatCompletion(messages, opts = {}) {
+  const token = await ensureSessionToken();
+  const model = opts.model || DEFAULT_MODEL;
+  const maxTokens = opts.max_tokens || 4000;
+
+  const body = {
+    model,
+    messages,
+    max_tokens: maxTokens,
+  };
+
+  // Add reasoning_effort for models that support it (e.g. gpt-5-mini)
+  if (opts.reasoning_effort) {
+    body.reasoning_effort = opts.reasoning_effort;
+  }
+
+  const url = `${_apiBase}/chat/completions`;
+  const res = await httpsRequest(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Editor-Version': 'vscode/1.96.0',
+      'Copilot-Integration-Id': 'vscode-chat',
+      'Editor-Plugin-Version': 'copilot-chat/0.24.2',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (res.statusCode === 401 || res.statusCode === 403) {
+    // Session token may have expired despite our margin check — force refresh
+    _sessionToken = null;
+    _sessionExpiresAt = 0;
+    throw new Error(
+      `Copilot API auth error (HTTP ${res.statusCode}): ${res.body}. ` +
+      'Token has been cleared; retry will attempt re-authentication.'
+    );
+  }
+
+  if (res.statusCode !== 200) {
+    throw new Error(
+      `Copilot API error (HTTP ${res.statusCode}): ${res.body}`
+    );
+  }
+
+  const data = res.json();
+
+  // Extract the assistant message content
+  const choice = data.choices && data.choices[0];
+  const content = choice && choice.message ? choice.message.content : '';
+
+  return {
+    content: content || '',
+    model: data.model || model,
+    usage: data.usage || {},
+  };
+}
+
+/**
+ * Summarize a coding session conversation using the Copilot LLM.
+ *
+ * @param {Array<{role: string, content: string}>} messages - Session messages
+ * @returns {Promise<string>} A concise summary of the session
+ * @throws {Error} If the API call fails
+ */
+async function summarizeSession(messages) {
+  // Truncate very long conversations to stay within context limits.
+  // Keep the first 2 and last 8 messages for large sessions.
+  let truncated = messages;
+  if (messages.length > 20) {
+    truncated = [
+      ...messages.slice(0, 2),
+      { role: 'system', content: `[... ${messages.length - 10} messages omitted for brevity ...]` },
+      ...messages.slice(-8),
+    ];
+  }
+
+  const systemPrompt = {
+    role: 'system',
+    content:
+      'You are a helpful assistant that summarizes coding sessions. ' +
+      'Given the conversation below, produce a concise 2-4 sentence summary ' +
+      'describing what was accomplished, key decisions made, and any outstanding issues. ' +
+      'Be specific about file names, features, and technologies mentioned.',
+  };
+
+  const result = await chatCompletion(
+    [systemPrompt, ...truncated],
+    { model: DEFAULT_MODEL, max_tokens: 500 }
+  );
+
+  return result.content.trim();
+}
+
+/**
+ * Returns the current authentication and connection status.
+ *
+ * @returns {{authenticated: boolean, model: string, api_base: string, token_expires_at: number}}
+ */
+function getStatus() {
+  const hasToken = !!_oauthToken || isAvailable();
+  const hasSession = !!_sessionToken && _sessionExpiresAt > Math.floor(Date.now() / 1000);
+
+  return {
+    authenticated: hasSession,
+    model: DEFAULT_MODEL,
+    api_base: _apiBase,
+    token_expires_at: _sessionExpiresAt,
+  };
+}
+
+// ── Exports ──────────────────────────────────────────────────────
+
+module.exports = {
+  isAvailable,
+  chatCompletion,
+  summarizeSession,
+  getStatus,
+};

--- a/src/data.js
+++ b/src/data.js
@@ -3565,15 +3565,16 @@ function buildOpencodeCostCache(sessions) {
   if (opencodeSessions.length === 0 || !fs.existsSync(OPENCODE_DB)) return cache;
   try {
     const batchRows = execFileSync('sqlite3', [
+      '-json',
       OPENCODE_DB,
       `SELECT session_id, data FROM message WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created`
     ], { encoding: 'utf8', timeout: 30000, windowsHide: true }).trim();
     if (batchRows) {
-      for (const row of batchRows.split('\n')) {
-        const sepIdx = row.indexOf('|');
-        if (sepIdx < 0) continue;
-        const sessId = row.slice(0, sepIdx);
-        const jsonStr = row.slice(sepIdx + 1);
+      const rows = JSON.parse(batchRows);
+      for (const row of rows) {
+        const sessId = row.session_id;
+        const jsonStr = row.data;
+        if (!sessId || typeof jsonStr !== 'string') continue;
         try {
           const msgData = JSON.parse(jsonStr);
           const t = msgData.tokens || {};

--- a/src/data.js
+++ b/src/data.js
@@ -410,6 +410,10 @@ function getSqliteBackfillStatus() {
 
 function _ensureSqliteBackfillRunning() {
   if (_sqliteBackfillRunning) return;
+  // Don't re-scan after the initial backfill completed this process lifetime.
+  // New/changed files are ingested incrementally by the warmer; this full
+  // scan is only needed once on cold start.
+  if (_sqliteBackfillStatus.phase === 'done') return;
   let sqliteIndex;
   try { sqliteIndex = require('./sqlite-index'); } catch { return; }
 

--- a/src/data.js
+++ b/src/data.js
@@ -1011,10 +1011,11 @@ function scanOpenCodeSessions() {
     const sessionMcp = {};
     const sessionSkills = {};
     try {
-      const toolRows = execSync(
-        `sqlite3 -separator $'\\t' "${OPENCODE_DB}" "SELECT session_id, json_extract(data, '\\$.tool'), json_extract(data, '\\$.state.input.name') FROM part WHERE json_extract(data, '\\$.type') = 'tool'"`,
-        { encoding: 'utf8', timeout: 10000, maxBuffer: 50 * 1024 * 1024 }
-      ).trim();
+      const toolRows = execFileSync('sqlite3', [
+        '-separator', '\t',
+        OPENCODE_DB,
+        "SELECT session_id, json_extract(data, '$.tool'), json_extract(data, '$.state.input.name') FROM part WHERE json_extract(data, '$.type') = 'tool'"
+      ], { encoding: 'utf8', timeout: 10000, maxBuffer: 50 * 1024 * 1024, windowsHide: true }).trim();
       if (toolRows) {
         for (const tr of toolRows.split('\n')) {
           const cols = tr.split('\t');
@@ -2606,23 +2607,26 @@ async function loadSessionsAsync(progressCb) {
   return sessions;
 }
 
-function loadSessionDetail(sessionId, project) {
+function loadSessionDetail(sessionId, project, opts) {
   const found = findSessionFile(sessionId, project);
-  if (!found) return { error: 'Session file not found', messages: [] };
+  if (!found) return { error: 'Session file not found', messages: [], total: 0 };
+
+  var offset = (opts && typeof opts.offset === 'number') ? opts.offset : 0;
+  var limit = (opts && typeof opts.limit === 'number') ? opts.limit : 0; // 0 = all (legacy)
 
   // OpenCode uses SQLite
   if (found.format === 'opencode') {
-    return loadOpenCodeDetail(sessionId);
+    return _paginateDetailResult(loadOpenCodeDetail(sessionId), offset, limit);
   }
 
   // Cursor
   if (found.format === 'cursor') {
-    return loadCursorDetail(sessionId);
+    return _paginateDetailResult(loadCursorDetail(sessionId), offset, limit);
   }
 
   // Kiro uses SQLite
   if (found.format === 'kiro') {
-    return loadKiroDetail(sessionId);
+    return _paginateDetailResult(loadKiroDetail(sessionId), offset, limit);
   }
 
   const messages = [];
@@ -2688,7 +2692,19 @@ function loadSessionDetail(sessionId, project) {
     if (m._toolSeen) delete m._toolSeen;
   }
 
-  return { messages: messages.slice(0, 200) };
+  return _paginateDetailResult({ messages }, offset, limit);
+}
+
+function _paginateDetailResult(result, offset, limit) {
+  if (!result || !result.messages) return { messages: [], total: 0, offset: offset, hasMore: false };
+  const all = result.messages;
+  const total = all.length;
+  if (!limit || limit <= 0) {
+    // Legacy behavior: return all (capped at 500)
+    return { messages: all.slice(0, 500), total, offset: 0, hasMore: false };
+  }
+  const sliced = all.slice(offset, offset + limit);
+  return { messages: sliced, total, offset, hasMore: offset + limit < total };
 }
 
 function deleteSession(sessionId, project) {
@@ -3556,6 +3572,7 @@ function createCostAggregator() {
         lastDate: state.lastDate,
         days,
         totalSessions: state.sessionsWithData,
+        totalSessionsAll: state.totalSessionsAll || state.processedCount,
         byDay: state.byDay,
         byWeek: state.byWeek,
         byProject: state.byProject,
@@ -3568,6 +3585,7 @@ function createCostAggregator() {
         processedCount: state.processedCount,
       };
     },
+    setTotalSessionsAll(n) { state.totalSessionsAll = n; },
   };
 }
 
@@ -3824,6 +3842,7 @@ function getCostAnalytics(sessions) {
     lastDate,
     days,
     totalSessions: sessionsWithData,
+    totalSessionsAll: sessions.length,
     byDay,
     byWeek,
     byProject,
@@ -3933,12 +3952,16 @@ function getActiveSessions() {
     const stat = m[4] || '';
     const cmd = m[5] || '';
 
-    // Skip wrappers
+    // Skip wrappers, MCP servers, plugins — only main agent processes
     if (cmd.includes('node bin/cli') || cmd.includes('/codedash') || cmd.includes('npm ')) continue;
     if (cmd.startsWith('grep ') || cmd.includes(' grep ')) continue;
+    if (cmd.includes('mcp-server') || cmd.includes('mcp_server') || cmd.includes('/mcp/') || cmd.includes('/mcp-servers/')) continue;
+    if (cmd.includes('/plugins/') || cmd.includes('plugin-') || cmd.includes('app-server-broker')) continue;
 
     const tool = _matchAgentCli(cmd);
     if (!tool) continue;
+    if (cmd.includes('.claude/') && !cmd.includes('claude ') && tool === 'claude') continue;
+    if (cmd.includes('.codex/') && !cmd.includes('codex ') && tool === 'codex') continue;
 
     matches.push({ pid, cpu, rss, stat, cmd, tool });
   }

--- a/src/data.js
+++ b/src/data.js
@@ -498,6 +498,42 @@ function _ensureSqliteBackfillRunning() {
       }
       await _flushSqliteIngestBatch();
 
+      // Phase 2: compute embeddings for sessions that don't have them yet
+      // (requires optional @huggingface/transformers npm package)
+      try {
+        const embeddings = require('./embeddings');
+        if (embeddings.isAvailable()) {
+          _sqliteBackfillStatus.phase = 'computing embeddings';
+          embeddings.ensureEmbeddingTable();
+          const existingCount = embeddings.getEmbeddingCount();
+          // Get sessions without embeddings
+          const allSessionRows = sqliteIndex._execJson(`SELECT id, first_message FROM sessions WHERE id NOT IN (SELECT session_id FROM session_embeddings) AND first_message != '' LIMIT 5000`);
+          if (allSessionRows.length > 0) {
+            _sqliteBackfillStatus.total = allSessionRows.length;
+            _sqliteBackfillStatus.done = 0;
+            const BATCH = 32;
+            for (let i = 0; i < allSessionRows.length; i += BATCH) {
+              const batch = allSessionRows.slice(i, i + BATCH);
+              const texts = batch.map(r => (r.first_message || '').slice(0, 512));
+              try {
+                const embs = await embeddings.embedBatch(texts);
+                const rows = batch.map((r, j) => ({
+                  session_id: r.id,
+                  embedding: embs[j],
+                  model: embeddings.MODEL_ID,
+                }));
+                embeddings.storeEmbeddings(rows);
+              } catch (e) {
+                // Model download/init error — skip embeddings
+                break;
+              }
+              _sqliteBackfillStatus.done = Math.min(i + BATCH, allSessionRows.length);
+              await new Promise(r => setImmediate(r));
+            }
+          }
+        }
+      } catch {}
+
       _sqliteBackfillStatus.phase = 'done';
       _sqliteBackfillStatus.finishedAt = Date.now();
     } catch (e) {

--- a/src/data.js
+++ b/src/data.js
@@ -789,9 +789,14 @@ async function parseClaudeSessionFileAsync(sessionFile) {
       const entry = JSON.parse(line);
       if (entry.type === 'user' || entry.type === 'assistant') msgCount++;
       if (entry.type === 'user' && isRealUserPromptAsync(entry)) userMsgCount++;
-      if (entry.timestamp) {
-        if (entry.timestamp < firstTs) firstTs = entry.timestamp;
-        if (entry.timestamp > lastTs) lastTs = entry.timestamp;
+      const rawTimestamp = entry.timestamp;
+      const normalizedTimestamp =
+        typeof rawTimestamp === 'number'
+          ? rawTimestamp
+          : (typeof rawTimestamp === 'string' ? Date.parse(rawTimestamp) : NaN);
+      if (Number.isFinite(normalizedTimestamp)) {
+        if (normalizedTimestamp < firstTs) firstTs = normalizedTimestamp;
+        if (normalizedTimestamp > lastTs) lastTs = normalizedTimestamp;
       }
       if (!projectPath && entry.type === 'user' && entry.cwd) projectPath = entry.cwd;
       if (!worktreeOriginalCwd && entry.type === 'worktree-state' && entry.worktreeSession && entry.worktreeSession.originalCwd) {

--- a/src/data.js
+++ b/src/data.js
@@ -98,10 +98,18 @@ function parseOpenCodeMcpServer(toolName) {
   return toolName.slice(0, idx);
 }
 
+// Persistent cache dir (survives tmpdir cleanup and process kills)
+const CODEDASH_CACHE_DIR = path.join(os.homedir(), '.codedash', 'cache');
+try { fs.mkdirSync(CODEDASH_CACHE_DIR, { recursive: true }); } catch {}
+
 // Disk cache for parsed Claude session files (keyed by path + mtime + size)
-const PARSED_CACHE_FILE = path.join(os.tmpdir(), 'codedash-parsed-cache.json');
+const PARSED_CACHE_FILE = path.join(CODEDASH_CACHE_DIR, 'parsed-cache.json');
+// Legacy tmpdir path (migration: read once, then ignore)
+const LEGACY_PARSED_CACHE_FILE = path.join(os.tmpdir(), 'codedash-parsed-cache.json');
 let _parsedDiskCache = null;
 let _parsedDiskCacheDirty = false;
+let _parsedDiskCacheEntriesSinceFlush = 0;
+const PARSED_CACHE_FLUSH_EVERY = 50; // flush after every N new entries
 // Reverse index: file path -> cache key (avoids repeated fs.statSync)
 const _fileCacheKeyIndex = {};
 
@@ -110,20 +118,490 @@ function _loadParsedDiskCache() {
   try {
     if (fs.existsSync(PARSED_CACHE_FILE)) {
       _parsedDiskCache = JSON.parse(fs.readFileSync(PARSED_CACHE_FILE, 'utf8'));
+    } else if (fs.existsSync(LEGACY_PARSED_CACHE_FILE)) {
+      // Migrate from tmpdir once
+      _parsedDiskCache = JSON.parse(fs.readFileSync(LEGACY_PARSED_CACHE_FILE, 'utf8'));
+      _parsedDiskCacheDirty = true;
     }
   } catch {}
   if (!_parsedDiskCache) _parsedDiskCache = {};
 }
 
-function _saveParsedDiskCache() {
+function _saveParsedDiskCache(force) {
   if (!_parsedDiskCacheDirty || !_parsedDiskCache) return;
+  if (!force && _parsedDiskCacheEntriesSinceFlush < PARSED_CACHE_FLUSH_EVERY) return;
   try {
-    fs.writeFileSync(PARSED_CACHE_FILE, JSON.stringify(_parsedDiskCache));
+    // Atomic write: write to .tmp then rename
+    const tmp = PARSED_CACHE_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(_parsedDiskCache));
+    fs.renameSync(tmp, PARSED_CACHE_FILE);
     _parsedDiskCacheDirty = false;
+    _parsedDiskCacheEntriesSinceFlush = 0;
   } catch {}
 }
 
-function parseClaudeSessionFile(sessionFile) {
+// ── Disk cache for computed session cost (path+mtime+size → cost) ─────────
+const COST_CACHE_FILE = path.join(CODEDASH_CACHE_DIR, 'cost-cache.json');
+let _costDiskCache = null;
+let _costDiskCacheDirty = false;
+let _costDiskCacheEntriesSinceFlush = 0;
+const COST_CACHE_FLUSH_EVERY = 50;
+
+function _loadCostDiskCache() {
+  if (_costDiskCache) return;
+  try {
+    if (fs.existsSync(COST_CACHE_FILE)) {
+      _costDiskCache = JSON.parse(fs.readFileSync(COST_CACHE_FILE, 'utf8'));
+    }
+  } catch {}
+  if (!_costDiskCache) _costDiskCache = {};
+}
+
+function _saveCostDiskCache(force) {
+  if (!_costDiskCacheDirty || !_costDiskCache) return;
+  if (!force && _costDiskCacheEntriesSinceFlush < COST_CACHE_FLUSH_EVERY) return;
+  try {
+    const tmp = COST_CACHE_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(_costDiskCache));
+    fs.renameSync(tmp, COST_CACHE_FILE);
+    _costDiskCacheDirty = false;
+    _costDiskCacheEntriesSinceFlush = 0;
+  } catch {}
+}
+
+// ── Background parse warming state ────────────────────────
+// Populated by sync loadSessions() with file paths whose parse cache is stale.
+// A singleton background task drains this set with setImmediate yielding so
+// the HTTP event loop stays responsive. UI can read _warmingStatus for progress.
+const _pendingParseFiles = new Set();
+let _warmingRunning = false;
+const _warmingStatus = {
+  running: false,
+  done: 0,
+  total: 0,
+  phase: 'idle',
+  startedAt: 0,
+  finishedAt: 0,
+};
+
+// ── SQLite ingest helper ────────────────────────────────────
+// Parse a single Claude session file fully (messages + metadata) and push
+// a batch row into the SQLite index. Used by the background warmer after
+// the parsed-cache entry has been created. Cheap when already indexed.
+let _sqliteIngestBatch = [];
+const _SQLITE_INGEST_FLUSH_EVERY = 5;
+
+function _ingestClaudeFileToSqlite(filePath) {
+  let sqliteIndex;
+  try { sqliteIndex = require('./sqlite-index'); } catch { return; }
+  try {
+    if (sqliteIndex.isFileCurrent(filePath)) return; // already indexed
+  } catch { return; }
+
+  let stat;
+  try { stat = fs.statSync(filePath); } catch { return; }
+
+  // Full read — at ingest time we need messages for FTS. Streaming for big
+  // files would be nicer but the warmer yields between files already.
+  let lines;
+  try { lines = readLines(filePath); } catch { return; }
+
+  const sid = path.basename(filePath, '.jsonl');
+  let projectPath = '';
+  let tool = 'claude';
+  let firstTs = stat.mtimeMs;
+  let lastTs = stat.mtimeMs;
+  let firstMsg = '';
+  let userMsgCount = 0;
+  let totalMsgCount = 0;
+  const msgs = [];
+  const dayMsgs = {};  // day → {messages, first_ts, last_ts}
+  let seq = 0;
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type !== 'user' && entry.type !== 'assistant') continue;
+      const role = entry.type;
+      const content = extractContent((entry.message || {}).content);
+      if (!content) continue;
+      const ts = entry.timestamp ? (typeof entry.timestamp === 'number' ? entry.timestamp : new Date(entry.timestamp).getTime()) : 0;
+      if (ts) {
+        if (ts < firstTs) firstTs = ts;
+        if (ts > lastTs) lastTs = ts;
+      }
+      if (!projectPath && entry.cwd) projectPath = entry.cwd;
+      totalMsgCount++;
+      if (role === 'user') {
+        userMsgCount++;
+        if (!firstMsg && content) firstMsg = content.slice(0, 200);
+      }
+      msgs.push({ seq: seq++, role, ts, content: content.slice(0, 8000) });
+      // Day breakdown for user messages only
+      if (role === 'user' && ts > 1000000000000) {
+        const d = new Date(ts);
+        const day = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+        if (!dayMsgs[day]) dayMsgs[day] = { messages: 0, first_ts: ts, last_ts: ts };
+        dayMsgs[day].messages++;
+        if (ts < dayMsgs[day].first_ts) dayMsgs[day].first_ts = ts;
+        if (ts > dayMsgs[day].last_ts) dayMsgs[day].last_ts = ts;
+      }
+    } catch {}
+  }
+
+  // Convert dayMsgs to daily_stats rows
+  const daily = {};
+  for (const day in dayMsgs) {
+    const dm = dayMsgs[day];
+    daily[day] = {
+      messages: dm.messages,
+      hours: Math.min((dm.last_ts - dm.first_ts) / 3600000, 16),
+    };
+  }
+
+  _sqliteIngestBatch.push({
+    filePath,
+    session: {
+      id: sid,
+      tool,
+      project: projectPath,
+      project_short: projectPath.replace(os.homedir(), '~'),
+      first_ts: firstTs,
+      last_ts: lastTs,
+      messages: totalMsgCount,
+      user_messages: userMsgCount,
+      file_size: stat.size,
+      first_message: firstMsg,
+      source_mtime: stat.mtimeMs,
+      source_size: stat.size,
+    },
+    messages: msgs,
+    daily,
+  });
+
+  // Don't flush here — backfill loop awaits the flush between files.
+}
+
+// Ingest a single Codex rollout JSONL into SQLite.
+function _ingestCodexFileToSqlite(filePath) {
+  let sqliteIndex;
+  try { sqliteIndex = require('./sqlite-index'); } catch { return; }
+  try { if (sqliteIndex.isFileCurrent(filePath)) return; } catch { return; }
+
+  let stat;
+  try { stat = fs.statSync(filePath); } catch { return; }
+
+  // Extract session id from filename
+  const basename = path.basename(filePath, '.jsonl');
+  const uuidMatch = basename.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/);
+  if (!uuidMatch) return;
+  const sid = uuidMatch[1];
+
+  let lines;
+  try { lines = readLines(filePath); } catch { return; }
+
+  let projectPath = '';
+  let firstTs = stat.mtimeMs;
+  let lastTs = stat.mtimeMs;
+  let firstMsg = '';
+  let userMsgCount = 0;
+  let totalMsgCount = 0;
+  const msgs = [];
+  const dayMsgs = {};
+  let seq = 0;
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'session_meta' && entry.payload && entry.payload.cwd && !projectPath) {
+        projectPath = entry.payload.cwd;
+        continue;
+      }
+      if (entry.type !== 'response_item' || !entry.payload) continue;
+      const role = entry.payload.role;
+      if (role !== 'user' && role !== 'assistant') continue;
+      const content = extractContent(entry.payload.content);
+      if (!content || isSystemMessage(content)) continue;
+      let ts = 0;
+      const tsVal = entry.timestamp || entry.ts;
+      if (typeof tsVal === 'number') ts = tsVal;
+      else if (typeof tsVal === 'string') ts = Date.parse(tsVal) || 0;
+      if (ts && ts < firstTs) firstTs = ts;
+      if (ts && ts > lastTs) lastTs = ts;
+
+      totalMsgCount++;
+      if (role === 'user') {
+        userMsgCount++;
+        if (!firstMsg) firstMsg = content.slice(0, 200);
+      }
+      msgs.push({ seq: seq++, role, ts, content: content.slice(0, 8000) });
+      if (role === 'user' && ts > 1000000000000) {
+        const d = new Date(ts);
+        const day = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+        if (!dayMsgs[day]) dayMsgs[day] = { messages: 0, first_ts: ts, last_ts: ts };
+        dayMsgs[day].messages++;
+        if (ts < dayMsgs[day].first_ts) dayMsgs[day].first_ts = ts;
+        if (ts > dayMsgs[day].last_ts) dayMsgs[day].last_ts = ts;
+      }
+    } catch {}
+  }
+
+  const daily = {};
+  for (const day in dayMsgs) {
+    const dm = dayMsgs[day];
+    daily[day] = {
+      messages: dm.messages,
+      hours: Math.min((dm.last_ts - dm.first_ts) / 3600000, 16),
+    };
+  }
+
+  _sqliteIngestBatch.push({
+    filePath,
+    session: {
+      id: sid,
+      tool: 'codex',
+      project: projectPath,
+      project_short: projectPath.replace(os.homedir(), '~'),
+      first_ts: firstTs,
+      last_ts: lastTs,
+      messages: totalMsgCount,
+      user_messages: userMsgCount,
+      file_size: stat.size,
+      first_message: firstMsg,
+      source_mtime: stat.mtimeMs,
+      source_size: stat.size,
+    },
+    messages: msgs,
+    daily,
+  });
+
+  // Don't flush here — backfill loop awaits the flush between files.
+}
+
+async function _flushSqliteIngestBatch() {
+  if (_sqliteIngestBatch.length === 0) return;
+  const batch = _sqliteIngestBatch;
+  _sqliteIngestBatch = [];  // take ownership before the async call
+  try {
+    const sqliteIndex = require('./sqlite-index');
+    await sqliteIndex.indexBatchAsync(batch);
+  } catch (e) {
+    try { console.error('sqlite ingest flush failed:', e.message); } catch {}
+  }
+}
+
+// ── SQLite backfill ────────────────────────────────────────
+// One-shot background task that iterates all existing Claude session files
+// and ingests them into SQLite (if not already there, matched by mtime+size
+// via files_seen). Yields between files.
+let _sqliteBackfillRunning = false;
+const _sqliteBackfillStatus = {
+  running: false,
+  done: 0,
+  total: 0,
+  phase: 'idle',
+  startedAt: 0,
+  finishedAt: 0,
+};
+
+function getSqliteBackfillStatus() {
+  return Object.assign({}, _sqliteBackfillStatus);
+}
+
+function _ensureSqliteBackfillRunning() {
+  if (_sqliteBackfillRunning) return;
+  let sqliteIndex;
+  try { sqliteIndex = require('./sqlite-index'); } catch { return; }
+
+  _sqliteBackfillRunning = true;
+  _sqliteBackfillStatus.running = true;
+  _sqliteBackfillStatus.startedAt = Date.now();
+  _sqliteBackfillStatus.phase = 'scanning';
+  _sqliteBackfillStatus.done = 0;
+
+  setImmediate(async () => {
+    try {
+      sqliteIndex.ensureSchema();
+
+      // Enumerate all Claude JSONL files + Codex session files
+      const allFiles = []; // array of {file, kind}
+      const walkClaude = (dir) => {
+        try {
+          for (const proj of fs.readdirSync(dir)) {
+            const pDir = path.join(dir, proj);
+            try {
+              if (!fs.statSync(pDir).isDirectory()) continue;
+              for (const f of fs.readdirSync(pDir)) {
+                if (f.endsWith('.jsonl')) allFiles.push({ file: path.join(pDir, f), kind: 'claude' });
+              }
+            } catch {}
+          }
+        } catch {}
+      };
+      if (fs.existsSync(PROJECTS_DIR)) walkClaude(PROJECTS_DIR);
+      for (const extra of EXTRA_CLAUDE_DIRS) {
+        const ep = path.join(extra, 'projects');
+        if (fs.existsSync(ep)) walkClaude(ep);
+      }
+      // Codex session files (~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl)
+      const codexSessDir = path.join(CODEX_DIR, 'sessions');
+      if (fs.existsSync(codexSessDir)) {
+        const walkCodex = (dir) => {
+          try {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const full = path.join(dir, entry.name);
+              if (entry.isDirectory()) walkCodex(full);
+              else if (entry.name.endsWith('.jsonl')) allFiles.push({ file: full, kind: 'codex' });
+            }
+          } catch {}
+        };
+        walkCodex(codexSessDir);
+      }
+
+      _sqliteBackfillStatus.total = allFiles.length;
+      _sqliteBackfillStatus.phase = 'ingesting';
+
+      // Sort newest first so fresh sessions hit the index sooner
+      allFiles.sort((a, b) => {
+        try { return fs.statSync(b.file).mtimeMs - fs.statSync(a.file).mtimeMs; } catch { return 0; }
+      });
+
+      // Single bulk read of files_seen — avoids N sync SQL calls
+      const filesSeen = sqliteIndex.loadAllFilesSeen();
+
+      for (const item of allFiles) {
+        try {
+          let stat;
+          try { stat = fs.statSync(item.file); } catch { _sqliteBackfillStatus.done++; continue; }
+          const seen = filesSeen.get(item.file);
+          const isCurrent = seen && seen.mtime === stat.mtimeMs && seen.size === stat.size;
+          if (!isCurrent) {
+            if (item.kind === 'codex') {
+              _ingestCodexFileToSqlite(item.file);
+            } else {
+              _ingestClaudeFileToSqlite(item.file);
+            }
+            if (_sqliteIngestBatch.length >= _SQLITE_INGEST_FLUSH_EVERY) {
+              await _flushSqliteIngestBatch();
+            }
+          }
+        } catch {}
+        _sqliteBackfillStatus.done++;
+        // Yield every 10 files so HTTP requests can slot in
+        if (_sqliteBackfillStatus.done % 10 === 0) {
+          await new Promise(r => setImmediate(r));
+        }
+      }
+      await _flushSqliteIngestBatch();
+
+      _sqliteBackfillStatus.phase = 'done';
+      _sqliteBackfillStatus.finishedAt = Date.now();
+    } catch (e) {
+      _sqliteBackfillStatus.phase = 'error: ' + (e && e.message || 'unknown');
+      _sqliteBackfillStatus.finishedAt = Date.now();
+    } finally {
+      _sqliteBackfillStatus.running = false;
+      _sqliteBackfillRunning = false;
+    }
+  });
+}
+
+function _ensureWarmingRunning() {
+  if (_warmingRunning) return;
+  if (_pendingParseFiles.size === 0 && _pendingCodexFiles.size === 0) return;
+  _warmingRunning = true;
+  _warmingStatus.running = true;
+  _warmingStatus.startedAt = Date.now();
+  _warmingStatus.done = 0;
+  _warmingStatus.total = _pendingParseFiles.size + _pendingCodexFiles.size;
+  _warmingStatus.phase = 'parsing session files';
+  setImmediate(async () => {
+    try {
+      while (_pendingParseFiles.size > 0 || _pendingCodexFiles.size > 0) {
+        // Claude batch (newest-first)
+        if (_pendingParseFiles.size > 0) {
+          const batch = Array.from(_pendingParseFiles);
+          batch.sort((a, b) => {
+            try { return fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs; } catch { return 0; }
+          });
+          _warmingStatus.total = _warmingStatus.done + batch.length + _pendingCodexFiles.size;
+          for (const file of batch) {
+            _pendingParseFiles.delete(file);
+            try {
+              let stat;
+              try { stat = fs.statSync(file); } catch { _warmingStatus.done++; continue; }
+              if (stat.size >= 5 * 1024 * 1024) {
+                await parseClaudeSessionFileAsync(file);
+              } else {
+                parseClaudeSessionFile(file);
+                await new Promise(r => setImmediate(r));
+              }
+              // Also push into persistent SQLite index (batched)
+              try { _ingestClaudeFileToSqlite(file); } catch {}
+            } catch {}
+            _warmingStatus.done++;
+          }
+          _flushSqliteIngestBatch();
+        }
+        // Codex batch
+        if (_pendingCodexFiles.size > 0) {
+          const batch = Array.from(_pendingCodexFiles);
+          batch.sort((a, b) => {
+            try { return fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs; } catch { return 0; }
+          });
+          _warmingStatus.total = _warmingStatus.done + batch.length + _pendingParseFiles.size;
+          for (const file of batch) {
+            _pendingCodexFiles.delete(file);
+            try {
+              parseCodexSessionFile(file);
+              await new Promise(r => setImmediate(r));
+            } catch {}
+            _warmingStatus.done++;
+          }
+        }
+        // Invalidate session cache so next /api/sessions picks up new detail
+        _sessionsCache = null;
+        _sessionsCacheTs = 0;
+      }
+      _saveParsedDiskCache(true);
+      _flushSqliteIngestBatch();
+      _warmingStatus.phase = 'done';
+      _warmingStatus.finishedAt = Date.now();
+    } catch (e) {
+      _warmingStatus.phase = 'error: ' + (e && e.message || 'unknown');
+      _warmingStatus.finishedAt = Date.now();
+    } finally {
+      _warmingStatus.running = false;
+      _warmingRunning = false;
+    }
+  });
+}
+
+function getWarmingStatus() {
+  return Object.assign({}, _warmingStatus, {
+    pending: _pendingParseFiles.size,
+  });
+}
+
+// Flush all caches on process exit / signals so partial progress isn't lost
+let _flushHandlersInstalled = false;
+function _installFlushHandlers() {
+  if (_flushHandlersInstalled) return;
+  _flushHandlersInstalled = true;
+  const flushAll = () => {
+    try { _saveParsedDiskCache(true); } catch {}
+    try { _saveCostDiskCache(true); } catch {}
+    try { if (typeof _saveDailyStatsDiskCache === 'function') _saveDailyStatsDiskCache(); } catch {}
+    try { if (typeof _saveGitRootDiskCache === 'function') _saveGitRootDiskCache(); } catch {}
+    try { if (typeof _flushSqliteIngestBatch === 'function') _flushSqliteIngestBatch(); } catch {}
+  };
+  process.on('exit', flushAll);
+  process.on('SIGINT', () => { flushAll(); process.exit(0); });
+  process.on('SIGTERM', () => { flushAll(); process.exit(0); });
+}
+_installFlushHandlers();
+
+function parseClaudeSessionFile(sessionFile, opts) {
   if (!fs.existsSync(sessionFile)) return null;
 
   let stat;
@@ -138,6 +616,14 @@ function parseClaudeSessionFile(sessionFile) {
   const cacheKey = sessionFile + '|' + stat.mtimeMs + '|' + stat.size;
   _fileCacheKeyIndex[sessionFile] = cacheKey;
   if (_parsedDiskCache[cacheKey]) return _parsedDiskCache[cacheKey];
+
+  // Cache-only mode: skip actual file read when not cached. Caller gets
+  // null-ish placeholder and the real parse happens in a background job.
+  // This is what keeps the sync loadSessions() fast on cold caches.
+  if (opts && opts.cacheOnly) {
+    _pendingParseFiles.add(sessionFile);
+    return null;
+  }
 
   let lines;
   try {
@@ -158,11 +644,27 @@ function parseClaudeSessionFile(sessionFile) {
   const mcpSet = new Set();
   const skillSet = new Set();
 
+  // Helper: is this `type=user` entry a REAL user prompt, not a tool_result?
+  // In Claude Code JSONL, tool_result messages are stored as type='user' with
+  // content=[{type:'tool_result', ...}]. We want to count only messages whose
+  // content contains real text from the human.
+  const isRealUserPrompt = (entry) => {
+    const c = (entry.message || {}).content;
+    if (typeof c === 'string') return c.trim().length > 0;
+    if (Array.isArray(c)) {
+      for (const p of c) {
+        if (p && p.type === 'text' && p.text && p.text.trim()) return true;
+      }
+      return false;
+    }
+    return false;
+  };
+
   for (const line of lines) {
     try {
       const entry = JSON.parse(line);
       if (entry.type === 'user' || entry.type === 'assistant') msgCount++;
-      if (entry.type === 'user') userMsgCount++;
+      if (entry.type === 'user' && isRealUserPrompt(entry)) userMsgCount++;
       if (entry.timestamp) {
         if (entry.timestamp < firstTs) firstTs = entry.timestamp;
         if (entry.timestamp > lastTs) lastTs = entry.timestamp;
@@ -225,6 +727,123 @@ function parseClaudeSessionFile(sessionFile) {
   // Cache to disk
   _parsedDiskCache[cacheKey] = result;
   _parsedDiskCacheDirty = true;
+  _parsedDiskCacheEntriesSinceFlush++;
+  // Periodic flush so long operations don't lose progress on kill
+  if (_parsedDiskCacheEntriesSinceFlush >= PARSED_CACHE_FLUSH_EVERY) {
+    _saveParsedDiskCache(true);
+  }
+  return result;
+}
+
+// Async variant: for large files (>5 MB) reads in chunks with setImmediate
+// between chunks so the Node event loop can handle other requests. Same
+// result shape and cache as sync version.
+async function parseClaudeSessionFileAsync(sessionFile) {
+  if (!fs.existsSync(sessionFile)) return null;
+  let stat;
+  try { stat = fs.statSync(sessionFile); } catch { return null; }
+
+  _loadParsedDiskCache();
+  const cacheKey = sessionFile + '|' + stat.mtimeMs + '|' + stat.size;
+  _fileCacheKeyIndex[sessionFile] = cacheKey;
+  if (_parsedDiskCache[cacheKey]) return _parsedDiskCache[cacheKey];
+
+  // Small files: use sync path (faster, avoids Promise overhead)
+  const BIG_THRESHOLD = 5 * 1024 * 1024; // 5 MB
+  if (stat.size < BIG_THRESHOLD) return parseClaudeSessionFile(sessionFile);
+
+  // Big file: stream read + parse line by line with periodic yielding.
+  let projectPath = '';
+  let tool = 'claude';
+  let msgCount = 0;
+  let firstMsg = '';
+  let customTitle = '';
+  let firstTs = stat.mtimeMs;
+  let lastTs = stat.mtimeMs;
+  let userMsgCount = 0;
+  let entrypointFound = false;
+  let worktreeOriginalCwd = '';
+  const mcpSet = new Set();
+  const skillSet = new Set();
+
+  const readline = require('readline');
+  const stream = fs.createReadStream(sessionFile, { encoding: 'utf8', highWaterMark: 1 << 20 });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  const isRealUserPromptAsync = (entry) => {
+    const c = (entry.message || {}).content;
+    if (typeof c === 'string') return c.trim().length > 0;
+    if (Array.isArray(c)) {
+      for (const p of c) {
+        if (p && p.type === 'text' && p.text && p.text.trim()) return true;
+      }
+      return false;
+    }
+    return false;
+  };
+
+  let linesSinceYield = 0;
+  for await (const line of rl) {
+    if (!line) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' || entry.type === 'assistant') msgCount++;
+      if (entry.type === 'user' && isRealUserPromptAsync(entry)) userMsgCount++;
+      if (entry.timestamp) {
+        if (entry.timestamp < firstTs) firstTs = entry.timestamp;
+        if (entry.timestamp > lastTs) lastTs = entry.timestamp;
+      }
+      if (!projectPath && entry.type === 'user' && entry.cwd) projectPath = entry.cwd;
+      if (!worktreeOriginalCwd && entry.type === 'worktree-state' && entry.worktreeSession && entry.worktreeSession.originalCwd) {
+        worktreeOriginalCwd = entry.worktreeSession.originalCwd;
+      }
+      if (!entrypointFound && entry.type === 'user' && entry.entrypoint) {
+        entrypointFound = true;
+        if (entry.entrypoint !== 'cli') tool = 'claude-ext';
+      }
+      if (entry.type === 'custom-title' && typeof entry.customTitle === 'string') {
+        const title = entry.customTitle.trim();
+        if (title) customTitle = title.slice(0, 200);
+      }
+      if (!firstMsg && entry.type === 'user' && entry.message && entry.message.content) {
+        const content = extractContent(entry.message.content).trim();
+        if (content) firstMsg = content.slice(0, 200);
+      }
+      if (entry.type === 'assistant') {
+        const aContent = (entry.message || {}).content;
+        if (Array.isArray(aContent)) {
+          for (const block of aContent) {
+            if (!block || block.type !== 'tool_use') continue;
+            const name = block.name || '';
+            if (name.startsWith('mcp__')) {
+              const parts = name.split('__');
+              if (parts.length >= 3) mcpSet.add(parts[1]);
+            } else if (name === 'Skill') {
+              const sk = (block.input || {}).skill;
+              if (sk) skillSet.add(sk.includes(':') ? sk.split(':')[0] : sk);
+            }
+          }
+        }
+      }
+    } catch {}
+    if (++linesSinceYield >= 2000) {
+      linesSinceYield = 0;
+      await new Promise(r => setImmediate(r));
+    }
+  }
+
+  const result = {
+    projectPath, tool, msgCount, userMsgCount,
+    firstMsg, customTitle, firstTs, lastTs,
+    fileSize: stat.size, worktreeOriginalCwd,
+    mcpServers: Array.from(mcpSet), skills: Array.from(skillSet),
+  };
+  _parsedDiskCache[cacheKey] = result;
+  _parsedDiskCacheDirty = true;
+  _parsedDiskCacheEntriesSinceFlush++;
+  if (_parsedDiskCacheEntriesSinceFlush >= PARSED_CACHE_FLUSH_EVERY) {
+    _saveParsedDiskCache(true);
+  }
   return result;
 }
 
@@ -926,13 +1545,25 @@ function loadCursorVscdbDetail(sessionId) {
   return { messages: messages.slice(0, 200) };
 }
 
-function parseCodexSessionFile(sessionFile) {
+function parseCodexSessionFile(sessionFile, opts) {
   if (!fs.existsSync(sessionFile)) return null;
 
   let stat;
+  try { stat = fs.statSync(sessionFile); } catch { return null; }
+
+  // Reuse the same parsed-cache keyed by path+mtime+size
+  _loadParsedDiskCache();
+  const cacheKey = 'codex:' + sessionFile + '|' + stat.mtimeMs + '|' + stat.size;
+  if (_parsedDiskCache[cacheKey]) return _parsedDiskCache[cacheKey];
+
+  // Cache-only mode: queue for background parsing, don't block
+  if (opts && opts.cacheOnly) {
+    _pendingCodexFiles.add(sessionFile);
+    return null;
+  }
+
   let lines;
   try {
-    stat = fs.statSync(sessionFile);
     lines = readLines(sessionFile);
   } catch {
     return null;
@@ -955,6 +1586,25 @@ function parseCodexSessionFile(sessionFile) {
   let firstMsg = '';
   let firstTs = stat.mtimeMs;
   let lastTs = stat.mtimeMs;
+  // Detect sub-agent/scripted codex sessions. Multiple signals:
+  //  1. originator='codex_exec' or source='exec' (standard `codex exec`)
+  //  2. first user prompt matches known auto-script patterns (team scripts
+  //     that spawn codex without the exec flag). Covers: "You are in /path.
+  //     Task: X", "Read-only task. Inspect ...", "Work in /path", "Pair-local
+  //     <name> lane", "## Memory Writing Agent", etc.
+  let isHelper = false;
+  // Regexes checked against the first user prompt (see after the loop)
+  const AUTO_SCRIPT_PATTERNS = [
+    /^You are in \//,
+    /^Read-only task\./,
+    /^Work (only )?in \//,
+    /^Pair-local [^\n]{1,60} lane/,
+    /^## [A-Z][a-z]+ [A-Z][a-z]+ Agent/,   // "## Memory Writing Agent:..."
+    /^Read \/[^\s]+\/AGENTS\.md/,
+    /^Read \$[A-Z_]+\//,
+    /^\[Sub-agent results\]/,
+    /^You are OMX /,
+  ];
   const mcpSet = new Set();
 
   for (const line of lines) {
@@ -966,8 +1616,11 @@ function parseCodexSessionFile(sessionFile) {
         if (ts > lastTs) lastTs = ts;
       }
 
-      if (entry.type === 'session_meta' && entry.payload && entry.payload.cwd && !projectPath) {
-        projectPath = entry.payload.cwd;
+      if (entry.type === 'session_meta' && entry.payload) {
+        if (entry.payload.cwd && !projectPath) projectPath = entry.payload.cwd;
+        const originator = entry.payload.originator || '';
+        const source = entry.payload.source || '';
+        if (originator === 'codex_exec' || source === 'exec') isHelper = true;
         continue;
       }
 
@@ -995,7 +1648,14 @@ function parseCodexSessionFile(sessionFile) {
     } catch {}
   }
 
-  return {
+  // Secondary helper detection by first user prompt pattern
+  if (!isHelper && firstMsg) {
+    for (const re of AUTO_SCRIPT_PATTERNS) {
+      if (re.test(firstMsg)) { isHelper = true; break; }
+    }
+  }
+
+  const result = {
     projectPath,
     msgCount,
     userMsgCount,
@@ -1004,11 +1664,23 @@ function parseCodexSessionFile(sessionFile) {
     lastTs,
     fileSize: stat.size,
     mcpServers: Array.from(mcpSet),
+    isHelper,
   };
+  _parsedDiskCache[cacheKey] = result;
+  _parsedDiskCacheDirty = true;
+  _parsedDiskCacheEntriesSinceFlush++;
+  if (_parsedDiskCacheEntriesSinceFlush >= PARSED_CACHE_FLUSH_EVERY) {
+    _saveParsedDiskCache(true);
+  }
+  return result;
 }
 
+// Queue for background codex file parsing (drained by ensureWarmingRunning)
+const _pendingCodexFiles = new Set();
+
 function scanCodexSessions() {
-  const sessions = [];
+  // Map for O(1) session lookups (was O(n²) with .find)
+  const sessionsById = new Map();
   const codexTitles = parseCodexSessionIndex(CODEX_DIR);
   const codexHistory = path.join(CODEX_DIR, 'history.jsonl');
   if (fs.existsSync(codexHistory)) {
@@ -1016,12 +1688,11 @@ function scanCodexSessions() {
     for (const line of lines) {
       try {
         const d = JSON.parse(line);
-        // Codex uses session_id, ts (seconds), text
         const sid = d.session_id || d.sessionId || d.id;
         if (!sid) continue;
         const ts = d.ts ? d.ts * 1000 : (d.timestamp || Date.now());
-        if (!sessions.find(s => s.id === sid)) {
-          sessions.push({
+        if (!sessionsById.has(sid)) {
+          sessionsById.set(sid, {
             id: sid,
             tool: 'codex',
             project: d.project || d.cwd || '',
@@ -1040,10 +1711,10 @@ function scanCodexSessions() {
   }
 
   // Enrich with session files from ~/.codex/sessions/
+  // Cache-only: uses the parse cache; uncached files go to background queue.
   const codexSessionsDir = path.join(CODEX_DIR, 'sessions');
   if (fs.existsSync(codexSessionsDir)) {
     try {
-      // Walk year/month/day directories
       const files = [];
       const walkDir = (dir) => {
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -1055,37 +1726,61 @@ function scanCodexSessions() {
       walkDir(codexSessionsDir);
 
       for (const f of files) {
-        // Extract session ID from filename (rollout-DATE-UUID.jsonl)
         const basename = path.basename(f, '.jsonl');
         const uuidMatch = basename.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/);
         if (!uuidMatch) continue;
         const sid = uuidMatch[1];
-        const summary = parseCodexSessionFile(f);
-        if (!summary) continue;
-
-        const existing = sessions.find(s => s.id === sid);
+        const summary = parseCodexSessionFile(f, { cacheOnly: true });
+        if (!summary) {
+          // No cached summary yet — create a minimal placeholder from stat
+          // so the session still shows in the list. Background job will enrich.
+          let size = 0, mtimeMs = 0;
+          try { const st = fs.statSync(f); size = st.size; mtimeMs = st.mtimeMs; } catch {}
+          const existing = sessionsById.get(sid);
+          if (existing) {
+            existing.has_detail = true;
+            existing.file_size = size;
+            existing._detail_pending = true;
+          } else {
+            sessionsById.set(sid, {
+              id: sid,
+              tool: 'codex',
+              project: '',
+              project_short: '',
+              first_ts: mtimeMs,
+              last_ts: mtimeMs,
+              messages: 0,
+              first_message: codexTitles[sid] || '',
+              has_detail: true,
+              file_size: size,
+              detail_messages: 0,
+              user_messages: 0,
+              mcp_servers: [],
+              skills: [],
+              _detail_pending: true,
+            });
+          }
+          continue;
+        }
+        const existing = sessionsById.get(sid);
         if (existing) {
           existing.has_detail = true;
           existing.file_size = summary.fileSize;
           existing.messages = summary.msgCount;
           existing.detail_messages = summary.msgCount;
           existing.user_messages = summary.userMsgCount || 0;
-          if (codexTitles[sid]) {
-            existing.first_message = codexTitles[sid];
-          } else if (summary.firstMsg && !existing.first_message) {
-            existing.first_message = summary.firstMsg;
-          }
+          if (summary.isHelper) existing.is_helper = true;
+          if (codexTitles[sid]) existing.first_message = codexTitles[sid];
+          else if (summary.firstMsg && !existing.first_message) existing.first_message = summary.firstMsg;
           if (summary.projectPath && !existing.project) {
             existing.project = summary.projectPath;
             existing.project_short = summary.projectPath.replace(os.homedir(), '~');
           }
           existing.first_ts = Math.min(existing.first_ts, summary.firstTs);
           existing.last_ts = Math.max(existing.last_ts, summary.lastTs);
-          if (summary.mcpServers && summary.mcpServers.length > 0) {
-            existing.mcp_servers = summary.mcpServers;
-          }
+          if (summary.mcpServers && summary.mcpServers.length > 0) existing.mcp_servers = summary.mcpServers;
         } else {
-          sessions.push({
+          sessionsById.set(sid, {
             id: sid,
             tool: 'codex',
             project: summary.projectPath,
@@ -1100,13 +1795,14 @@ function scanCodexSessions() {
             user_messages: summary.userMsgCount || 0,
             mcp_servers: summary.mcpServers || [],
             skills: [],
+            is_helper: summary.isHelper || false,
           });
         }
       }
     } catch {}
   }
 
-  return sessions;
+  return Array.from(sessionsById.values());
 }
 
 // ── Git root resolver ───────────────────────────────────────
@@ -1121,46 +1817,105 @@ function scanCodexSessions() {
 //      from the session cwd string. Works without git for standard worktree layouts.
 
 const _gitRootCache = {};
-const GIT_ROOT_CACHE_FILE = path.join(os.tmpdir(), 'codedash-gitroot-cache.json');
+// Persistent dir (survives /tmp cleanup). Legacy file in tmpdir migrated once.
+const GIT_ROOT_CACHE_FILE = path.join(CODEDASH_CACHE_DIR, 'git-root-cache.json');
+const LEGACY_GIT_ROOT_CACHE_FILE = path.join(os.tmpdir(), 'codedash-gitroot-cache.json');
 let _gitRootDiskCache = null;
+let _gitRootDirty = false;
+// Queue of project paths that still need git resolution. Filled by sync
+// loadSessions() when a path is uncached, drained in background by
+// _ensureGitRootResolverRunning() so the sync path returns immediately.
+const _pendingGitRoots = new Set();
+let _gitRootResolverRunning = false;
 
 function _loadGitRootDiskCache() {
   if (_gitRootDiskCache) return;
   try {
     if (fs.existsSync(GIT_ROOT_CACHE_FILE)) {
       _gitRootDiskCache = JSON.parse(fs.readFileSync(GIT_ROOT_CACHE_FILE, 'utf8'));
-      // Pre-fill memory cache from disk
-      Object.assign(_gitRootCache, _gitRootDiskCache);
+    } else if (fs.existsSync(LEGACY_GIT_ROOT_CACHE_FILE)) {
+      _gitRootDiskCache = JSON.parse(fs.readFileSync(LEGACY_GIT_ROOT_CACHE_FILE, 'utf8'));
+      _gitRootDirty = true;
     }
+    if (_gitRootDiskCache) Object.assign(_gitRootCache, _gitRootDiskCache);
   } catch {}
   if (!_gitRootDiskCache) _gitRootDiskCache = {};
 }
 
 function _saveGitRootDiskCache() {
+  if (!_gitRootDirty) return;
   try {
-    fs.writeFileSync(GIT_ROOT_CACHE_FILE, JSON.stringify(_gitRootCache));
+    const tmp = GIT_ROOT_CACHE_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(_gitRootCache));
+    fs.renameSync(tmp, GIT_ROOT_CACHE_FILE);
+    _gitRootDirty = false;
   } catch {}
+}
+
+// Sync resolver: never shells out from the hot path. Uses cache; queues
+// unknown paths for background resolution.
+// ── Conversation group key ─────────────────────────────────
+// Two sessions belong to the same conversation group if they share the same
+// project AND the same initial user prompt (first ~200 chars). This dedupes
+// `codex exec` retries, `codex resume` chains, and sub-agent re-runs that
+// would otherwise show as N separate cards in the UI. Helper sessions
+// (is_helper=true) all collapse into their own single bucket per project.
+function computeSessionGroupKey(s) {
+  const proj = (s.project || 'unknown').trim();
+  // Normalize first message: lowercase, collapse whitespace, truncate
+  let msg = (s.first_message || '').replace(/\s+/g, ' ').trim().slice(0, 200);
+  if (s.is_helper) {
+    // All helpers in the same project collapse into one group.
+    return 'helper::' + proj;
+  }
+  if (!msg) return s.tool + '::' + proj + '::' + s.id; // no prompt — unique
+  return s.tool + '::' + proj + '::' + msg;
 }
 
 function resolveGitRoot(projectPath) {
   if (!projectPath) return '';
   _loadGitRootDiskCache();
   if (_gitRootCache[projectPath] !== undefined) return _gitRootCache[projectPath];
-  // Skip remote/non-existent paths
+  // Fast skip: non-existent paths can never be git roots, record & done.
   if (!fs.existsSync(projectPath)) {
     _gitRootCache[projectPath] = '';
+    _gitRootDirty = true;
     return '';
   }
-  try {
-    const root = execFileSync('git', ['-C', projectPath, 'rev-parse', '--show-toplevel'], {
-      encoding: 'utf8', timeout: 2000, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe']
-    }).trim();
-    _gitRootCache[projectPath] = root;
-    return root;
-  } catch {
-    _gitRootCache[projectPath] = '';
-    return '';
-  }
+  // Queue for background resolver — sync path returns '' for now
+  _pendingGitRoots.add(projectPath);
+  _ensureGitRootResolverRunning();
+  return '';
+}
+
+function _ensureGitRootResolverRunning() {
+  if (_gitRootResolverRunning) return;
+  if (_pendingGitRoots.size === 0) return;
+  _gitRootResolverRunning = true;
+  setImmediate(async () => {
+    try {
+      while (_pendingGitRoots.size > 0) {
+        const snapshot = Array.from(_pendingGitRoots);
+        for (const p of snapshot) {
+          _pendingGitRoots.delete(p);
+          if (_gitRootCache[p] !== undefined) continue;
+          let root = '';
+          try {
+            root = execFileSync('git', ['-C', p, 'rev-parse', '--show-toplevel'], {
+              encoding: 'utf8', timeout: 2000, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'],
+            }).trim();
+          } catch {}
+          _gitRootCache[p] = root;
+          _gitRootDirty = true;
+          // Yield between shell-outs so HTTP stays responsive
+          await new Promise(r => setImmediate(r));
+        }
+        _saveGitRootDiskCache();
+      }
+    } finally {
+      _gitRootResolverRunning = false;
+    }
+  });
 }
 
 const _gitInfoCache = {};
@@ -1205,15 +1960,15 @@ function getProjectGitInfo(projectPath) {
 
 let _sessionsCache = null;
 let _sessionsCacheTs = 0;
-const SESSIONS_CACHE_TTL = 60000; // 60 seconds — hot cache, invalidated by file changes
+const SESSIONS_CACHE_TTL = 60000; // 60 seconds — hot cache, extended if no file changes
 
-// Track file mtimes for smart invalidation
+// Track history/projects mtime so we only rescan when files actually changed.
+// Lets loadSessions() extend the cache window past TTL when nothing happened.
 let _historyMtime = 0;
 let _historySize = 0;
 let _projectsDirMtime = 0;
 
 function _sessionsNeedRescan() {
-  // Check if history.jsonl or projects dir changed since last scan
   try {
     if (fs.existsSync(HISTORY_FILE)) {
       const st = fs.statSync(HISTORY_FILE);
@@ -1374,11 +2129,11 @@ function _loadCursorVscdbInBackground() {
 function loadSessions() {
   const now = Date.now();
   if (_sessionsCache) {
-    // Hot cache: return immediately if within TTL and no file changes
+    // Hot cache: return immediately within TTL window
     if ((now - _sessionsCacheTs) < SESSIONS_CACHE_TTL) return _sessionsCache;
-    // Extended cache: even after TTL, only rescan if files actually changed
+    // Extended cache: after TTL, only rescan if files actually changed
     if (!_sessionsNeedRescan()) {
-      _sessionsCacheTs = now; // extend TTL
+      _sessionsCacheTs = now;
       return _sessionsCache;
     }
   }
@@ -1539,12 +2294,19 @@ function loadSessions() {
     }
 
     if (sessionFile) {
-      const summary = parseClaudeSessionFile(sessionFile);
+      // Cache-only: never read disk from the sync path. Uncached files are
+      // queued for background warming — subsequent calls will see full data.
+      const summary = parseClaudeSessionFile(sessionFile, { cacheOnly: true });
       if (summary) mergeClaudeSessionDetail(s, summary, sessionFile);
       else {
+        // Placeholder: session exists on disk, actual details pending
         s.has_detail = true;
-        try { s.file_size = fs.statSync(sessionFile).size; } catch { s.file_size = 0; }
         s._session_file = sessionFile;
+        s._detail_pending = true;
+        try { s.file_size = fs.statSync(sessionFile).size; } catch { s.file_size = 0; }
+        if (s.detail_messages === undefined) s.detail_messages = 0;
+        if (!s.mcp_servers) s.mcp_servers = [];
+        if (!s.skills) s.skills = [];
       }
     } else if (!s.has_detail) {
       s.has_detail = false;
@@ -1556,6 +2318,7 @@ function loadSessions() {
   }
 
   // Scan project dirs for orphan sessions (e.g. Claude Extension sessions not in history.jsonl)
+  // Cache-only in sync path; uncached files get queued and background job parses them.
   if (fs.existsSync(PROJECTS_DIR)) {
     try {
       for (const proj of fs.readdirSync(PROJECTS_DIR)) {
@@ -1566,12 +2329,37 @@ function loadSessions() {
           const sid = file.replace('.jsonl', '');
           const filePath = path.join(projDir, file);
           if (sessions[sid]) {
-            const summary = parseClaudeSessionFile(filePath);
+            const summary = parseClaudeSessionFile(filePath, { cacheOnly: true });
             if (summary) mergeClaudeSessionDetail(sessions[sid], summary, filePath);
+            else sessions[sid]._detail_pending = true;
             continue;
           }
-          const summary = parseClaudeSessionFile(filePath);
-          if (!summary) continue;
+          const summary = parseClaudeSessionFile(filePath, { cacheOnly: true });
+          if (!summary) {
+            // Create a placeholder from stat + history of same sid (none here)
+            let size = 0;
+            try { size = fs.statSync(filePath).size; } catch {}
+            sessions[sid] = {
+              id: sid,
+              tool: 'claude',
+              project: '',
+              project_short: '',
+              first_ts: 0,
+              last_ts: 0,
+              messages: 0,
+              first_message: '',
+              has_detail: true,
+              file_size: size,
+              detail_messages: 0,
+              mcp_servers: [],
+              skills: [],
+              _claude_dir: CLAUDE_DIR,
+              _session_file: filePath,
+              _detail_pending: true,
+              worktree_original_cwd: '',
+            };
+            continue;
+          }
           sessions[sid] = {
             id: sid,
             tool: summary.tool,
@@ -1594,6 +2382,12 @@ function loadSessions() {
       }
     } catch {}
   }
+
+  // If any Claude files were uncached, _pendingParseFiles has been populated
+  // by parseClaudeSessionFile(cacheOnly: true). Kick off the warmer.
+  _ensureWarmingRunning();
+  // Kick off one-shot SQLite backfill (noop if already running/done)
+  _ensureSqliteBackfillRunning();
 
   // Ensure all sessions have mcp_servers/skills (defaults for non-Claude)
   for (const s of Object.values(sessions)) {
@@ -1625,12 +2419,27 @@ function loadSessions() {
     s.date = dt.getFullYear() + '-' + String(dt.getMonth()+1).padStart(2,'0') + '-' + String(dt.getDate()).padStart(2,'0');
     // Priority: worktree-state.originalCwd (container-safe) > git rev-parse > path heuristic (frontend)
     s.git_root = s.worktree_original_cwd || (s.project ? (_gitRootCache[s.project] || '') : '');
+    // Conversation group key — sessions with the same project + initial
+    // prompt are treated as retries/resumes of the same conversation. Used
+    // by the shared groupSessions() helper in all views (Timeline, All
+    // Sessions, Cloud Sync) so we don't render 50 duplicate cards.
+    s.group_key = computeSessionGroupKey(s);
   }
 
   // Flag for frontend: true = cursor vscdb still loading, will have more data soon
   result._loading = !_cursorVscdbSessions && _cursorVscdbLoading;
+  // Warming state: true when background parse of session files is in progress
+  result._warming = _warmingStatus.running;
+  if (_warmingStatus.running || _warmingStatus.pending > 0) {
+    result._warmingProgress = {
+      done: _warmingStatus.done,
+      total: _warmingStatus.total,
+      phase: _warmingStatus.phase,
+      pending: _pendingParseFiles.size,
+    };
+  }
 
-  // Flush disk caches
+  // Flush disk caches (non-force: only writes if dirty beyond threshold)
   _saveParsedDiskCache();
   _saveGitRootDiskCache();
   _updateScanMarkers();
@@ -1638,6 +2447,91 @@ function loadSessions() {
   _sessionsCache = result;
   _sessionsCacheTs = Date.now();
   return result;
+}
+
+// ── Async pre-warm of parse cache + incremental change detection ─────────
+// Lists all Claude session JSONL files and parses those whose cache entry
+// is stale (mtime or size changed) or missing. Yields between files so the
+// HTTP event loop stays responsive. Reports progress via callback.
+async function loadSessionsAsync(progressCb) {
+  _loadParsedDiskCache();
+  _loadCostDiskCache();
+
+  const report = (phase, done, total, extra) => {
+    if (typeof progressCb === 'function') {
+      try { progressCb({ phase, done, total, ...(extra || {}) }); } catch {}
+    }
+  };
+
+  // Phase 1: enumerate all Claude JSONL files (fast, just readdir)
+  report('scanning files', 0, 0);
+  const allClaudeFiles = [];
+  const walkClaude = (dir) => {
+    try {
+      for (const proj of fs.readdirSync(dir)) {
+        const projDir = path.join(dir, proj);
+        try {
+          if (!fs.statSync(projDir).isDirectory()) continue;
+          for (const file of fs.readdirSync(projDir)) {
+            if (!file.endsWith('.jsonl')) continue;
+            allClaudeFiles.push(path.join(projDir, file));
+          }
+        } catch {}
+      }
+    } catch {}
+  };
+  if (fs.existsSync(PROJECTS_DIR)) walkClaude(PROJECTS_DIR);
+  for (const extra of EXTRA_CLAUDE_DIRS) {
+    const ep = path.join(extra, 'projects');
+    if (fs.existsSync(ep)) walkClaude(ep);
+  }
+
+  // Phase 2: figure out which files need (re)parsing — incremental path
+  const toParse = [];
+  let cachedCount = 0;
+  for (const f of allClaudeFiles) {
+    let stat;
+    try { stat = fs.statSync(f); } catch { continue; }
+    const key = f + '|' + stat.mtimeMs + '|' + stat.size;
+    if (_parsedDiskCache[key]) {
+      _fileCacheKeyIndex[f] = key;
+      cachedCount++;
+    } else {
+      toParse.push({ file: f, size: stat.size });
+    }
+  }
+  // Parse newest (largest mtime) first so dashboards reflect fresh data fastest
+  toParse.sort((a, b) => {
+    try { return fs.statSync(b.file).mtimeMs - fs.statSync(a.file).mtimeMs; } catch { return 0; }
+  });
+
+  const total = allClaudeFiles.length;
+  report('parsing session files', cachedCount, total, { cached: cachedCount, toParse: toParse.length });
+
+  // Phase 3: parse uncached files with yielding
+  let done = cachedCount;
+  for (const { file, size } of toParse) {
+    try {
+      if (size >= 5 * 1024 * 1024) {
+        await parseClaudeSessionFileAsync(file);
+      } else {
+        parseClaudeSessionFile(file);
+        // Tiny yield so poll requests can slot in between files
+        await new Promise(r => setImmediate(r));
+      }
+    } catch {}
+    done++;
+    report('parsing session files', done, total, { cached: cachedCount, toParse: toParse.length });
+  }
+  _saveParsedDiskCache(true);
+
+  // Phase 4: invalidate any stale in-memory session cache, then build full
+  // sessions list from now-warm parse cache (sync call, fast)
+  _sessionsCache = null;
+  _sessionsCacheTs = 0;
+  report('aggregating sessions', total, total);
+  const sessions = loadSessions();
+  return sessions;
 }
 
 function loadSessionDetail(sessionId, project) {
@@ -1852,7 +2746,7 @@ function exportSessionMarkdown(sessionId, project) {
 // Session file index: sessionId -> file path (built once, avoids O(sessions*projects) scans)
 let _sessionFileIndex = null;
 let _sessionFileIndexTs = 0;
-const SESSION_FILE_INDEX_TTL = 120000; // 2 minutes — dirs rarely change
+const SESSION_FILE_INDEX_TTL = 30000; // 30 seconds
 
 function _buildSessionFileIndex() {
   const now = Date.now();
@@ -1996,14 +2890,27 @@ function isSystemMessage(text) {
   if (!text) return true;
   var t = text.trim();
   if (t === 'exit' || t === 'quit' || t === '/exit') return true;
+  // XML-wrapped injected context (Claude Code + Codex)
   if (t.startsWith('<permissions')) return true;
   if (t.startsWith('<environment_context')) return true;
   if (t.startsWith('<collaboration_mode')) return true;
-  if (t.startsWith('# AGENTS.md')) return true;
   if (t.startsWith('<INSTRUCTIONS>')) return true;
-  // Codex developer role system prompts
+  if (t.startsWith('<cwd>')) return true;
+  if (t.startsWith('<turn_aborted>')) return true;
+  if (t.startsWith('<ide_selection>')) return true;
+  if (t.startsWith('<command_output>')) return true;
+  // Agent instruction docs and skill metadata
+  if (t.startsWith('# AGENTS.md')) return true;
+  if (t.startsWith('# CLAUDE.md')) return true;
+  // Codex developer/system prompts
   if (t.startsWith('You are Codex')) return true;
   if (t.startsWith('Filesystem sandboxing')) return true;
+  // Codex runtime nudges / auto-steering (not real user prompts)
+  if (t.startsWith('Warning: The maximum number of unified exec')) return true;
+  if (t.indexOf('AUTOSTEERING:') >= 0 && t.length < 400) return true;
+  // Sub-agent delegate result injection
+  if (t.startsWith('[Sub-agent results]')) return true;
+  if (t.startsWith('[sub-agent result]')) return true;
   return false;
 }
 
@@ -2188,14 +3095,34 @@ function getSearchIndex(sessions) {
 
 function searchFullText(query, sessions) {
   if (!query || query.length < 2) return [];
+
+  // Prefer the persistent SQLite FTS5 index — O(log n), no RAM bloat.
+  try {
+    const sqliteIndex = require('./sqlite-index');
+    const rows = sqliteIndex.search(query, 200);
+    if (rows && rows.length > 0) {
+      // Group by session_id, keep up to 3 snippets per session
+      const bySession = {};
+      for (const r of rows) {
+        if (!bySession[r.session_id]) bySession[r.session_id] = [];
+        if (bySession[r.session_id].length >= 3) continue;
+        bySession[r.session_id].push({
+          role: r.role,
+          snippet: (r.snippet || '').replace(/<</g, '').replace(/>>/g, ''),
+        });
+      }
+      return Object.keys(bySession).map(sid => ({ sessionId: sid, matches: bySession[sid] }));
+    }
+  } catch (e) {
+    // Fall through to in-memory fallback
+  }
+
+  // Fallback: in-memory scan (pre-SQLite ingest completion)
   const q = query.toLowerCase();
   const index = getSearchIndex(sessions);
   const results = [];
-
   for (const entry of index) {
     if (entry.fullText.indexOf(q) === -1) continue;
-
-    // Find matching messages with snippets
     const matches = [];
     for (const t of entry.texts) {
       if (matches.length >= 3) break;
@@ -2209,12 +3136,8 @@ function searchFullText(query, sessions) {
         });
       }
     }
-
-    if (matches.length > 0) {
-      results.push({ sessionId: entry.sessionId, matches });
-    }
+    if (matches.length > 0) results.push({ sessionId: entry.sessionId, matches });
   }
-
   return results;
 }
 
@@ -2298,27 +3221,7 @@ function getModelPricing(model) {
 }
 
 // ── Compute real cost from session file token usage ────────
-
-// Disk cache for computed session costs
-const COST_CACHE_FILE = path.join(os.tmpdir(), 'codedash-cost-cache.json');
-let _costDiskCache = null;
-
-function _loadCostDiskCache() {
-  if (_costDiskCache) return;
-  try {
-    if (fs.existsSync(COST_CACHE_FILE)) {
-      _costDiskCache = JSON.parse(fs.readFileSync(COST_CACHE_FILE, 'utf8'));
-    }
-  } catch {}
-  if (!_costDiskCache) _costDiskCache = {};
-}
-
-function _saveCostDiskCache() {
-  if (!_costDiskCache) return;
-  try {
-    fs.writeFileSync(COST_CACHE_FILE, JSON.stringify(_costDiskCache));
-  } catch {}
-}
+// (COST_CACHE_FILE/_costDiskCache/_loadCostDiskCache/_saveCostDiskCache defined at top)
 
 const EMPTY_COST = { cost: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: '' };
 
@@ -2458,57 +3361,214 @@ function computeSessionCost(sessionId, project) {
   }
 
   const result = { cost: totalCost, inputTokens: totalInput, outputTokens: totalOutput, cacheReadTokens: totalCacheRead, cacheCreateTokens: totalCacheCreate, contextPctSum, contextTurnCount, model };
-  if (cacheKey) _costDiskCache[cacheKey] = result;
+  if (cacheKey) {
+    _costDiskCache[cacheKey] = result;
+    _costDiskCacheDirty = true;
+    _costDiskCacheEntriesSinceFlush++;
+    if (_costDiskCacheEntriesSinceFlush >= COST_CACHE_FLUSH_EVERY) {
+      _saveCostDiskCache(true);
+    }
+  }
   _costMemCache[sessionId] = result;
   return result;
 }
 
 // ── Cost analytics ────────────────────────────────────────
 
-// Analytics result cache — avoids recomputing 31k sessions every request
-const ANALYTICS_CACHE_FILE = path.join(os.tmpdir(), 'codedash-analytics-cache.json');
-let _analyticsCacheResult = null;
-let _analyticsCacheKey = null;
+// ── Incremental cost aggregator ───────────────────────────────
+// Streaming version of getCostAnalytics: create an aggregator, feed sessions
+// one at a time via merge(), read a snapshot at any point via finalize().
+// Lets the background job expose live partial results to the UI.
+function createCostAggregator() {
+  const state = {
+    byDay: {}, byProject: {}, byWeek: {}, byAgent: {},
+    totalCost: 0, totalTokens: 0,
+    totalInputTokens: 0, totalOutputTokens: 0,
+    totalCacheReadTokens: 0, totalCacheCreateTokens: 0,
+    globalContextPctSum: 0, globalContextTurnCount: 0,
+    firstDate: null, lastDate: null,
+    sessionsWithData: 0,
+    sessionCosts: [],
+    agentNoCostData: {},
+    seenAgents: new Set(),
+    processedCount: 0,
+  };
+  return {
+    state,
+    merge(session, costData) {
+      state.processedCount++;
+      if (!state.seenAgents.has(session.tool)) {
+        state.seenAgents.add(session.tool);
+        if (!state.byAgent[session.tool]) state.byAgent[session.tool] = { cost: 0, sessions: 0, tokens: 0, estimated: false };
+      }
+      const cost = costData.cost;
+      const tokens = costData.inputTokens + costData.outputTokens + costData.cacheReadTokens + costData.cacheCreateTokens;
+      if (cost === 0 && tokens === 0) {
+        if (!state.agentNoCostData[session.tool]) state.agentNoCostData[session.tool] = 0;
+        state.agentNoCostData[session.tool]++;
+        return;
+      }
+      state.sessionsWithData++;
+      state.totalCost += cost;
+      state.totalTokens += tokens;
+      state.totalInputTokens += costData.inputTokens;
+      state.totalOutputTokens += costData.outputTokens;
+      state.totalCacheReadTokens += costData.cacheReadTokens;
+      state.totalCacheCreateTokens += costData.cacheCreateTokens;
 
-function _analyticsKey(sessions) {
-  // Key: session count + newest session mtime
-  let newest = 0;
-  for (const s of sessions) {
-    if (s.last_ts > newest) newest = s.last_ts;
+      const agent = session.tool || 'unknown';
+      if (!state.byAgent[agent]) state.byAgent[agent] = { cost: 0, sessions: 0, tokens: 0, estimated: false };
+      state.byAgent[agent].cost += cost;
+      state.byAgent[agent].sessions++;
+      state.byAgent[agent].tokens += tokens;
+      if (agent === 'codex') state.byAgent[agent].estimated = true;
+      if (agent === 'cursor' && costData.model && costData.model.includes('-estimated')) state.byAgent[agent].estimated = true;
+      if (agent === 'opencode' && !costData.model) state.byAgent[agent].estimated = true;
+
+      state.globalContextPctSum += costData.contextPctSum;
+      state.globalContextTurnCount += costData.contextTurnCount;
+
+      const day = session.date || 'unknown';
+      if (session.date) {
+        if (!state.firstDate || session.date < state.firstDate) state.firstDate = session.date;
+        if (!state.lastDate || session.date > state.lastDate) state.lastDate = session.date;
+      }
+      if (!state.byDay[day]) state.byDay[day] = { cost: 0, sessions: 0, tokens: 0 };
+      state.byDay[day].cost += cost;
+      state.byDay[day].sessions++;
+      state.byDay[day].tokens += tokens;
+
+      if (session.date) {
+        const d = new Date(session.date);
+        const weekStart = new Date(d);
+        weekStart.setDate(d.getDate() - d.getDay());
+        const weekKey = weekStart.toISOString().slice(0, 10);
+        if (!state.byWeek[weekKey]) state.byWeek[weekKey] = { cost: 0, sessions: 0 };
+        state.byWeek[weekKey].cost += cost;
+        state.byWeek[weekKey].sessions++;
+      }
+
+      const proj = session.project_short || session.project || 'unknown';
+      if (!state.byProject[proj]) state.byProject[proj] = { cost: 0, sessions: 0, tokens: 0 };
+      state.byProject[proj].cost += cost;
+      state.byProject[proj].sessions++;
+      state.byProject[proj].tokens += tokens;
+
+      state.sessionCosts.push({ id: session.id, cost, project: proj, date: session.date, last_ts: session.last_ts || 0 });
+    },
+    finalize() {
+      // Sort top sessions by cost (snapshot a shallow copy so partials stay consistent)
+      const topCopy = state.sessionCosts.slice().sort((a, b) => b.cost - a.cost);
+      const days = state.firstDate && state.lastDate
+        ? Math.max(1, Math.round((new Date(state.lastDate) - new Date(state.firstDate)) / 86400000) + 1)
+        : 1;
+      const now = Date.now();
+      const todayStr = new Date().toISOString().slice(0, 10);
+      const hoursElapsedToday = (now - new Date(todayStr).getTime()) / 3600000;
+      let last1hCost = 0;
+      let todayCost = 0;
+      for (const sc of topCopy) {
+        if (sc.last_ts >= now - 3600000) last1hCost += sc.cost;
+        if (sc.date === todayStr) todayCost += sc.cost;
+      }
+      return {
+        totalCost: state.totalCost,
+        totalTokens: state.totalTokens,
+        totalInputTokens: state.totalInputTokens,
+        totalOutputTokens: state.totalOutputTokens,
+        totalCacheReadTokens: state.totalCacheReadTokens,
+        totalCacheCreateTokens: state.totalCacheCreateTokens,
+        avgContextPct: state.globalContextTurnCount > 0 ? Math.round(state.globalContextPctSum / state.globalContextTurnCount) : 0,
+        dailyRate: state.totalCost / days,
+        firstDate: state.firstDate,
+        lastDate: state.lastDate,
+        days,
+        totalSessions: state.sessionsWithData,
+        byDay: state.byDay,
+        byWeek: state.byWeek,
+        byProject: state.byProject,
+        topSessions: topCopy.slice(0, 10),
+        byAgent: state.byAgent,
+        agentNoCostData: state.agentNoCostData,
+        last1hCost,
+        todayCost,
+        hoursElapsedToday: Math.max(1, hoursElapsedToday),
+        processedCount: state.processedCount,
+      };
+    },
+  };
+}
+
+// Compute per-session cost respecting special per-tool paths used by
+// getCostAnalytics (opencode batch, cursor vscdb tokens, ...).
+function computeSessionCostForAnalytics(session, opencodeCostCache) {
+  if (session.tool === 'opencode' && opencodeCostCache && opencodeCostCache[session.id]) {
+    return opencodeCostCache[session.id];
   }
-  return sessions.length + ':' + newest;
+  if (session.tool === 'cursor') {
+    const inp = session._cursor_input_tokens || 0;
+    const out = session._cursor_output_tokens || 0;
+    if (inp > 0 || out > 0) {
+      const model = session._cursor_model || '';
+      const pricing = getModelPricing(model);
+      return { cost: inp * pricing.input + out * pricing.output, inputTokens: inp, outputTokens: out, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: model };
+    }
+    if (session.user_messages > 0 || session.messages > 0) {
+      const userMsgs = session.user_messages || Math.ceil((session.messages || 0) * 0.07);
+      const model = session._cursor_model || 'claude-sonnet';
+      const pricing = getModelPricing(model);
+      const estInput = userMsgs * 2000;
+      const estOutput = userMsgs * 1000;
+      return { cost: estInput * pricing.input + estOutput * pricing.output, inputTokens: estInput, outputTokens: estOutput, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: model + '-estimated' };
+    }
+    return EMPTY_COST;
+  }
+  return computeSessionCost(session.id, session.project);
+}
+
+// Pre-compute OpenCode costs in one batch SQL — used by the streaming path
+function buildOpencodeCostCache(sessions) {
+  const cache = {};
+  const opencodeSessions = sessions.filter(s => s.tool === 'opencode');
+  if (opencodeSessions.length === 0 || !fs.existsSync(OPENCODE_DB)) return cache;
+  try {
+    const batchRows = execFileSync('sqlite3', [
+      OPENCODE_DB,
+      `SELECT session_id, data FROM message WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created`
+    ], { encoding: 'utf8', timeout: 30000, windowsHide: true }).trim();
+    if (batchRows) {
+      for (const row of batchRows.split('\n')) {
+        const sepIdx = row.indexOf('|');
+        if (sepIdx < 0) continue;
+        const sessId = row.slice(0, sepIdx);
+        const jsonStr = row.slice(sepIdx + 1);
+        try {
+          const msgData = JSON.parse(jsonStr);
+          const t = msgData.tokens || {};
+          const inp = t.input || 0;
+          const out = (t.output || 0) + (t.reasoning || 0);
+          const cacheRead = (t.cache && t.cache.read) || 0;
+          const cacheCreate = (t.cache && t.cache.write) || 0;
+          if (inp === 0 && out === 0) continue;
+          if (!cache[sessId]) cache[sessId] = { cost: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreateTokens: 0, contextPctSum: 0, contextTurnCount: 0, model: '' };
+          const c = cache[sessId];
+          if (!c.model && msgData.modelID) c.model = msgData.modelID;
+          const pricing = getModelPricing(msgData.modelID || c.model);
+          c.inputTokens += inp;
+          c.outputTokens += out;
+          c.cacheReadTokens += cacheRead;
+          c.cacheCreateTokens += cacheCreate;
+          c.cost += inp * pricing.input + cacheCreate * pricing.cache_create + cacheRead * pricing.cache_read + out * pricing.output;
+          const ctx = inp + cacheCreate + cacheRead;
+          if (ctx > 0) { c.contextPctSum += (ctx / CONTEXT_WINDOW) * 100; c.contextTurnCount++; }
+        } catch {}
+      }
+    }
+  } catch {}
+  return cache;
 }
 
 function getCostAnalytics(sessions) {
-  // Fast cache check — if sessions haven't changed, return cached result
-  const key = _analyticsKey(sessions);
-  if (_analyticsCacheResult && _analyticsCacheKey === key) return _analyticsCacheResult;
-
-  // Try disk cache
-  if (!_analyticsCacheResult) {
-    try {
-      if (fs.existsSync(ANALYTICS_CACHE_FILE)) {
-        const cached = JSON.parse(fs.readFileSync(ANALYTICS_CACHE_FILE, 'utf8'));
-        if (cached._key === key) {
-          _analyticsCacheResult = cached.data;
-          _analyticsCacheKey = key;
-          return cached.data;
-        }
-      }
-    } catch {}
-  }
-
-  const result = _computeCostAnalytics(sessions);
-
-  // Save to cache
-  _analyticsCacheResult = result;
-  _analyticsCacheKey = key;
-  try { fs.writeFileSync(ANALYTICS_CACHE_FILE, JSON.stringify({ _key: key, data: result })); } catch {}
-
-  return result;
-}
-
-function _computeCostAnalytics(sessions) {
   const byDay = {};
   const byProject = {};
   const byWeek = {};
@@ -2675,7 +3735,8 @@ function _computeCostAnalytics(sessions) {
     if (sc.date === todayStr) todayCost += sc.cost;
   }
 
-  _saveCostDiskCache();
+  _saveCostDiskCache(true);
+  _saveParsedDiskCache(true);
 
   return {
     totalCost,
@@ -2704,13 +3765,63 @@ function _computeCostAnalytics(sessions) {
 
 // ── Active sessions detection ─────────────────────────────
 
-function getActiveSessions() {
-  const active = [];
-  const seenPids = new Set();
+// ── Active sessions (cached, non-blocking) ──────────────────
+// getActiveSessions() is called from /api/active which the browser polls on
+// a timer. The previous version shelled out to `ps` + `lsof` synchronously
+// once per matching process, doing an O(N) sync scan that blocked the event
+// loop for tens of seconds when many processes had "codex"/"claude" in their
+// cmdline (e.g. codex-up-exec wrapper spawned by Claude Code tooling).
+//
+// New design:
+//   1. Cached result served for up to 3 seconds.
+//   2. Tighter cmd matching — must be a real agent CLI, not a substring hit.
+//   3. pid→cwd is remembered across calls (pids are stable for the process
+//      lifetime). We only look up cwd for pids we've never seen.
+//   4. lsof is run ONCE as a single batch call for all unknown pids, with
+//      a hard 2-second total timeout.
+//   5. No inner loadSessions() calls; session matching uses the in-memory
+//      sessions cache if it already exists, otherwise cwd-match is skipped
+//      and a background refresh fires.
+let _activeCache = null;
+let _activeCacheTs = 0;
+const ACTIVE_CACHE_TTL = 3000; // 3 seconds
+const _pidCwdCache = new Map(); // pid → cwd (stable for process lifetime)
 
-  // 1. Claude Code — read PID files for session ID mapping
+// Real agent CLI invocations — tighter than a substring match.
+// Matches the binary name at the START of cmd (or after a /path/).
+// Includes codex-up variants (user wrapper that spawns codex exec).
+const AGENT_CLI_MATCHERS = [
+  { tool: 'claude',  re: /(^|\/)claude(\s|$)/ },
+  { tool: 'codex',   re: /(^|\/)codex(-up(-exec)?)?(\s|$)/ },
+  { tool: 'opencode',re: /(^|\/)opencode(\s|$)/ },
+  { tool: 'kiro',    re: /(^|\/)kiro-cli(\s|$)/ },
+  { tool: 'cursor',  re: /(^|\/)cursor-agent(\s|$)/ },
+];
+
+function _matchAgentCli(cmd) {
+  for (const m of AGENT_CLI_MATCHERS) {
+    if (m.re.test(cmd)) return m.tool;
+  }
+  return '';
+}
+
+function getActiveSessions() {
+  const now = Date.now();
+  if (_activeCache && (now - _activeCacheTs) < ACTIVE_CACHE_TTL) {
+    return _activeCache;
+  }
+  const active = [];
+
+  // Skip on Windows
+  if (process.platform === 'win32') {
+    _activeCache = active;
+    _activeCacheTs = now;
+    return active;
+  }
+
+  // 1. Read Claude Code PID files (provides cwd + sessionId directly)
   const sessionsDir = path.join(CLAUDE_DIR, 'sessions');
-  const claudePidMap = {}; // pid → {sessionId, cwd, startedAt}
+  const claudePidMap = {};
   if (fs.existsSync(sessionsDir)) {
     for (const file of fs.readdirSync(sessionsDir)) {
       if (!file.endsWith('.json')) continue;
@@ -2721,104 +3832,129 @@ function getActiveSessions() {
     }
   }
 
-  // 2. Scan ALL agent processes via ps
-  const agentPatterns = [
-    { pattern: 'claude', tool: 'claude', match: /\bclaude\b/ },
-    { pattern: 'codex', tool: 'codex', match: /\bcodex\b/ },
-    { pattern: 'opencode', tool: 'opencode', match: /\bopencode\b/ },
-    { pattern: 'kiro', tool: 'kiro', match: /kiro-cli/ },
-    { pattern: 'cursor-agent', tool: 'cursor', match: /cursor-agent/ },
-  ];
-
-  // Skip process scanning on Windows (no ps/grep)
-  if (process.platform === 'win32') return active;
-
+  // 2. Single `ps` call
+  let psOut = '';
   try {
-    const psOut = execSync(
-      'ps aux 2>/dev/null | grep -E "claude|codex|opencode|kiro-cli|cursor-agent" | grep -v grep || true',
-      { encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] }
+    psOut = execSync(
+      'ps -eo pid=,pcpu=,rss=,stat=,command= 2>/dev/null',
+      { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: 4 * 1024 * 1024 }
     );
+  } catch {
+    _activeCache = active;
+    _activeCacheTs = now;
+    return active;
+  }
 
-    for (const line of psOut.split('\n').filter(Boolean)) {
-      const parts = line.trim().split(/\s+/);
-      if (parts.length < 11) continue;
+  // 3. Parse + filter with strict agent CLI matching
+  const matches = [];
+  const livePids = new Set();
+  for (const line of psOut.split('\n')) {
+    if (!line) continue;
+    const m = line.match(/^\s*(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)$/);
+    if (!m) continue;
+    const pid = parseInt(m[1]);
+    if (!pid) continue;
+    livePids.add(pid);
+    const cpu = parseFloat(m[2]) || 0;
+    const rss = parseInt(m[3]) || 0;
+    const stat = m[4] || '';
+    const cmd = m[5] || '';
 
-      const pid = parseInt(parts[1]);
-      if (seenPids.has(pid)) continue;
+    // Skip wrappers
+    if (cmd.includes('node bin/cli') || cmd.includes('/codedash') || cmd.includes('npm ')) continue;
+    if (cmd.startsWith('grep ') || cmd.includes(' grep ')) continue;
 
-      const cpu = parseFloat(parts[2]) || 0;
-      const rss = parseInt(parts[5]) || 0;
-      const stat = parts[7] || '';
-      const cmd = parts.slice(10).join(' ');
+    const tool = _matchAgentCli(cmd);
+    if (!tool) continue;
 
-      // Determine tool
-      let tool = '';
-      for (const ap of agentPatterns) {
-        if (ap.match.test(cmd)) { tool = ap.tool; break; }
-      }
-      if (!tool) continue;
+    matches.push({ pid, cpu, rss, stat, cmd, tool });
+  }
 
-      // Skip node/npm/shell wrappers — only main processes
-      if (cmd.includes('node bin/cli') || cmd.includes('npm') || cmd.includes('grep')) continue;
+  // Drop stale pids from cwd cache
+  for (const pid of Array.from(_pidCwdCache.keys())) {
+    if (!livePids.has(pid)) _pidCwdCache.delete(pid);
+  }
 
-      seenPids.add(pid);
-
-      // Get session ID from Claude PID files
-      let sessionId = '';
-      let cwd = '';
-      let startedAt = 0;
-      let sessionSource = '';
-      if (claudePidMap[pid]) {
-        sessionId = claudePidMap[pid].sessionId || '';
-        cwd = claudePidMap[pid].cwd || '';
-        startedAt = claudePidMap[pid].startedAt || 0;
-        if (sessionId) sessionSource = 'pid-file';
-      }
-
-      // Try to get cwd from lsof if not from PID file
-      if (!cwd) {
-        try {
-          const lsofOut = execSync(`lsof -d cwd -p ${pid} -Fn 2>/dev/null`, { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'] });
-          const match = lsofOut.match(/\nn(\/[^\n]+)/);
-          if (match) cwd = match[1];
-        } catch {}
-      }
-
-      // Try to find session ID by matching cwd + tool to loaded sessions
-      if (!sessionId) {
-        const allS = loadSessions();
-        const match = allS.find(s => s.tool === tool && s.project === cwd);
-        if (match) {
-          sessionId = match.id;
-          sessionSource = 'cwd-match';
-        }
-        // If still no match, find latest session of this tool
-        if (!sessionId) {
-          const latest = allS.filter(s => s.tool === tool).sort((a,b) => b.last_ts - a.last_ts)[0];
-          if (latest) {
-            sessionId = latest.id;
-            sessionSource = 'fallback-latest';
-          }
+  // 4. Collect unknown pids (not in PID files, not in cache). Look up cwd
+  //    via a SINGLE batch lsof call with a hard 1-second timeout.
+  const unknownPids = [];
+  for (const m of matches) {
+    if (claudePidMap[m.pid] && claudePidMap[m.pid].cwd) continue;
+    if (_pidCwdCache.has(m.pid)) continue;
+    unknownPids.push(m.pid);
+  }
+  if (unknownPids.length > 0) {
+    try {
+      // -a ANDs the -d/-p conditions (without it, lsof ORs and returns cwd for
+      // all processes, not just the requested pids).
+      const out = execSync(
+        `lsof -a -d cwd -Fpn -p ${unknownPids.join(',')} 2>/dev/null`,
+        { encoding: 'utf8', timeout: 1500, stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: 1 * 1024 * 1024 }
+      );
+      // lsof -Fpn output: p<PID>\nn<CWD>\np<PID>\nn<CWD>...
+      let curPid = 0;
+      for (const line of out.split('\n')) {
+        if (line.startsWith('p')) {
+          curPid = parseInt(line.slice(1)) || 0;
+        } else if (line.startsWith('n') && curPid) {
+          _pidCwdCache.set(curPid, line.slice(1));
         }
       }
-
-      const status = cpu < 1 && (stat.includes('S') || stat.includes('T')) ? 'waiting' : 'active';
-
-      active.push({
-        pid: pid,
-        sessionId: sessionId,
-        cwd: cwd,
-        startedAt: startedAt,
-        kind: tool,
-        entrypoint: tool,
-        status: status,
-        cpu: cpu,
-        memoryMB: Math.round(rss / 1024),
-        _sessionSource: sessionSource,
-      });
+      // Mark pids we asked about but didn't get cwd for — empty string so we
+      // don't keep asking on every poll.
+      for (const pid of unknownPids) {
+        if (!_pidCwdCache.has(pid)) _pidCwdCache.set(pid, '');
+      }
+    } catch {
+      // Timeout / error: mark all as unknown so we don't retry each poll
+      for (const pid of unknownPids) _pidCwdCache.set(pid, '');
     }
-  } catch {}
+  }
 
+  // 5. Assemble results using only already-loaded sessions cache for cwd-match.
+  //    Never call loadSessions() here — it may invalidate and re-parse.
+  const cachedSessions = _sessionsCache || [];
+
+  for (const m of matches) {
+    let sessionId = '';
+    let cwd = '';
+    let startedAt = 0;
+    let sessionSource = '';
+
+    if (claudePidMap[m.pid]) {
+      sessionId = claudePidMap[m.pid].sessionId || '';
+      cwd = claudePidMap[m.pid].cwd || '';
+      startedAt = claudePidMap[m.pid].startedAt || 0;
+      if (sessionId) sessionSource = 'pid-file';
+    }
+    if (!cwd) cwd = _pidCwdCache.get(m.pid) || '';
+
+    if (!sessionId && cachedSessions.length > 0) {
+      const match = cachedSessions.find(s => s.tool === m.tool && s.project === cwd);
+      if (match) {
+        sessionId = match.id;
+        sessionSource = 'cwd-match';
+      }
+    }
+
+    const status = m.cpu < 1 && (m.stat.includes('S') || m.stat.includes('T')) ? 'waiting' : 'active';
+
+    active.push({
+      pid: m.pid,
+      sessionId,
+      cwd,
+      startedAt,
+      kind: m.tool,
+      entrypoint: m.tool,
+      status,
+      cpu: m.cpu,
+      memoryMB: Math.round(m.rss / 1024),
+      _sessionSource: sessionSource,
+    });
+  }
+
+  _activeCache = active;
+  _activeCacheTs = Date.now();
   return active;
 }
 
@@ -2852,7 +3988,8 @@ const fmtLocalDay = (ts) => {
 };
 
 // Disk cache for per-session daily message breakdown
-const DAILY_STATS_CACHE_FILE = path.join(os.tmpdir(), 'codedash-daily-stats-cache.json');
+const DAILY_STATS_CACHE_FILE = path.join(CODEDASH_CACHE_DIR, 'daily-stats-cache.json');
+const LEGACY_DAILY_STATS_CACHE_FILE = path.join(os.tmpdir(), 'codedash-daily-stats-cache.json');
 let _dailyStatsDiskCache = null;
 
 function _loadDailyStatsDiskCache() {
@@ -2860,6 +3997,8 @@ function _loadDailyStatsDiskCache() {
   try {
     if (fs.existsSync(DAILY_STATS_CACHE_FILE)) {
       _dailyStatsDiskCache = JSON.parse(fs.readFileSync(DAILY_STATS_CACHE_FILE, 'utf8'));
+    } else if (fs.existsSync(LEGACY_DAILY_STATS_CACHE_FILE)) {
+      _dailyStatsDiskCache = JSON.parse(fs.readFileSync(LEGACY_DAILY_STATS_CACHE_FILE, 'utf8'));
     }
   } catch {}
   if (!_dailyStatsDiskCache) _dailyStatsDiskCache = {};
@@ -2868,7 +4007,9 @@ function _loadDailyStatsDiskCache() {
 function _saveDailyStatsDiskCache() {
   if (!_dailyStatsDiskCache) return;
   try {
-    fs.writeFileSync(DAILY_STATS_CACHE_FILE, JSON.stringify(_dailyStatsDiskCache));
+    const tmp = DAILY_STATS_CACHE_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(_dailyStatsDiskCache));
+    fs.renameSync(tmp, DAILY_STATS_CACHE_FILE);
   } catch {}
 }
 
@@ -2920,37 +4061,7 @@ function _computeSessionDailyBreakdown(s, found) {
   return { msgsByDay, tsByDay };
 }
 
-// Daily stats result cache
-const DAILY_RESULT_CACHE_FILE = path.join(os.tmpdir(), 'codedash-daily-result-cache.json');
-let _dailyResultCache = null;
-let _dailyResultCacheKey = null;
-
 function getDailyStats(sessions) {
-  const key = _analyticsKey(sessions);
-  if (_dailyResultCache && _dailyResultCacheKey === key) return _dailyResultCache;
-
-  // Try disk cache
-  if (!_dailyResultCache) {
-    try {
-      if (fs.existsSync(DAILY_RESULT_CACHE_FILE)) {
-        const cached = JSON.parse(fs.readFileSync(DAILY_RESULT_CACHE_FILE, 'utf8'));
-        if (cached._key === key) {
-          _dailyResultCache = cached.data;
-          _dailyResultCacheKey = key;
-          return cached.data;
-        }
-      }
-    } catch {}
-  }
-
-  const result = _computeDailyStats(sessions);
-  _dailyResultCache = result;
-  _dailyResultCacheKey = key;
-  try { fs.writeFileSync(DAILY_RESULT_CACHE_FILE, JSON.stringify({ _key: key, data: result })); } catch {}
-  return result;
-}
-
-function _computeDailyStats(sessions) {
   const byDay = {};
   const ensureDay = (date) => {
     if (!byDay[date]) byDay[date] = { date, sessions: 0, messages: 0, hours: 0, cost: 0, agents: {} };
@@ -3005,12 +4116,10 @@ function _computeDailyStats(sessions) {
     const day = s.date || fmtLocalDay(s.last_ts);
     const d = ensureDay(day);
     d.sessions++;
-    // Use exact user_messages count if available, otherwise estimate
+    // Only count EXACT user_messages. The 0.5 estimate was wildly wrong
+    // because Claude type=user entries include tool_results (up to 28x inflation).
     if (s.user_messages > 0) {
       d.messages += s.user_messages;
-    } else {
-      const totalMsgEst = s.detail_messages || s.messages || 0;
-      d.messages += Math.ceil(totalMsgEst * 0.5);
     }
     d.hours += Math.min((s.last_ts - s.first_ts) / 3600000, 16);
     d.cost += sessionCost;
@@ -3023,6 +4132,8 @@ function _computeDailyStats(sessions) {
     d.cost = Math.round(d.cost * 100) / 100;
   }
   _saveDailyStatsDiskCache();
+  _saveCostDiskCache(true);
+  _saveParsedDiskCache(true);
   return Object.values(byDay).sort((a, b) => b.date.localeCompare(a.date));
 }
 
@@ -3083,6 +4194,12 @@ function getLeaderboardStats() {
 
 module.exports = {
   loadSessions,
+  loadSessionsAsync,
+  getWarmingStatus,
+  getSqliteBackfillStatus,
+  createCostAggregator,
+  computeSessionCostForAnalytics,
+  buildOpencodeCostCache,
   loadSessionDetail,
   getProjectGitInfo,
   getLeaderboardStats,

--- a/src/data.js
+++ b/src/data.js
@@ -585,19 +585,37 @@ function getWarmingStatus() {
 
 // Flush all caches on process exit / signals so partial progress isn't lost
 let _flushHandlersInstalled = false;
+let _flushInProgress = null;
 function _installFlushHandlers() {
   if (_flushHandlersInstalled) return;
   _flushHandlersInstalled = true;
-  const flushAll = () => {
+  const flushAllSync = () => {
     try { _saveParsedDiskCache(true); } catch {}
     try { _saveCostDiskCache(true); } catch {}
     try { if (typeof _saveDailyStatsDiskCache === 'function') _saveDailyStatsDiskCache(); } catch {}
     try { if (typeof _saveGitRootDiskCache === 'function') _saveGitRootDiskCache(); } catch {}
-    try { if (typeof _flushSqliteIngestBatch === 'function') _flushSqliteIngestBatch(); } catch {}
   };
-  process.on('exit', flushAll);
-  process.on('SIGINT', () => { flushAll(); process.exit(0); });
-  process.on('SIGTERM', () => { flushAll(); process.exit(0); });
+  const flushAll = async () => {
+    flushAllSync();
+    try {
+      if (typeof _flushSqliteIngestBatch === 'function') {
+        await _flushSqliteIngestBatch();
+      }
+    } catch {}
+  };
+  const handleSignal = async () => {
+    if (!_flushInProgress) {
+      _flushInProgress = flushAll();
+    }
+    try {
+      await _flushInProgress;
+    } finally {
+      process.exit(0);
+    }
+  };
+  process.on('exit', flushAllSync);
+  process.on('SIGINT', handleSignal);
+  process.on('SIGTERM', handleSignal);
 }
 _installFlushHandlers();
 

--- a/src/data.js
+++ b/src/data.js
@@ -2343,14 +2343,23 @@ function loadSessions() {
           if (!summary) {
             // Create a placeholder from stat + history of same sid (none here)
             let size = 0;
-            try { size = fs.statSync(filePath).size; } catch {}
+            let placeholderTs = 0;
+            try {
+              const stat = fs.statSync(filePath);
+              size = stat.size;
+              if (Number.isFinite(stat.mtimeMs) && stat.mtimeMs > 0) {
+                placeholderTs = Math.floor(stat.mtimeMs);
+              } else if (Number.isFinite(stat.ctimeMs) && stat.ctimeMs > 0) {
+                placeholderTs = Math.floor(stat.ctimeMs);
+              }
+            } catch {}
             sessions[sid] = {
               id: sid,
               tool: 'claude',
               project: '',
               project_short: '',
-              first_ts: 0,
-              last_ts: 0,
+              first_ts: placeholderTs,
+              last_ts: placeholderTs,
               messages: 0,
               first_message: '',
               has_detail: true,

--- a/src/data.js
+++ b/src/data.js
@@ -1867,7 +1867,7 @@ function _saveGitRootDiskCache() {
 // (is_helper=true) all collapse into their own single bucket per project.
 function computeSessionGroupKey(s) {
   const proj = (s.project || 'unknown').trim();
-  // Normalize first message: lowercase, collapse whitespace, truncate
+  // Normalize first message: collapse whitespace, trim, truncate
   let msg = (s.first_message || '').replace(/\s+/g, ' ').trim().slice(0, 200);
   if (s.is_helper) {
     // All helpers in the same project collapse into one group.

--- a/src/embeddings.js
+++ b/src/embeddings.js
@@ -105,15 +105,160 @@ async function embedLocal(texts) {
   return results;
 }
 
+// ── Copilot token exchange (for automatic API embeddings) ────
+// Reads GitHub Copilot OAuth credentials and exchanges for a
+// short-lived session token, exactly like copilot-client.js does
+// for chat completions.
+
+const COPILOT_TOKEN_ENDPOINT = 'https://api.github.com/copilot_internal/v2/token';
+const COPILOT_DEFAULT_API_BASE = 'https://api.individual.githubcopilot.com';
+const COPILOT_USER_AGENT = `copilot/1.0.14 (client/github/cli ${process.platform} v24.11.1) term/${process.env.TERM_PROGRAM || 'xterm'}`;
+const COPILOT_TOKEN_REFRESH_MARGIN_SEC = 60;
+
+let _copilotSessionToken = null;
+let _copilotSessionExpiresAt = 0;
+let _copilotApiBase = COPILOT_DEFAULT_API_BASE;
+
+/**
+ * Load the Copilot OAuth token from known credential locations.
+ * @returns {string|null} The gho_... token, or null
+ */
+function _loadCopilotOAuthToken() {
+  // 1. ~/.copilot/auth/credential.json
+  try {
+    const credPath = path.join(os.homedir(), '.copilot', 'auth', 'credential.json');
+    if (fs.existsSync(credPath)) {
+      const data = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+      if (data.token && typeof data.token === 'string' && data.token.length > 0) {
+        return data.token;
+      }
+    }
+  } catch (_) {}
+  // 2. ~/.config/github-copilot/apps.json (legacy VS Code extension)
+  try {
+    const appsPath = path.join(os.homedir(), '.config', 'github-copilot', 'apps.json');
+    if (fs.existsSync(appsPath)) {
+      const data = JSON.parse(fs.readFileSync(appsPath, 'utf8'));
+      for (const key of Object.keys(data)) {
+        if (key.startsWith('github.com') && data[key] && data[key].oauth_token) {
+          return data[key].oauth_token;
+        }
+      }
+    }
+  } catch (_) {}
+  return null;
+}
+
+/**
+ * Exchange OAuth token for a short-lived Copilot session token.
+ * Caches result and refreshes 60s before expiry.
+ * @returns {Promise<{token: string, api_base: string}>}
+ */
+async function _ensureCopilotSession() {
+  const now = Math.floor(Date.now() / 1000);
+  if (_copilotSessionToken && _copilotSessionExpiresAt > now + COPILOT_TOKEN_REFRESH_MARGIN_SEC) {
+    return { token: _copilotSessionToken, api_base: _copilotApiBase };
+  }
+
+  const oauthToken = _loadCopilotOAuthToken();
+  if (!oauthToken) throw new Error('No Copilot OAuth token found');
+
+  const result = await new Promise((resolve, reject) => {
+    const parsed = new URL(COPILOT_TOKEN_ENDPOINT);
+    const req = https.request({
+      hostname: parsed.hostname,
+      port: 443,
+      path: parsed.pathname + parsed.search,
+      method: 'GET',
+      headers: {
+        'User-Agent': COPILOT_USER_AGENT,
+        'Accept': 'application/json',
+        'Authorization': 'token ' + oauthToken,
+      },
+    }, (res) => {
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        if (res.statusCode !== 200) {
+          return reject(new Error('Copilot token exchange failed (HTTP ' + res.statusCode + '): ' + body));
+        }
+        try { resolve(JSON.parse(body)); } catch (e) { reject(e); }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('Copilot token exchange timeout')); });
+    req.end();
+  });
+
+  if (!result.token) throw new Error('Copilot token exchange returned empty token');
+
+  _copilotSessionToken = result.token;
+  _copilotSessionExpiresAt = result.expires_at || 0;
+  _copilotApiBase = (result.endpoints && result.endpoints.api) || COPILOT_DEFAULT_API_BASE;
+
+  return { token: _copilotSessionToken, api_base: _copilotApiBase };
+}
+
+/**
+ * Check if Copilot credentials exist on disk (sync, no network).
+ * @returns {boolean}
+ */
+function _isCopilotAvailable() {
+  return _loadCopilotOAuthToken() !== null;
+}
+
 // ── Provider 2: API (OpenAI-compatible) ──────────────────────
+// Priority: 1) Copilot auto-discovery  2) Manual config fallback
 async function embedAPI(texts) {
-  const cfg = loadConfig();
-  if (!cfg.api_base_url || !cfg.api_key) throw new Error('API embedding not configured');
   if (!Array.isArray(texts)) texts = [texts];
 
-  const url = new URL(cfg.api_base_url);
+  // ── Try Copilot first ──
+  if (_isCopilotAvailable()) {
+    try {
+      const session = await _ensureCopilotSession();
+      return await _callEmbeddingsEndpoint(
+        session.api_base + '/embeddings',
+        session.token,
+        'text-embedding-3-small',
+        texts,
+        { 'Copilot-Integration-Id': 'codedash', 'Editor-Version': 'codedash/1.0' }
+      );
+    } catch (copilotErr) {
+      // Copilot failed — fall through to manual config
+      const cfg = loadConfig();
+      if (!cfg.api_base_url || !cfg.api_key) {
+        throw new Error('Copilot embeddings failed: ' + copilotErr.message);
+      }
+    }
+  }
+
+  // ── Fallback: manual config (api_base_url + api_key) ──
+  const cfg = loadConfig();
+  if (!cfg.api_base_url || !cfg.api_key) throw new Error('API embedding not configured (no Copilot credentials and no manual config)');
+
+  return await _callEmbeddingsEndpoint(
+    cfg.api_base_url,
+    cfg.api_key,
+    cfg.api_model || 'text-embedding-3-small',
+    texts,
+    {}
+  );
+}
+
+/**
+ * Call an OpenAI-compatible /embeddings endpoint.
+ * @param {string} endpointUrl - Full URL (e.g. "https://api.../embeddings")
+ * @param {string} token - Bearer token
+ * @param {string} model - Model name
+ * @param {string[]} texts - Input texts
+ * @param {Object} extraHeaders - Additional headers
+ * @returns {Promise<number[][]>}
+ */
+function _callEmbeddingsEndpoint(endpointUrl, token, model, texts, extraHeaders) {
+  const url = new URL(endpointUrl);
   const body = JSON.stringify({
-    model: cfg.api_model || 'text-embedding-3-small',
+    model,
     input: texts,
     encoding_format: 'float',
   });
@@ -124,8 +269,9 @@ async function embedAPI(texts) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + cfg.api_key,
+        'Authorization': 'Bearer ' + token,
         'Accept': 'application/json',
+        ...extraHeaders,
       },
       timeout: 30000,
     }, (res) => {
@@ -137,7 +283,7 @@ async function embedAPI(texts) {
           if (parsed.data && Array.isArray(parsed.data)) {
             resolve(parsed.data.map(d => d.embedding));
           } else {
-            reject(new Error('Unexpected API response'));
+            reject(new Error('Unexpected API response: ' + (data.slice(0, 200))));
           }
         } catch (e) { reject(e); }
       });
@@ -193,10 +339,10 @@ async function embed(texts) {
       return await embedLocal(texts);
     }
   } catch {}
-  // Try API
+  // Try API (Copilot auto-discovery or manual config)
   try {
     const cfg = loadConfig();
-    if (cfg.api_base_url && cfg.api_key) {
+    if (_isCopilotAvailable() || (cfg.api_base_url && cfg.api_key)) {
       return await embedAPI(texts);
     }
   } catch {}
@@ -209,6 +355,7 @@ function isAvailable() {
     require.resolve('@huggingface/transformers');
     return true;
   } catch {
+    if (_isCopilotAvailable()) return true;
     const cfg = loadConfig();
     return !!(cfg.api_base_url && cfg.api_key);
   }

--- a/src/embeddings.js
+++ b/src/embeddings.js
@@ -1,130 +1,311 @@
-// Vector search via sentence embeddings (optional — requires @huggingface/transformers).
+// Memento-style 6-stage hybrid RAG search pipeline.
 //
-// Uses all-MiniLM-L6-v2 (384-dim, ~23 MB ONNX) for semantic similarity search
-// across session first_messages and message content. Falls back gracefully if
-// the npm package isn't installed.
+// Based on the Memento paper (arXiv 2603.18743) retrieval pipeline (Figure 8):
+//   Stage 1: FTS5 sparse recall (top-20)
+//   Stage 2: Dense embedding recall (top-20)
+//   Stage 3: Reciprocal Rank Fusion (k=60)
+//   Stage 4: Utility reranking (per-entry success/failure rate)
+//   Stage 5: Threshold filter
+//   Stage 6: Top-k
 //
-// Architecture:
-//   1. Pre-compute embeddings for each session's first_message during SQLite
-//      backfill and store them as JSON arrays in the `session_embeddings` table.
-//   2. On search: embed the query, load candidate embeddings from SQLite,
-//      compute cosine similarity, return top-K.
-//   3. Hybrid mode: FTS5 for recall (top 200) → vector re-rank for precision.
+// Provider chain (matches codex-git kb_embedding_store.rs):
+//   1. Local: MiniLM-L6-v2 (default, 384d, 23MB) or Qwen3-Embedding-0.6B (1024d)
+//   2. API: OpenAI-compatible /embeddings endpoint (GitHub Models, Copilot proxy, etc)
+//   3. TF-IDF fallback: bag-of-words 256-dim hashed vectors (always available)
+//
+// Weights from Memento paper results:
+//   BM25 Recall@1 = 0.32 → weight 0.3
+//   Embedding Recall@1 = 0.54 → weight 0.7
+//   Utility reranking: final = rrf * (0.7 + 0.3 * utility_rate)
 
-const { spawnSync } = require('child_process');
+const https = require('https');
+const http = require('http');
 const path = require('path');
 const os = require('os');
+const fs = require('fs');
 
-// ── Lazy-load transformers.js ──────────────────────────────
-let _pipeline = null;
+// ── Constants (Memento paper) ─────────────────────────────────
+const RRF_K = 60;                // Standard RRF smoothing (Cormack et al. 2009)
+const STAGE_CANDIDATE_K = 20;    // Candidates per retrieval stage
+const BM25_WEIGHT = 0.3;         // Weaker lexical signal
+const EMBEDDING_WEIGHT = 0.7;    // Stronger dense signal
+const UTILITY_BASE = 0.7;        // Minimum influence even for zero-utility
+const UTILITY_SCALE = 0.3;       // Scale factor for utility rate
+const TFIDF_DIM = 256;           // TF-IDF fallback bucket count
+
+// ── Model configuration ──────────────────────────────────────
+const MODELS = {
+  'minilm': {
+    id: 'Xenova/all-MiniLM-L6-v2',
+    dim: 384,
+    description: 'Fast, English-optimized (23MB)',
+  },
+  'qwen3': {
+    id: 'onnx-community/Qwen3-Embedding-0.6B-ONNX',
+    dim: 1024,
+    description: 'Best quality, multilingual (600MB)',
+  },
+};
+
+// Config file at ~/.codedash/embedding-config.json
+const CONFIG_FILE = path.join(os.homedir(), '.codedash', 'embedding-config.json');
+
+function loadConfig() {
+  try {
+    if (fs.existsSync(CONFIG_FILE)) return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+  } catch {}
+  return {};
+}
+
+function getModelId() {
+  const cfg = loadConfig();
+  const key = cfg.model || 'minilm';
+  return (MODELS[key] || MODELS.minilm).id;
+}
+
+function getModelDim() {
+  const cfg = loadConfig();
+  const key = cfg.model || 'minilm';
+  return (MODELS[key] || MODELS.minilm).dim;
+}
+
+// ── Provider 1: Local (transformers.js ONNX) ─────────────────
 let _extractor = null;
-let _loading = false;
 let _loadPromise = null;
-let _available = null; // null = unknown, true/false after first check
+let _localAvailable = null;
 
-const MODEL_ID = 'Xenova/all-MiniLM-L6-v2';
-const EMBEDDING_DIM = 384;
-
-async function _ensureModel() {
+async function _ensureLocalModel() {
   if (_extractor) return _extractor;
   if (_loadPromise) return _loadPromise;
-
   _loadPromise = (async () => {
-    try {
-      const { pipeline } = await import('@huggingface/transformers');
-      _extractor = await pipeline('feature-extraction', MODEL_ID, {
-        device: 'cpu',
-        dtype: 'fp32',
-      });
-      _available = true;
-      return _extractor;
-    } catch (e) {
-      _available = false;
-      _loadPromise = null;
-      throw new Error('Vector search unavailable: ' + e.message);
-    }
+    const { pipeline } = await import('@huggingface/transformers');
+    _extractor = await pipeline('feature-extraction', getModelId(), {
+      device: 'cpu', dtype: 'fp32',
+    });
+    _localAvailable = true;
+    return _extractor;
   })();
-
   return _loadPromise;
 }
 
-function isAvailable() {
-  if (_available !== null) return _available;
-  try {
-    require.resolve('@huggingface/transformers');
-    _available = true; // module exists, model may still need download
-    return true;
-  } catch {
-    _available = false;
-    return false;
-  }
-}
-
-// ── Embedding computation ───────────────────────────────────
-
-async function embed(text) {
-  const extractor = await _ensureModel();
-  const result = await extractor(text, { pooling: 'mean', normalize: true });
-  return Array.from(result.data);
-}
-
-async function embedBatch(texts, batchSize) {
-  batchSize = batchSize || 32;
-  const extractor = await _ensureModel();
-  const all = [];
-  for (let i = 0; i < texts.length; i += batchSize) {
-    const batch = texts.slice(i, i + batchSize);
-    const results = await extractor(batch, { pooling: 'mean', normalize: true });
-    // results.data is a flat Float32Array of shape [batch, dim]
+async function embedLocal(texts) {
+  const extractor = await _ensureLocalModel();
+  const dim = getModelDim();
+  if (!Array.isArray(texts)) texts = [texts];
+  const results = [];
+  // Process in batches of 32
+  for (let i = 0; i < texts.length; i += 32) {
+    const batch = texts.slice(i, i + 32);
+    const out = await extractor(batch, { pooling: 'mean', normalize: true });
     for (let j = 0; j < batch.length; j++) {
-      const start = j * EMBEDDING_DIM;
-      all.push(Array.from(results.data.slice(start, start + EMBEDDING_DIM)));
+      const start = j * dim;
+      results.push(Array.from(out.data.slice(start, start + dim)));
     }
   }
-  return all;
+  return results;
 }
 
-// ── Cosine similarity ───────────────────────────────────────
+// ── Provider 2: API (OpenAI-compatible) ──────────────────────
+async function embedAPI(texts) {
+  const cfg = loadConfig();
+  if (!cfg.api_base_url || !cfg.api_key) throw new Error('API embedding not configured');
+  if (!Array.isArray(texts)) texts = [texts];
 
+  const url = new URL(cfg.api_base_url);
+  const body = JSON.stringify({
+    model: cfg.api_model || 'text-embedding-3-small',
+    input: texts,
+    encoding_format: 'float',
+  });
+
+  return new Promise((resolve, reject) => {
+    const mod = url.protocol === 'https:' ? https : http;
+    const req = mod.request(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + cfg.api_key,
+        'Accept': 'application/json',
+      },
+      timeout: 30000,
+    }, (res) => {
+      let data = '';
+      res.on('data', d => data += d);
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed.data && Array.isArray(parsed.data)) {
+            resolve(parsed.data.map(d => d.embedding));
+          } else {
+            reject(new Error('Unexpected API response'));
+          }
+        } catch (e) { reject(e); }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('API timeout')); });
+    req.write(body);
+    req.end();
+  });
+}
+
+// ── Provider 3: TF-IDF fallback (always available) ───────────
+function tokenize(text) {
+  return (text || '').toLowerCase()
+    .replace(/[^a-zа-яёüöäß0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(t => t.length > 1);
+}
+
+function embedTFIDF(texts) {
+  if (!Array.isArray(texts)) texts = [texts];
+  return texts.map(text => {
+    const tokens = tokenize(text);
+    const freq = {};
+    for (const t of tokens) {
+      const bucket = hashStr(t) % TFIDF_DIM;
+      freq[bucket] = (freq[bucket] || 0) + 1;
+    }
+    // TF vector + L2 normalize
+    const vec = new Float64Array(TFIDF_DIM);
+    for (const [b, f] of Object.entries(freq)) {
+      vec[parseInt(b)] = f; // simple TF, no IDF (single-doc context)
+    }
+    let norm = 0;
+    for (let i = 0; i < TFIDF_DIM; i++) norm += vec[i] * vec[i];
+    norm = Math.sqrt(norm) || 1;
+    return Array.from(vec.map(v => v / norm));
+  });
+}
+
+function hashStr(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+// ── Provider chain ───────────────────────────────────────────
+async function embed(texts) {
+  if (!Array.isArray(texts)) texts = [texts];
+  // Try local first
+  try {
+    if (_localAvailable !== false) {
+      return await embedLocal(texts);
+    }
+  } catch {}
+  // Try API
+  try {
+    const cfg = loadConfig();
+    if (cfg.api_base_url && cfg.api_key) {
+      return await embedAPI(texts);
+    }
+  } catch {}
+  // TF-IDF fallback
+  return embedTFIDF(texts);
+}
+
+function isAvailable() {
+  try {
+    require.resolve('@huggingface/transformers');
+    return true;
+  } catch {
+    const cfg = loadConfig();
+    return !!(cfg.api_base_url && cfg.api_key);
+  }
+}
+
+// ── Cosine similarity ────────────────────────────────────────
 function cosineSimilarity(a, b) {
+  if (a.length !== b.length) return 0;
   let dot = 0;
   for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
-  // Vectors are already L2-normalized by the pipeline, so dot = cosine
-  return dot;
+  return dot; // Already L2-normalized
 }
 
-// ── SQLite storage ──────────────────────────────────────────
+// ── Reciprocal Rank Fusion (Cormack et al. 2009) ─────────────
+function reciprocalRankFusion(bm25Ranked, embeddingRanked, bm25Weight, embWeight) {
+  const scores = new Map();
+  // Graceful degradation
+  const hasBM25 = bm25Ranked.length > 0;
+  const hasEmb = embeddingRanked.length > 0;
+  if (!hasBM25 && !hasEmb) return [];
+  const effBM25 = hasBM25 && hasEmb ? bm25Weight : hasBM25 ? 1.0 : 0.0;
+  const effEmb = hasBM25 && hasEmb ? embWeight : hasEmb ? 1.0 : 0.0;
 
-function _sqliteIndex() {
-  return require('./sqlite-index');
+  for (let rank = 0; rank < bm25Ranked.length; rank++) {
+    const id = bm25Ranked[rank].id;
+    scores.set(id, (scores.get(id) || 0) + effBM25 / (RRF_K + rank + 1));
+  }
+  for (let rank = 0; rank < embeddingRanked.length; rank++) {
+    const id = embeddingRanked[rank].id;
+    scores.set(id, (scores.get(id) || 0) + effEmb / (RRF_K + rank + 1));
+  }
+  return [...scores.entries()]
+    .map(([id, score]) => ({ id, rrf_score: score }))
+    .sort((a, b) => b.rrf_score - a.rrf_score);
 }
 
-function ensureEmbeddingTable() {
+// ── Utility tracker (SQLite-backed) ──────────────────────────
+function _sqliteIndex() { return require('./sqlite-index'); }
+
+function ensureTables() {
   const sq = _sqliteIndex();
   sq._exec(`
     CREATE TABLE IF NOT EXISTS session_embeddings (
       session_id TEXT PRIMARY KEY,
-      embedding  TEXT NOT NULL,
-      model      TEXT NOT NULL,
+      embedding TEXT NOT NULL,
+      model TEXT NOT NULL,
+      provider TEXT DEFAULT 'local',
       computed_at INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_emb_model ON session_embeddings(model);
+
+    CREATE TABLE IF NOT EXISTS search_utility (
+      session_id TEXT NOT NULL,
+      query_hash TEXT NOT NULL,
+      outcome TEXT NOT NULL,
+      ts INTEGER NOT NULL,
+      PRIMARY KEY (session_id, query_hash)
+    );
   `);
 }
 
+function recordUtility(sessionId, queryHash, outcome) {
+  // outcome: 'click' | 'expand' | 'ignore'
+  try {
+    const sq = _sqliteIndex();
+    const esc = (s) => "'" + String(s).replace(/'/g, "''") + "'";
+    sq._exec(`INSERT OR REPLACE INTO search_utility (session_id, query_hash, outcome, ts) VALUES (${esc(sessionId)}, ${esc(queryHash)}, ${esc(outcome)}, ${Date.now()});`);
+  } catch {}
+}
+
+function getUtilityRate(sessionId) {
+  try {
+    const sq = _sqliteIndex();
+    const esc = (s) => "'" + String(s).replace(/'/g, "''") + "'";
+    const rows = sq._execJson(`SELECT outcome, COUNT(*) AS n FROM search_utility WHERE session_id = ${esc(sessionId)} GROUP BY outcome`);
+    let positive = 0, total = 0;
+    for (const r of rows) {
+      total += r.n;
+      if (r.outcome === 'click' || r.outcome === 'expand') positive += r.n;
+    }
+    return total > 0 ? positive / total : 0.5; // default 0.5 for unknown
+  } catch { return 0.5; }
+}
+
+// ── Embedding storage ────────────────────────────────────────
 function storeEmbeddings(rows) {
-  // rows: [{session_id, embedding (array), model}]
   if (!rows || rows.length === 0) return;
   const sq = _sqliteIndex();
-  ensureEmbeddingTable();
-
+  ensureTables();
   const now = Date.now();
   const parts = ['BEGIN;'];
   for (const r of rows) {
     const sid = r.session_id.replace(/'/g, "''");
     const emb = JSON.stringify(r.embedding);
-    const model = (r.model || MODEL_ID).replace(/'/g, "''");
-    parts.push(`INSERT OR REPLACE INTO session_embeddings (session_id, embedding, model, computed_at) VALUES ('${sid}', '${emb}', '${model}', ${now});`);
+    const model = (r.model || getModelId()).replace(/'/g, "''");
+    const provider = (r.provider || 'local').replace(/'/g, "''");
+    parts.push(`INSERT OR REPLACE INTO session_embeddings (session_id, embedding, model, provider, computed_at) VALUES ('${sid}', '${emb}', '${model}', '${provider}', ${now});`);
   }
   parts.push('COMMIT;');
   sq._exec(parts.join('\n'), { timeout: 60000 });
@@ -132,8 +313,8 @@ function storeEmbeddings(rows) {
 
 function loadAllEmbeddings() {
   const sq = _sqliteIndex();
-  ensureEmbeddingTable();
-  const rows = sq._execJson(`SELECT session_id, embedding FROM session_embeddings WHERE model = '${MODEL_ID.replace(/'/g, "''")}'`);
+  ensureTables();
+  const rows = sq._execJson(`SELECT session_id, embedding FROM session_embeddings`);
   return rows.map(r => ({
     session_id: r.session_id,
     embedding: JSON.parse(r.embedding),
@@ -142,92 +323,138 @@ function loadAllEmbeddings() {
 
 function getEmbeddingCount() {
   const sq = _sqliteIndex();
-  ensureEmbeddingTable();
+  ensureTables();
   const rows = sq._execJson(`SELECT COUNT(*) AS n FROM session_embeddings`);
   return (rows[0] || {}).n || 0;
 }
 
-// ── Semantic search ─────────────────────────────────────────
-
-async function semanticSearch(query, limit) {
-  limit = limit || 20;
-  const queryEmb = await embed(query);
-  const all = loadAllEmbeddings();
-
-  if (all.length === 0) return [];
-
-  // Compute similarities
-  const scored = all.map(r => ({
-    session_id: r.session_id,
-    score: cosineSimilarity(queryEmb, r.embedding),
-  }));
-
-  // Sort by descending similarity, return top-K
-  scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, limit);
-}
-
-// ── Hybrid search: FTS5 recall → vector re-rank ─────────────
+// ── 6-Stage Memento Search Pipeline ──────────────────────────
 
 async function hybridSearch(query, limit) {
   limit = limit || 20;
   const sq = _sqliteIndex();
 
-  // Phase 1: FTS5 text search for recall (broad set)
-  const ftsResults = sq.search(query, 200);
+  // ── Stage 1: FTS5 sparse recall (top-20) ──
+  const ftsResults = sq.search(query, STAGE_CANDIDATE_K);
+  const ftsRanked = ftsResults.map(r => ({
+    id: r.session_id,
+    bm25_score: 1.0, // FTS5 doesn't expose raw BM25, use rank position
+    ...r,
+  }));
 
-  if (!isAvailable() || ftsResults.length === 0) {
-    // No vector model — return FTS5 results as-is
-    return ftsResults.map(r => ({ ...r, search_type: 'text' }));
-  }
-
-  // Phase 2: embed query
-  let queryEmb;
+  // ── Stage 2: Dense embedding recall (top-20) ──
+  let embRanked = [];
   try {
-    queryEmb = await embed(query);
-  } catch {
-    return ftsResults.map(r => ({ ...r, search_type: 'text' }));
-  }
+    const queryEmb = (await embed(query))[0];
+    const all = loadAllEmbeddings();
+    if (all.length > 0) {
+      const scored = all.map(r => ({
+        id: r.session_id,
+        emb_score: cosineSimilarity(queryEmb, r.embedding),
+      }));
+      scored.sort((a, b) => b.emb_score - a.emb_score);
+      embRanked = scored.slice(0, STAGE_CANDIDATE_K);
+    }
+  } catch {}
 
-  // Phase 3: load embeddings for FTS5-matched sessions
-  const ftsSessionIds = [...new Set(ftsResults.map(r => r.session_id))];
-  const all = loadAllEmbeddings();
-  const embMap = new Map(all.map(r => [r.session_id, r.embedding]));
+  // ── Stage 3: Reciprocal Rank Fusion (k=60) ──
+  const fused = reciprocalRankFusion(ftsRanked, embRanked, BM25_WEIGHT, EMBEDDING_WEIGHT);
 
-  // Phase 4: score and re-rank
-  const scored = ftsSessionIds.map(sid => {
-    const emb = embMap.get(sid);
-    const similarity = emb ? cosineSimilarity(queryEmb, emb) : 0;
-    const ftsSnippets = ftsResults.filter(r => r.session_id === sid);
+  // Build lookup maps
+  const ftsMap = new Map(ftsResults.map(r => [r.session_id, r]));
+  const embMap = new Map(embRanked.map(r => [r.id, r.emb_score]));
+
+  // ── Stage 4: Utility reranking ──
+  const reranked = fused.map(item => {
+    const utilityRate = getUtilityRate(item.id);
+    const multiplier = UTILITY_BASE + UTILITY_SCALE * utilityRate;
     return {
-      session_id: sid,
-      similarity,
-      fts_matches: ftsSnippets.length,
-      // Combined score: FTS match count + semantic similarity
-      combined_score: (ftsSnippets.length * 0.3) + (similarity * 0.7),
-      matches: ftsSnippets.slice(0, 3).map(r => ({
-        role: r.role,
-        snippet: (r.snippet || '').replace(/<</g, '').replace(/>>/g, ''),
-      })),
-      search_type: emb ? 'hybrid' : 'text',
+      ...item,
+      utility_rate: utilityRate,
+      fused_score: item.rrf_score * multiplier,
     };
   });
+  reranked.sort((a, b) => b.fused_score - a.fused_score);
 
-  scored.sort((a, b) => b.combined_score - a.combined_score);
+  // ── Stage 5: Threshold filter ──
+  const MIN_SCORE = 0.0001;
+
+  // ── Stage 6: Top-k with enrichment ──
+  const results = [];
+  for (const item of reranked) {
+    if (item.fused_score < MIN_SCORE) continue;
+    if (results.length >= limit) break;
+
+    const fts = ftsMap.get(item.id);
+    const embScore = embMap.get(item.id) || 0;
+
+    results.push({
+      session_id: item.id,
+      fused_score: item.fused_score,
+      rrf_score: item.rrf_score,
+      bm25_rank: ftsRanked.findIndex(r => r.id === item.id),
+      embedding_score: embScore,
+      utility_rate: item.utility_rate,
+      search_type: fts && embScore > 0 ? 'hybrid' : fts ? 'text' : 'semantic',
+      matches: fts ? [{
+        role: fts.role || 'unknown',
+        snippet: (fts.snippet || '').replace(/<</g, '').replace(/>>/g, ''),
+      }] : [],
+    });
+  }
+
+  return results;
+}
+
+// Pure semantic search (no FTS5)
+async function semanticSearch(query, limit) {
+  limit = limit || 20;
+  const queryEmb = (await embed(query))[0];
+  const all = loadAllEmbeddings();
+  if (all.length === 0) return [];
+  const scored = all.map(r => ({
+    session_id: r.session_id,
+    score: cosineSimilarity(queryEmb, r.embedding),
+  }));
+  scored.sort((a, b) => b.score - a.score);
   return scored.slice(0, limit);
 }
 
+// Batch embed for backfill
+async function embedBatch(texts, batchSize) {
+  return embed(Array.isArray(texts) ? texts : [texts]);
+}
+
 module.exports = {
-  isAvailable,
+  // Config
+  MODELS,
+  loadConfig,
+  getModelId,
+  getModelDim,
+  // Provider chain
   embed,
-  embedBatch,
+  embedLocal,
+  embedAPI,
+  embedTFIDF,
+  isAvailable,
+  // Search pipeline
+  hybridSearch,
+  semanticSearch,
+  reciprocalRankFusion,
   cosineSimilarity,
-  ensureEmbeddingTable,
+  // Storage
+  ensureTables,
   storeEmbeddings,
   loadAllEmbeddings,
   getEmbeddingCount,
-  semanticSearch,
-  hybridSearch,
-  EMBEDDING_DIM,
-  MODEL_ID,
+  embedBatch,
+  // Utility tracker
+  recordUtility,
+  getUtilityRate,
+  // Constants
+  EMBEDDING_DIM: 384, // default, actual may vary by model
+  MODEL_ID: 'configurable', // use getModelId()
+  RRF_K,
+  BM25_WEIGHT,
+  EMBEDDING_WEIGHT,
 };

--- a/src/embeddings.js
+++ b/src/embeddings.js
@@ -1,0 +1,233 @@
+// Vector search via sentence embeddings (optional — requires @huggingface/transformers).
+//
+// Uses all-MiniLM-L6-v2 (384-dim, ~23 MB ONNX) for semantic similarity search
+// across session first_messages and message content. Falls back gracefully if
+// the npm package isn't installed.
+//
+// Architecture:
+//   1. Pre-compute embeddings for each session's first_message during SQLite
+//      backfill and store them as JSON arrays in the `session_embeddings` table.
+//   2. On search: embed the query, load candidate embeddings from SQLite,
+//      compute cosine similarity, return top-K.
+//   3. Hybrid mode: FTS5 for recall (top 200) → vector re-rank for precision.
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+
+// ── Lazy-load transformers.js ──────────────────────────────
+let _pipeline = null;
+let _extractor = null;
+let _loading = false;
+let _loadPromise = null;
+let _available = null; // null = unknown, true/false after first check
+
+const MODEL_ID = 'Xenova/all-MiniLM-L6-v2';
+const EMBEDDING_DIM = 384;
+
+async function _ensureModel() {
+  if (_extractor) return _extractor;
+  if (_loadPromise) return _loadPromise;
+
+  _loadPromise = (async () => {
+    try {
+      const { pipeline } = await import('@huggingface/transformers');
+      _extractor = await pipeline('feature-extraction', MODEL_ID, {
+        device: 'cpu',
+        dtype: 'fp32',
+      });
+      _available = true;
+      return _extractor;
+    } catch (e) {
+      _available = false;
+      _loadPromise = null;
+      throw new Error('Vector search unavailable: ' + e.message);
+    }
+  })();
+
+  return _loadPromise;
+}
+
+function isAvailable() {
+  if (_available !== null) return _available;
+  try {
+    require.resolve('@huggingface/transformers');
+    _available = true; // module exists, model may still need download
+    return true;
+  } catch {
+    _available = false;
+    return false;
+  }
+}
+
+// ── Embedding computation ───────────────────────────────────
+
+async function embed(text) {
+  const extractor = await _ensureModel();
+  const result = await extractor(text, { pooling: 'mean', normalize: true });
+  return Array.from(result.data);
+}
+
+async function embedBatch(texts, batchSize) {
+  batchSize = batchSize || 32;
+  const extractor = await _ensureModel();
+  const all = [];
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    const results = await extractor(batch, { pooling: 'mean', normalize: true });
+    // results.data is a flat Float32Array of shape [batch, dim]
+    for (let j = 0; j < batch.length; j++) {
+      const start = j * EMBEDDING_DIM;
+      all.push(Array.from(results.data.slice(start, start + EMBEDDING_DIM)));
+    }
+  }
+  return all;
+}
+
+// ── Cosine similarity ───────────────────────────────────────
+
+function cosineSimilarity(a, b) {
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  // Vectors are already L2-normalized by the pipeline, so dot = cosine
+  return dot;
+}
+
+// ── SQLite storage ──────────────────────────────────────────
+
+function _sqliteIndex() {
+  return require('./sqlite-index');
+}
+
+function ensureEmbeddingTable() {
+  const sq = _sqliteIndex();
+  sq._exec(`
+    CREATE TABLE IF NOT EXISTS session_embeddings (
+      session_id TEXT PRIMARY KEY,
+      embedding  TEXT NOT NULL,
+      model      TEXT NOT NULL,
+      computed_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_emb_model ON session_embeddings(model);
+  `);
+}
+
+function storeEmbeddings(rows) {
+  // rows: [{session_id, embedding (array), model}]
+  if (!rows || rows.length === 0) return;
+  const sq = _sqliteIndex();
+  ensureEmbeddingTable();
+
+  const now = Date.now();
+  const parts = ['BEGIN;'];
+  for (const r of rows) {
+    const sid = r.session_id.replace(/'/g, "''");
+    const emb = JSON.stringify(r.embedding);
+    const model = (r.model || MODEL_ID).replace(/'/g, "''");
+    parts.push(`INSERT OR REPLACE INTO session_embeddings (session_id, embedding, model, computed_at) VALUES ('${sid}', '${emb}', '${model}', ${now});`);
+  }
+  parts.push('COMMIT;');
+  sq._exec(parts.join('\n'), { timeout: 60000 });
+}
+
+function loadAllEmbeddings() {
+  const sq = _sqliteIndex();
+  ensureEmbeddingTable();
+  const rows = sq._execJson(`SELECT session_id, embedding FROM session_embeddings WHERE model = '${MODEL_ID.replace(/'/g, "''")}'`);
+  return rows.map(r => ({
+    session_id: r.session_id,
+    embedding: JSON.parse(r.embedding),
+  }));
+}
+
+function getEmbeddingCount() {
+  const sq = _sqliteIndex();
+  ensureEmbeddingTable();
+  const rows = sq._execJson(`SELECT COUNT(*) AS n FROM session_embeddings`);
+  return (rows[0] || {}).n || 0;
+}
+
+// ── Semantic search ─────────────────────────────────────────
+
+async function semanticSearch(query, limit) {
+  limit = limit || 20;
+  const queryEmb = await embed(query);
+  const all = loadAllEmbeddings();
+
+  if (all.length === 0) return [];
+
+  // Compute similarities
+  const scored = all.map(r => ({
+    session_id: r.session_id,
+    score: cosineSimilarity(queryEmb, r.embedding),
+  }));
+
+  // Sort by descending similarity, return top-K
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit);
+}
+
+// ── Hybrid search: FTS5 recall → vector re-rank ─────────────
+
+async function hybridSearch(query, limit) {
+  limit = limit || 20;
+  const sq = _sqliteIndex();
+
+  // Phase 1: FTS5 text search for recall (broad set)
+  const ftsResults = sq.search(query, 200);
+
+  if (!isAvailable() || ftsResults.length === 0) {
+    // No vector model — return FTS5 results as-is
+    return ftsResults.map(r => ({ ...r, search_type: 'text' }));
+  }
+
+  // Phase 2: embed query
+  let queryEmb;
+  try {
+    queryEmb = await embed(query);
+  } catch {
+    return ftsResults.map(r => ({ ...r, search_type: 'text' }));
+  }
+
+  // Phase 3: load embeddings for FTS5-matched sessions
+  const ftsSessionIds = [...new Set(ftsResults.map(r => r.session_id))];
+  const all = loadAllEmbeddings();
+  const embMap = new Map(all.map(r => [r.session_id, r.embedding]));
+
+  // Phase 4: score and re-rank
+  const scored = ftsSessionIds.map(sid => {
+    const emb = embMap.get(sid);
+    const similarity = emb ? cosineSimilarity(queryEmb, emb) : 0;
+    const ftsSnippets = ftsResults.filter(r => r.session_id === sid);
+    return {
+      session_id: sid,
+      similarity,
+      fts_matches: ftsSnippets.length,
+      // Combined score: FTS match count + semantic similarity
+      combined_score: (ftsSnippets.length * 0.3) + (similarity * 0.7),
+      matches: ftsSnippets.slice(0, 3).map(r => ({
+        role: r.role,
+        snippet: (r.snippet || '').replace(/<</g, '').replace(/>>/g, ''),
+      })),
+      search_type: emb ? 'hybrid' : 'text',
+    };
+  });
+
+  scored.sort((a, b) => b.combined_score - a.combined_score);
+  return scored.slice(0, limit);
+}
+
+module.exports = {
+  isAvailable,
+  embed,
+  embedBatch,
+  cosineSimilarity,
+  ensureEmbeddingTable,
+  storeEmbeddings,
+  loadAllEmbeddings,
+  getEmbeddingCount,
+  semanticSearch,
+  hybridSearch,
+  EMBEDDING_DIM,
+  MODEL_ID,
+};

--- a/src/frontend/analytics.js
+++ b/src/frontend/analytics.js
@@ -283,7 +283,7 @@ function renderAnalyticsUI(container, data, opts) {
   html += '<div class="analytics-card"><span class="analytics-val">$' + (data.totalCost || 0).toFixed(2) + '</span><span class="analytics-label">Total cost (API-equivalent)</span></div>';
   html += '<div class="analytics-card"><span class="analytics-val">' + formatTokens(data.totalTokens || 0) + '</span><span class="analytics-label">Total tokens</span></div>';
   html += '<div class="analytics-card"><span class="analytics-val">$' + (data.dailyRate || 0).toFixed(2) + '</span><span class="analytics-label">Avg per day (' + (data.days || 1) + ' days)</span></div>';
-  html += '<div class="analytics-card"><span class="analytics-val">' + (data.totalSessions || 0) + '</span><span class="analytics-label">Sessions</span></div>';
+  html += '<div class="analytics-card"><span class="analytics-val">' + (data.totalSessions || 0) + '</span><span class="analytics-label">Sessions with cost data' + (data.totalSessionsAll > data.totalSessions ? ' / ' + data.totalSessionsAll + ' total' : '') + '</span></div>';
   html += '</div>';
 
   // Burn rate

--- a/src/frontend/analytics.js
+++ b/src/frontend/analytics.js
@@ -9,9 +9,43 @@ async function renderAnalytics(container) {
     if (dateFrom) params.push('from=' + dateFrom);
     if (dateTo) params.push('to=' + dateTo);
     if (params.length) url += '?' + params.join('&');
-    var resp = await fetch(url);
-    var data = await resp.json();
 
+    // Poll loop — server runs a background job, we render live partial snapshots
+    var pollStart = Date.now();
+    var data = null;
+    while (true) {
+      var resp = await fetch(url);
+      var payload = await resp.json();
+      if (payload.status === 'done') { data = payload; break; }
+      if (payload.status === 'error') {
+        container.innerHTML = '<div class="empty-state">Analytics failed: ' + escHtml(payload.error || 'unknown') + '</div>';
+        return;
+      }
+      var p = (payload.progress || {});
+      var done = p.done || 0, total = p.total || 0;
+      var pct = total > 0 ? Math.round(done / total * 100) : 0;
+      var phase = p.phase || 'working';
+      var elapsed = Math.round((payload.elapsedMs || (Date.now() - pollStart)) / 1000);
+      if (payload.partialResult && payload.partialResult.totalSessions > 0) {
+        renderAnalyticsUI(container, payload.partialResult, {
+          live: true, done: done, total: total, pct: pct, phase: phase, elapsed: elapsed,
+        });
+      } else {
+        container.innerHTML =
+          '<div class="analytics-progress">' +
+          '<div class="progress-title">Computing cost analytics…</div>' +
+          '<div class="progress-phase">' + escHtml(phase) + ' — ' + done + ' / ' + total + ' sessions (' + pct + '%)</div>' +
+          '<div class="progress-bar-outer"><div class="progress-bar-inner" style="width:' + pct + '%"></div></div>' +
+          '<div class="progress-subtle">elapsed ' + elapsed + 's · cached for next time</div>' +
+          '</div>';
+      }
+      await new Promise(function(r){ setTimeout(r, 500); });
+    }
+
+    renderAnalyticsUI(container, data, { live: false });
+    return;
+    /* === below is the original inline render block; kept so the upstream
+       split structure is preserved and renderAnalyticsUI uses the same code path === */
     var html = '<div class="analytics-container">';
     html += '<h2 class="heatmap-title">Cost Analytics</h2>';
 
@@ -225,6 +259,145 @@ async function renderAnalytics(container) {
   } catch (e) {
     container.innerHTML = '<div class="empty-state">Failed to load analytics.</div>';
   }
+}
+
+// Renders the full Cost Analytics UI from either partial (live) or final data.
+// When opts.live is true, prepends a sticky progress banner.
+function renderAnalyticsUI(container, data, opts) {
+  opts = opts || {};
+  var html = '<div class="analytics-container">';
+
+  if (opts.live) {
+    var pct = opts.pct || 0;
+    html += '<div class="analytics-live-banner">';
+    html += '<div class="alb-row"><span class="alb-pulse"></span><span class="alb-title">Computing cost analytics — live</span><span class="alb-elapsed">' + (opts.elapsed || 0) + 's</span></div>';
+    html += '<div class="alb-phase">' + escHtml(opts.phase || '') + ' — ' + (opts.done || 0) + ' / ' + (opts.total || 0) + ' sessions (' + pct + '%) · numbers update as sessions are processed</div>';
+    html += '<div class="progress-bar-outer"><div class="progress-bar-inner" style="width:' + pct + '%"></div></div>';
+    html += '</div>';
+  }
+
+  html += '<h2 class="heatmap-title">Cost Analytics' + (opts.live ? ' <span style="font-size:12px;opacity:0.6;font-weight:normal">(live)</span>' : '') + '</h2>';
+
+  // Summary cards
+  html += '<div class="analytics-summary">';
+  html += '<div class="analytics-card"><span class="analytics-val">$' + (data.totalCost || 0).toFixed(2) + '</span><span class="analytics-label">Total cost (API-equivalent)</span></div>';
+  html += '<div class="analytics-card"><span class="analytics-val">' + formatTokens(data.totalTokens || 0) + '</span><span class="analytics-label">Total tokens</span></div>';
+  html += '<div class="analytics-card"><span class="analytics-val">$' + (data.dailyRate || 0).toFixed(2) + '</span><span class="analytics-label">Avg per day (' + (data.days || 1) + ' days)</span></div>';
+  html += '<div class="analytics-card"><span class="analytics-val">' + (data.totalSessions || 0) + '</span><span class="analytics-label">Sessions</span></div>';
+  html += '</div>';
+
+  // Burn rate
+  var todayCost = data.todayCost || 0;
+  var last1hCost = data.last1hCost || 0;
+  var dailyRate = data.dailyRate || 0;
+  var hoursElapsed = data.hoursElapsedToday || 1;
+  var projectedDaily = todayCost / (hoursElapsed / 24);
+  var paceRatio = dailyRate > 0 ? projectedDaily / dailyRate : 0;
+  var burnClass = paceRatio >= 2 ? 'burn-high' : paceRatio >= 1.3 ? 'burn-medium' : 'burn-low';
+  var paceLabel = paceRatio >= 2 ? '🔥 ' + Math.round(paceRatio) + 'x avg' : paceRatio >= 1.3 ? '↑ ' + paceRatio.toFixed(1) + 'x avg' : dailyRate > 0 ? '✓ normal' : '';
+  html += '<div class="burn-rate-bar">';
+  html += '<div class="burn-rate-title">Burn Rate</div>';
+  html += '<div class="burn-rate-stats">';
+  html += '<div class="burn-stat"><span class="burn-val ' + burnClass + '">$' + todayCost.toFixed(3) + '</span><span class="burn-label">today</span>' + (paceLabel ? '<span class="burn-pace ' + burnClass + '">' + paceLabel + '</span>' : '') + '</div>';
+  html += '<div class="burn-stat"><span class="burn-val">$' + last1hCost.toFixed(3) + '</span><span class="burn-label">last hour</span></div>';
+  if (dailyRate > 0) {
+    html += '<div class="burn-stat"><span class="burn-val">$' + projectedDaily.toFixed(2) + '</span><span class="burn-label">projected today</span></div>';
+  }
+  html += '</div></div>';
+
+  // Token breakdown
+  if (data.totalInputTokens !== undefined) {
+    var totalTok = (data.totalInputTokens || 0) + (data.totalOutputTokens || 0) + (data.totalCacheReadTokens || 0) + (data.totalCacheCreateTokens || 0);
+    var pctOf = function(n) { return totalTok > 0 ? Math.round(n / totalTok * 100) : 0; };
+    html += '<div class="chart-section analytics-token-breakdown">';
+    html += '<h3>Token Breakdown</h3>';
+    html += '<div class="token-breakdown-grid">';
+    html += '<div class="token-type-card"><span class="token-type-val">' + formatTokens(data.totalInputTokens || 0) + '</span><span class="token-type-label">Input</span><span class="token-type-pct">' + pctOf(data.totalInputTokens || 0) + '%</span></div>';
+    html += '<div class="token-type-card"><span class="token-type-val">' + formatTokens(data.totalOutputTokens || 0) + '</span><span class="token-type-label">Output</span><span class="token-type-pct">' + pctOf(data.totalOutputTokens || 0) + '%</span></div>';
+    html += '<div class="token-type-card token-cache-read"><span class="token-type-val">' + formatTokens(data.totalCacheReadTokens || 0) + '</span><span class="token-type-label">Cache read</span><span class="token-type-pct">' + pctOf(data.totalCacheReadTokens || 0) + '%</span></div>';
+    html += '<div class="token-type-card token-cache-create"><span class="token-type-val">' + formatTokens(data.totalCacheCreateTokens || 0) + '</span><span class="token-type-label">Cache write</span><span class="token-type-pct">' + pctOf(data.totalCacheCreateTokens || 0) + '%</span></div>';
+    if (data.avgContextPct > 0) {
+      html += '<div class="token-type-card token-context"><span class="token-type-val">' + data.avgContextPct + '%</span><span class="token-type-label">Avg context used</span><span class="token-type-pct">of 200K</span></div>';
+    }
+    html += '</div></div>';
+  }
+
+  // Cost by agent
+  var agentEntries = Object.entries(data.byAgent || {}).filter(function(e) { return e[1].sessions > 0; });
+  if (agentEntries.length >= 1) {
+    agentEntries.sort(function(a, b) { return b[1].cost - a[1].cost; });
+    html += '<div class="chart-section"><h3>Cost by Agent</h3>';
+    html += '<div class="hbar-chart">';
+    var maxAgentCost = agentEntries[0][1].cost || 1;
+    agentEntries.forEach(function(entry) {
+      var name = entry[0]; var info = entry[1];
+      var p = maxAgentCost > 0 ? (info.cost / maxAgentCost * 100) : 0;
+      var label = { 'claude': 'Claude Code', 'claude-ext': 'Claude Ext', 'codex': 'Codex', 'opencode': 'OpenCode', 'cursor': 'Cursor', 'kiro': 'Kiro' }[name] || name;
+      var estMark = info.estimated ? ' <span style="font-size:10px;opacity:0.6">~est.</span>' : '';
+      html += '<div class="hbar-row">';
+      html += '<span class="hbar-name">' + label + estMark + '</span>';
+      html += '<div class="hbar-track"><div class="hbar-fill" style="width:' + p + '%"></div></div>';
+      html += '<span class="hbar-val">$' + info.cost.toFixed(2) + ' <span style="font-size:10px;opacity:0.6">(' + info.sessions + ' sess.)</span></span>';
+      html += '</div>';
+    });
+    html += '</div></div>';
+  }
+
+  // Daily cost chart (last 30 days)
+  var dayKeys = Object.keys(data.byDay || {}).sort();
+  var last30 = dayKeys.slice(-30);
+  if (last30.length > 0) {
+    var maxCost = Math.max.apply(null, last30.map(function(d) { return data.byDay[d].cost; }));
+    html += '<div class="chart-section"><h3>Daily Cost (last 30 days)</h3>';
+    html += '<div class="bar-chart">';
+    last30.forEach(function(d) {
+      var c = data.byDay[d];
+      var p = maxCost > 0 ? (c.cost / maxCost * 100) : 0;
+      var label = d.slice(5);
+      html += '<div class="bar-col" title="' + d + ': $' + c.cost.toFixed(2) + ' (' + c.sessions + ' sessions)">';
+      html += '<div class="bar-fill" style="height:' + p + '%"></div>';
+      html += '<div class="bar-label">' + label + '</div>';
+      html += '</div>';
+    });
+    html += '</div></div>';
+  }
+
+  // Cost by project
+  var projects = Object.entries(data.byProject || {}).sort(function(a, b) { return b[1].cost - a[1].cost; });
+  var topProjects = projects.slice(0, 10);
+  if (topProjects.length > 0) {
+    var maxProjCost = topProjects[0][1].cost || 1;
+    html += '<div class="chart-section"><h3>Cost by Project</h3>';
+    html += '<div class="hbar-chart">';
+    topProjects.forEach(function(entry) {
+      var name = entry[0]; var info = entry[1];
+      var p = maxProjCost > 0 ? (info.cost / maxProjCost * 100) : 0;
+      html += '<div class="hbar-row">';
+      html += '<span class="hbar-name">' + escHtml(name) + '</span>';
+      html += '<div class="hbar-track"><div class="hbar-fill" style="width:' + p + '%"></div></div>';
+      html += '<span class="hbar-val">$' + info.cost.toFixed(2) + '</span>';
+      html += '</div>';
+    });
+    html += '</div></div>';
+  }
+
+  // Top expensive sessions
+  if (data.topSessions && data.topSessions.length > 0) {
+    html += '<div class="chart-section"><h3>Most Expensive Sessions</h3>';
+    html += '<div class="top-sessions">';
+    data.topSessions.forEach(function(s) {
+      html += '<div class="top-session-row" onclick="onCardClick(\'' + s.id + '\', event)">';
+      html += '<span class="top-session-cost">$' + s.cost.toFixed(2) + '</span>';
+      html += '<span class="top-session-project">' + escHtml(s.project || '') + '</span>';
+      html += '<span class="top-session-date">' + (s.date || '') + '</span>';
+      html += '<span class="top-session-id">' + (s.id || '').slice(0, 8) + '</span>';
+      html += '</div>';
+    });
+    html += '</div></div>';
+  }
+
+  html += '</div>';
+  container.innerHTML = html;
 }
 
 function formatTokens(n) {

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -691,6 +691,9 @@ function renderCard(s, idx) {
   }
   html += '<div class="card-footer">';
   html += '<span class="card-meta">' + s.messages + ' msgs</span>';
+  if (s._group_extra > 0) {
+    html += '<span class="card-meta group-badge" title="' + s._group_count + ' sessions with the same initial prompt in this project">+' + s._group_extra + ' more (' + s._group_total_msgs + ' total msgs)</span>';
+  }
   if (s.file_size) {
     html += '<span class="card-meta">' + formatBytes(s.file_size) + '</span>';
   }
@@ -968,8 +971,14 @@ function render() {
   }
 
   var renderFn = layout === 'list' ? renderListCard : renderCard;
-  var visible = sessions.slice(0, renderLimit);
-  var hasMore = sessions.length > renderLimit;
+
+  // Dedupe conversation groups first (same project+initial prompt collapses
+  // into a single representative card with "+N more" badge). Shared helper
+  // used by Timeline / Cloud Sync too.
+  var conversationGroups = groupSessionsByConversation(sessions);
+  var dedupedSessions = conversationGroups.map(function(g) { return withGroupBadge(g.representative, g); });
+  var visible = dedupedSessions.slice(0, renderLimit);
+  var hasMore = dedupedSessions.length > renderLimit;
 
   if (grouped) {
     renderGrouped(content, visible, renderFn);
@@ -980,7 +989,7 @@ function render() {
   }
 
   if (hasMore) {
-    content.innerHTML += '<div style="text-align:center;padding:20px"><button class="toolbar-btn" onclick="loadMoreCards()" style="padding:8px 24px">Load more (' + (sessions.length - renderLimit) + ' remaining)</button></div>';
+    content.innerHTML += '<div style="text-align:center;padding:20px"><button class="toolbar-btn" onclick="loadMoreCards()" style="padding:8px 24px">Load more (' + (dedupedSessions.length - renderLimit) + ' remaining)</button></div>';
   }
 }
 
@@ -1024,13 +1033,63 @@ function renderGrouped(container, sessions, renderFn) {
   container.innerHTML = html;
 }
 
+// ── Shared session grouping ───────────────────────────────────
+// Collapses near-duplicate sessions (same project + same initial prompt) into
+// a single "conversation group". Representative is the newest session; the
+// rest are attached as `group_members` so the UI can show "+N more" and let
+// the user drill down. Used by Timeline / All Sessions / Cloud Sync views —
+// all call this helper, no per-view dedup logic.
+function groupSessionsByConversation(sessions) {
+  var groups = {};
+  var order = [];
+  sessions.forEach(function(s) {
+    var k = s.group_key || s.id;
+    if (!groups[k]) {
+      groups[k] = {
+        key: k,
+        representative: s,
+        members: [s],
+        total_msgs: s.messages || 0,
+        total_file_size: s.file_size || 0,
+      };
+      order.push(k);
+      return;
+    }
+    var g = groups[k];
+    g.members.push(s);
+    g.total_msgs += s.messages || 0;
+    g.total_file_size += s.file_size || 0;
+    // Newest last_ts wins as representative
+    if (s.last_ts > g.representative.last_ts) g.representative = s;
+  });
+  return order.map(function(k) { return groups[k]; });
+}
+
+// Decorate a session with group metadata so renderCard can show "+N more".
+function withGroupBadge(s, group) {
+  if (!group || group.members.length <= 1) return s;
+  var extra = group.members.length - 1;
+  // Clone shallow so we don't mutate the original
+  return Object.assign({}, s, {
+    _group_count: group.members.length,
+    _group_extra: extra,
+    _group_total_msgs: group.total_msgs,
+    _group_members: group.members,
+  });
+}
+
 function renderTimeline(container, sessions) {
-  // Group by date
+  // Group by date, then within each date dedupe near-duplicate conversations
   var byDate = {};
   sessions.forEach(function(s) {
     var d = s.date || 'unknown';
     if (!byDate[d]) byDate[d] = [];
     byDate[d].push(s);
+  });
+  // Replace each day's flat list with grouped representatives
+  Object.keys(byDate).forEach(function(d) {
+    var groups = groupSessionsByConversation(byDate[d]);
+    byDate[d] = groups.map(function(g) { return withGroupBadge(g.representative, g); });
   });
 
   var dates = Object.keys(byDate).sort().reverse();
@@ -1069,6 +1128,9 @@ function renderQACard(s, idx) {
   html += '<span class="qa-question">' + escHtml((s.first_message || '').slice(0, 160)) + '</span>';
   html += '<span class="qa-meta">';
   html += '<span class="qa-msgs">' + s.messages + ' msgs</span>';
+  if (s._group_extra > 0) {
+    html += '<span class="group-badge" title="' + s._group_count + ' sessions with the same initial prompt">+' + s._group_extra + '</span>';
+  }
   if (costStr) html += '<span class="cost-badge">' + costStr + '</span>';
   html += '<span class="qa-time">' + timeAgo(s.last_ts) + '</span>';
   html += '</span>';
@@ -1098,17 +1160,27 @@ function renderProjects(container, sessions) {
   var html = '<div class="git-projects">';
   sorted.forEach(function(entry) {
     var name = entry[0];
-    var list = entry[1].slice().sort(function(a, b) { return b.last_ts - a.last_ts; });
+    var rawList = entry[1];
+    // Dedupe conversation groups within the project (same first prompt
+    // collapses into one representative card with "+N more" badge).
+    var convGroups = groupSessionsByConversation(rawList);
+    var list = convGroups
+      .map(function(g) { return withGroupBadge(g.representative, g); })
+      .sort(function(a, b) { return b.last_ts - a.last_ts; });
+
     var color = getProjectColor(name);
-    var totalMsgs = list.reduce(function(s, e) { return s + (e.messages || 0); }, 0);
-    var totalCost = list.reduce(function(s, e) { return s + estimateCost(e.file_size); }, 0);
+    var totalMsgs = rawList.reduce(function(s, e) { return s + (e.messages || 0); }, 0);
+    var totalCost = rawList.reduce(function(s, e) { return s + estimateCost(e.file_size); }, 0);
     var costLabel = totalCost > 0 ? ' · ~$' + totalCost.toFixed(2) : '';
+    var dedupLabel = rawList.length !== list.length
+      ? ' (' + rawList.length + ' raw → ' + list.length + ' unique)'
+      : '';
 
     html += '<div class="git-project-group">';
     html += '<div class="git-project-header" onclick="this.parentElement.classList.toggle(\'collapsed\')">';
     html += '<span class="group-dot" style="background:' + color + '"></span>';
     html += '<span class="git-project-name">' + escHtml(name) + '</span>';
-    html += '<span class="git-project-stats">' + list.length + ' sessions · ' + totalMsgs + ' msgs' + escHtml(costLabel) + '</span>';
+    html += '<span class="git-project-stats">' + list.length + ' sessions' + dedupLabel + ' · ' + totalMsgs + ' msgs' + escHtml(costLabel) + '</span>';
     html += '<span class="group-chevron">&#9660;</span>';
     html += '</div>';
     html += '<div class="qa-list">';

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -826,18 +826,33 @@ async function toggleExpand(sessionId, project, btn) {
 
 var deepSearchCache = {};
 var deepSearchTimeout = null;
+var searchMode = 'hybrid'; // text|semantic|hybrid
+
+function setSearchMode(mode) {
+  searchMode = mode;
+  document.querySelectorAll('.search-mode-btn').forEach(function(b) {
+    b.classList.toggle('active', b.dataset.mode === mode);
+  });
+  // Re-run current search with new mode
+  deepSearchCache = {};
+  if (searchQuery && searchQuery.length >= 3) {
+    deepSearch(searchQuery);
+  }
+}
 
 async function deepSearch(query) {
   if (!query || query.length < 3) return;
-  if (deepSearchCache[query]) {
-    applyDeepSearchResults(deepSearchCache[query]);
+  var cacheKey = searchMode + ':' + query;
+  if (deepSearchCache[cacheKey]) {
+    applyDeepSearchResults(deepSearchCache[cacheKey]);
     return;
   }
 
   try {
-    var resp = await fetch('/api/search?q=' + encodeURIComponent(query));
+    var url = '/api/search?q=' + encodeURIComponent(query) + '&mode=' + searchMode;
+    var resp = await fetch(url);
     var results = await resp.json();
-    deepSearchCache[query] = results;
+    deepSearchCache[cacheKey] = results;
     applyDeepSearchResults(results);
   } catch {}
 }

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1870,25 +1870,7 @@ async function checkForUpdates() {
     }
     localStorage.setItem('codedash-last-version', data.current);
 
-    if (data.updateAvailable) {
-      if (badge) {
-        badge.textContent = 'v' + data.current + ' → v' + data.latest;
-        badge.classList.add('update-available');
-        badge.title = 'Click to copy update command';
-        badge.onclick = function() {
-          navigator.clipboard.writeText('npm i -g codedash-app@latest').then(function() {
-            showToast('Copied: npm i -g codedash-app@latest');
-          });
-        };
-      }
-      var banner = document.getElementById('updateBanner');
-      var text = document.getElementById('updateText');
-      if (banner && text) {
-        text.textContent = 'v' + data.latest + ' available — run: npm i -g codedash-app@latest';
-        banner.style.display = 'flex';
-        banner.dataset.cmd = 'npm i -g codedash-app@latest';
-      }
-    }
+    // Update banner disabled — dev/fork build, not published to npm
   } catch {}
 }
 

--- a/src/frontend/cloud.js
+++ b/src/frontend/cloud.js
@@ -82,10 +82,17 @@ async function renderCloud(container) {
   html += '<div style="' + panelStyle + '">';
 
   if (cloudLocalSessions) {
-    for (var i = 0; i < cloudLocalSessions.length; i++) {
-      var ls = cloudLocalSessions[i];
+    // Dedupe near-duplicate conversations via the shared helper — same
+    // logic as Timeline, All Sessions etc.
+    var _groups = groupSessionsByConversation(cloudLocalSessions);
+    for (var i = 0; i < _groups.length; i++) {
+      var g = _groups[i];
+      var ls = g.representative;
+      var extra = g.members.length - 1;
       var inCloud = cloudSessionIds.has(ls.id);
-      var sub = (ls.project_short || '') + ' \u00b7 ' + (ls.messages || 0) + ' msgs';
+      var subParts = [(ls.project_short || ''), (ls.messages || 0) + ' msgs'];
+      if (extra > 0) subParts.push('+' + extra + ' more (' + g.total_msgs + ' total)');
+      var sub = subParts.join(' \u00b7 ');
       var btnHtml = inCloud
         ? '<span class="dim" style="font-size:10px;white-space:nowrap;">in cloud</span>'
         : '<button class="launch-btn btn-primary" style="padding:3px 8px;font-size:10px;" onclick="cloudPushOne(\'' + ls.id + '\',this)">Push</button>';

--- a/src/frontend/detail.js
+++ b/src/frontend/detail.js
@@ -1,11 +1,34 @@
 // ── Detail panel ───────────────────────────────────────────────
 
+// Progressive loading page size
+var DETAIL_PAGE_SIZE = 50;
+
+// State for current detail view
+var _detailState = {
+  sessionId: null,
+  project: null,
+  allMessages: [],   // all loaded messages so far
+  total: 0,
+  offset: 0,
+  hasMore: false,
+  filter: 'all'      // 'all' | 'user' | 'assistant' | 'tool'
+};
+
 async function openDetail(s) {
   var panel = document.getElementById('detailPanel');
   var overlay = document.getElementById('overlay');
   var title = document.getElementById('detailTitle');
   var body = document.getElementById('detailBody');
   if (!panel || !body) return;
+
+  // Reset detail state
+  _detailState.sessionId = s.id;
+  _detailState.project = s.project || '';
+  _detailState.allMessages = [];
+  _detailState.total = 0;
+  _detailState.offset = 0;
+  _detailState.hasMore = false;
+  _detailState.filter = 'all';
 
   title.textContent = escHtml(getProjectName(s.project)) + ' / ' + s.id.slice(0, 12);
 
@@ -82,9 +105,21 @@ async function openDetail(s) {
     var convertTarget = s.tool === 'codex' ? 'claude' : 'codex';
     infoHtml += '<button class="launch-btn btn-secondary" onclick="convertTo(\'' + s.id + '\',\'' + escHtml(s.project || '') + '\',\'' + convertTarget + '\')">Convert to ' + convertTarget + '</button>';
     infoHtml += '<button class="launch-btn btn-secondary" onclick="downloadHandoff(\'' + s.id + '\',\'' + escHtml(s.project || '') + '\')">Handoff</button>';
+    infoHtml += '<button class="launch-btn btn-secondary btn-summarize" id="detailSummarizeBtn" onclick="summarizeSession(\'' + s.id + '\',\'' + escProject + '\')">&#10024; Summarize</button>';
   }
   infoHtml += '<button class="star-btn detail-star' + (isStarred ? ' active' : '') + '" onclick="toggleStar(\'' + s.id + '\')">&#9733; ' + (isStarred ? 'Starred' : 'Star') + '</button>';
   infoHtml += '<button class="launch-btn btn-delete" onclick="showDeleteConfirm(\'' + s.id + '\',\'' + escHtml(s.project || '') + '\')">Delete</button>';
+  infoHtml += '</div>';
+
+  // Summary box (hidden by default, shown after summarize)
+  infoHtml += '<div class="detail-summary" id="detailSummary" style="display:none"></div>';
+
+  // Message filters
+  infoHtml += '<div class="detail-msg-filters" id="detailMsgFilters" style="display:none">';
+  infoHtml += '<button class="filter-btn active" data-filter="all" onclick="setDetailFilter(\'all\')">All</button>';
+  infoHtml += '<button class="filter-btn" data-filter="user" onclick="setDetailFilter(\'user\')">User</button>';
+  infoHtml += '<button class="filter-btn" data-filter="assistant" onclick="setDetailFilter(\'assistant\')">Assistant</button>';
+  infoHtml += '<button class="filter-btn" data-filter="tool" onclick="setDetailFilter(\'tool\')">Tools</button>';
   infoHtml += '</div>';
 
   body.innerHTML = infoHtml + '<div class="detail-messages"><div class="loading">Loading messages...</div></div><div class="detail-commits"></div>';
@@ -92,43 +127,9 @@ async function openDetail(s) {
   panel.classList.add('open');
   overlay.classList.add('open');
 
-  // Load messages
+  // Load messages progressively
   if (s.has_detail) {
-    try {
-      var resp = await fetch('/api/session/' + s.id + '?project=' + encodeURIComponent(s.project || ''));
-      var data = await resp.json();
-      var msgContainer = body.querySelector('.detail-messages');
-      if (data.messages && data.messages.length > 0) {
-        var msgsHtml = '<h3>Conversation</h3>';
-        data.messages.forEach(function(m) {
-          var roleClass = m.role === 'user' ? 'msg-user' : 'msg-assistant';
-          var roleLabel = m.role === 'user' ? 'You' : 'Assistant';
-          var hasTools = m.tools && m.tools.length > 0;
-          msgsHtml += '<div class="message ' + roleClass + (hasTools ? ' has-tools' : '') + '">';
-          msgsHtml += '<div class="msg-inner">';
-          msgsHtml += '<div class="msg-role">' + roleLabel + '</div>';
-          msgsHtml += '<div class="msg-content">' + escHtml(m.content) + '</div>';
-          msgsHtml += '</div>';
-          if (hasTools) {
-            msgsHtml += '<div class="msg-tools">';
-            m.tools.forEach(function(t) {
-              if (t.type === 'mcp') {
-                msgsHtml += '<span class="tool-badge badge-mcp">' + escHtml(t.tool) + '</span>';
-              } else if (t.type === 'skill') {
-                msgsHtml += '<span class="tool-badge badge-skill">' + escHtml(t.skill) + '</span>';
-              }
-            });
-            msgsHtml += '</div>';
-          }
-          msgsHtml += '</div>';
-        });
-        msgContainer.innerHTML = msgsHtml;
-      } else {
-        msgContainer.innerHTML = '<div class="empty-state">No messages found in detail file.</div>';
-      }
-    } catch (e) {
-      body.querySelector('.detail-messages').innerHTML = '<div class="empty-state">Failed to load messages.</div>';
-    }
+    await _loadDetailPage(s.id, s.project || '', 0, body);
   } else {
     body.querySelector('.detail-messages').innerHTML = '<div class="empty-state">No detail file available for this session.</div>';
   }
@@ -194,6 +195,173 @@ async function openDetail(s) {
       cHtml += '</div>';
       commitsContainer.innerHTML = cHtml;
     }
+  }
+}
+
+// ── Progressive message loading ───────────────────────────────
+
+async function _loadDetailPage(sessionId, project, offset, body) {
+  try {
+    var url = '/api/session/' + sessionId + '?project=' + encodeURIComponent(project) +
+      '&offset=' + offset + '&limit=' + DETAIL_PAGE_SIZE;
+    var resp = await fetch(url);
+    var data = await resp.json();
+    var msgContainer = body.querySelector('.detail-messages');
+    if (!msgContainer) return;
+
+    _detailState.total = data.total || 0;
+    _detailState.hasMore = !!data.hasMore;
+    _detailState.offset = (data.offset || 0) + (data.messages ? data.messages.length : 0);
+
+    if (data.messages && data.messages.length > 0) {
+      // Append to our running list
+      for (var i = 0; i < data.messages.length; i++) {
+        _detailState.allMessages.push(data.messages[i]);
+      }
+      // Show filter bar
+      var filterBar = document.getElementById('detailMsgFilters');
+      if (filterBar) filterBar.style.display = '';
+      // Re-render all visible messages
+      _renderDetailMessages(msgContainer);
+    } else if (_detailState.allMessages.length === 0) {
+      msgContainer.innerHTML = '<div class="empty-state">No messages found in detail file.</div>';
+    }
+  } catch (e) {
+    var mc = body.querySelector('.detail-messages');
+    if (mc && _detailState.allMessages.length === 0) {
+      mc.innerHTML = '<div class="empty-state">Failed to load messages.</div>';
+    }
+  }
+}
+
+function _renderSingleMessage(m) {
+  var roleClass = m.role === 'user' ? 'msg-user' : 'msg-assistant';
+  var roleLabel = m.role === 'user' ? 'You' : 'Assistant';
+  var hasTools = m.tools && m.tools.length > 0;
+  var html = '<div class="message ' + roleClass + (hasTools ? ' has-tools' : '') + '" data-role="' + (m.role || 'assistant') + '" data-has-tools="' + (hasTools ? '1' : '0') + '">';
+  html += '<div class="msg-inner">';
+  html += '<div class="msg-role">' + roleLabel + '</div>';
+  html += '<div class="msg-content">' + escHtml(m.content) + '</div>';
+  html += '</div>';
+  if (hasTools) {
+    html += '<div class="msg-tools">';
+    m.tools.forEach(function(t) {
+      if (t.type === 'mcp') {
+        html += '<span class="tool-badge badge-mcp">' + escHtml(t.tool) + '</span>';
+      } else if (t.type === 'skill') {
+        html += '<span class="tool-badge badge-skill">' + escHtml(t.skill) + '</span>';
+      }
+    });
+    html += '</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function _renderDetailMessages(container) {
+  var msgs = _detailState.allMessages;
+  var filter = _detailState.filter;
+  var html = '<h3>Conversation (' + _detailState.allMessages.length;
+  if (_detailState.total > _detailState.allMessages.length) {
+    html += ' of ' + _detailState.total;
+  }
+  html += ' messages)</h3>';
+  html += '<div class="detail-msg-list" id="detailMsgList">';
+
+  for (var i = 0; i < msgs.length; i++) {
+    var m = msgs[i];
+    var visible = _matchesFilter(m, filter);
+    if (visible) {
+      html += _renderSingleMessage(m);
+    }
+  }
+  html += '</div>';
+
+  // "Load more" button
+  if (_detailState.hasMore) {
+    var remaining = _detailState.total - _detailState.offset;
+    html += '<div class="detail-load-more">';
+    html += '<button class="launch-btn btn-secondary" id="detailLoadMoreBtn" onclick="_onLoadMore()">Load more (' + remaining + ' remaining)</button>';
+    html += '</div>';
+  }
+
+  container.innerHTML = html;
+}
+
+function _matchesFilter(m, filter) {
+  if (filter === 'all') return true;
+  if (filter === 'user') return m.role === 'user';
+  if (filter === 'assistant') return m.role === 'assistant';
+  if (filter === 'tool') return m.tools && m.tools.length > 0;
+  return true;
+}
+
+async function _onLoadMore() {
+  var btn = document.getElementById('detailLoadMoreBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Loading...';
+  }
+  var body = document.getElementById('detailBody');
+  if (!body) return;
+  await _loadDetailPage(_detailState.sessionId, _detailState.project, _detailState.offset, body);
+}
+
+// ── Message filters ───────────────────────────────────────────
+
+function setDetailFilter(filter) {
+  _detailState.filter = filter;
+  // Update active button
+  var btns = document.querySelectorAll('.detail-msg-filters .filter-btn');
+  for (var i = 0; i < btns.length; i++) {
+    if (btns[i].getAttribute('data-filter') === filter) {
+      btns[i].classList.add('active');
+    } else {
+      btns[i].classList.remove('active');
+    }
+  }
+  // Re-render messages (client-side filter, no re-fetch)
+  var msgContainer = document.querySelector('.detail-messages');
+  if (msgContainer) _renderDetailMessages(msgContainer);
+}
+
+// ── Summarize session ─────────────────────────────────────────
+
+async function summarizeSession(sessionId, project) {
+  var btn = document.getElementById('detailSummarizeBtn');
+  var summaryBox = document.getElementById('detailSummary');
+  if (!btn || !summaryBox) return;
+
+  btn.disabled = true;
+  btn.innerHTML = '&#8987; Summarizing...';
+
+  try {
+    var resp = await fetch('/api/summarize/' + sessionId + '?project=' + encodeURIComponent(project), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}'
+    });
+    var data = await resp.json();
+
+    if (data.ok && data.summary) {
+      summaryBox.style.display = '';
+      summaryBox.innerHTML = '<div class="summary-header"><span class="summary-label">&#10024; Summary</span><button class="toolbar-btn" style="font-size:10px;padding:1px 6px" onclick="this.parentElement.parentElement.style.display=\'none\'" title="Dismiss">&times;</button></div><div class="summary-content">' + escHtml(data.summary) + '</div>';
+      btn.innerHTML = '&#10024; Summarize';
+      btn.disabled = false;
+    } else if (data.error && (data.error.indexOf('not available') >= 0 || data.error.indexOf('not authenticated') >= 0)) {
+      summaryBox.style.display = '';
+      summaryBox.innerHTML = '<div class="summary-header"><span class="summary-label">&#10024; Summary</span></div><div class="summary-content summary-unavailable">Connect GitHub Copilot in Settings to use Summarize.</div>';
+      btn.innerHTML = '&#10024; Summarize';
+      btn.disabled = false;
+    } else {
+      showToast('Summarize failed: ' + (data.error || 'unknown'));
+      btn.innerHTML = '&#10024; Summarize';
+      btn.disabled = false;
+    }
+  } catch (e) {
+    showToast('Summarize failed: ' + e.message);
+    btn.innerHTML = '&#10024; Summarize';
+    btn.disabled = false;
   }
 }
 

--- a/src/frontend/heatmap.js
+++ b/src/frontend/heatmap.js
@@ -11,10 +11,16 @@ function renderHeatmap(container) {
   var now = new Date();
   var oneYearAgo = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
 
-  // Count sessions per day + by tool
+  // Dedupe sessions into conversation groups so retry/resume chains count
+  // as ONE session. Otherwise a `codex exec` loop looks like 1000 sessions
+  // in a single day. Uses the shared helper from app.js.
+  var dedupedGroups = groupSessionsByConversation(allSessions);
+  var dedupedSessions = dedupedGroups.map(function(g) { return g.representative; });
+
+  // Count sessions per day + by tool (deduped)
   var counts = {};
   var toolCounts = {};
-  allSessions.forEach(function(s) {
+  dedupedSessions.forEach(function(s) {
     var d = s.date;
     if (!d) return;
     counts[d] = (counts[d] || 0) + 1;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -111,6 +111,11 @@
 <div class="main">
     <div class="toolbar">
         <input type="text" class="search-box" placeholder="Search sessions, projects... (press /)" oninput="onSearch(this.value)">
+        <div class="search-mode-group">
+            <button class="search-mode-btn" data-mode="text" onclick="setSearchMode('text')" title="Keyword search (FTS5)">Text</button>
+            <button class="search-mode-btn active" data-mode="hybrid" onclick="setSearchMode('hybrid')" title="Text + semantic re-ranking">Hybrid</button>
+            <button class="search-mode-btn" data-mode="semantic" onclick="setSearchMode('semantic')" title="Pure semantic similarity">Semantic</button>
+        </div>
         <select id="tagFilter" class="toolbar-btn" onchange="onTagFilter(this.value)">
             <option value="">All Tags</option>
             <option value="bug">bug</option>

--- a/src/frontend/leaderboard.js
+++ b/src/frontend/leaderboard.js
@@ -18,10 +18,18 @@ async function syncLeaderboard() {
 
 var _lbRemoteData = null;
 var _lbCurrentTab = 'today';
+var _lbSortBy = 'messages'; // messages, hours, cost
 
 function switchLbTab(tab, btn) {
   _lbCurrentTab = tab;
-  document.querySelectorAll('.lb-tab').forEach(function(t) { t.classList.remove('active'); });
+  document.querySelectorAll('.lb-tab:not(.lb-sort)').forEach(function(t) { t.classList.remove('active'); });
+  if (btn) btn.classList.add('active');
+  renderGlobalBoard();
+}
+
+function switchLbSort(sortBy, btn) {
+  _lbSortBy = sortBy;
+  document.querySelectorAll('.lb-sort').forEach(function(t) { t.classList.remove('active'); });
   if (btn) btn.classList.add('active');
   renderGlobalBoard();
 }
@@ -35,15 +43,13 @@ function renderGlobalBoard() {
     return;
   }
 
-  // Sort by tab
+  // Sort by tab + sort criterion
   var sorted = data.users.slice();
-  if (_lbCurrentTab === 'today') {
-    sorted.sort(function(a,b) { return (b.stats?.today?.messages||0) - (a.stats?.today?.messages||0); });
-  } else if (_lbCurrentTab === 'week') {
-    sorted.sort(function(a,b) { return (b.stats?.week?.messages||0) - (a.stats?.week?.messages||0); });
-  } else {
-    sorted.sort(function(a,b) { return (b.stats?.totals?.messages||0) - (a.stats?.totals?.messages||0); });
-  }
+  var getVal = function(u) {
+    var s = _lbCurrentTab === 'today' ? (u.stats?.today||{}) : _lbCurrentTab === 'week' ? (u.stats?.week||{}) : (u.stats?.totals||{});
+    return s[_lbSortBy] || 0;
+  };
+  sorted.sort(function(a,b) { return getVal(b) - getVal(a); });
 
   var html = '';
   sorted.forEach(function(u, i) {
@@ -203,6 +209,9 @@ async function renderLeaderboard(container) {
     var ghResp = await fetch('/api/github/profile');
     var gh = await ghResp.json();
 
+    // Guard: if user navigated away during fetch, don't overwrite
+    if (currentView !== 'leaderboard') return;
+
     var html = '<div class="leaderboard-container">';
 
     // Header card — GitHub profile or anonymous
@@ -289,6 +298,11 @@ async function renderLeaderboard(container) {
     html += '<button class="lb-tab active" onclick="switchLbTab(\'today\',this)">Today</button>';
     html += '<button class="lb-tab" onclick="switchLbTab(\'week\',this)">Week</button>';
     html += '<button class="lb-tab" onclick="switchLbTab(\'alltime\',this)">All Time</button>';
+    html += '<span style="margin-left:auto;display:flex;gap:4px;">';
+    html += '<button class="lb-tab lb-sort' + (_lbSortBy==='messages'?' active':'') + '" onclick="switchLbSort(\'messages\',this)" style="font-size:11px;padding:4px 8px;">Msgs</button>';
+    html += '<button class="lb-tab lb-sort' + (_lbSortBy==='hours'?' active':'') + '" onclick="switchLbSort(\'hours\',this)" style="font-size:11px;padding:4px 8px;">Hours</button>';
+    html += '<button class="lb-tab lb-sort' + (_lbSortBy==='cost'?' active':'') + '" onclick="switchLbSort(\'cost\',this)" style="font-size:11px;padding:4px 8px;">Cost</button>';
+    html += '</span>';
     html += '</div>';
     html += '<div id="globalBoard"><div class="loading">Loading...</div></div>';
 

--- a/src/frontend/leaderboard.js
+++ b/src/frontend/leaderboard.js
@@ -170,8 +170,36 @@ async function githubLogout() {
 async function renderLeaderboard(container) {
   container.innerHTML = '<div class="loading">Loading stats...</div>';
   try {
-    var resp = await fetch('/api/leaderboard');
-    var data = await resp.json();
+    // Poll loop with live partial — same pattern as analytics
+    var pollStart = Date.now();
+    var data = null;
+    while (true) {
+      var resp = await fetch('/api/leaderboard');
+      var payload = await resp.json();
+      if (payload.status === 'done') { data = payload; break; }
+      if (payload.status === 'error') {
+        container.innerHTML = '<div class="empty-state">Leaderboard failed: ' + escHtml(payload.error || 'unknown') + '</div>';
+        return;
+      }
+      var p = (payload.progress || {});
+      var done = p.done || 0, total = p.total || 0;
+      var pct = total > 0 ? Math.round(done / total * 100) : 0;
+      var phase = p.phase || 'working';
+      var elapsed = Math.round((payload.elapsedMs || (Date.now() - pollStart)) / 1000);
+      var partialLine = '';
+      if (payload.partialResult && payload.partialResult.totals) {
+        var t = payload.partialResult.totals;
+        partialLine = ' · $' + (t.cost||0).toFixed(2) + ' / ' + (t.messages||0) + ' msgs so far';
+      }
+      container.innerHTML =
+        '<div class="analytics-progress">' +
+        '<div class="progress-title">Building leaderboard stats…</div>' +
+        '<div class="progress-phase">' + escHtml(phase) + ' — ' + done + ' / ' + total + ' sessions (' + pct + '%)</div>' +
+        '<div class="progress-bar-outer"><div class="progress-bar-inner" style="width:' + pct + '%"></div></div>' +
+        '<div class="progress-subtle">elapsed ' + elapsed + 's' + partialLine + '</div>' +
+        '</div>';
+      await new Promise(function(r){ setTimeout(r, 500); });
+    }
     var ghResp = await fetch('/api/github/profile');
     var gh = await ghResp.json();
 

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -203,10 +203,20 @@ body {
     width: 100%;
     padding: 8px 12px;
     border-radius: 6px;
-    background: rgba(255,255,255,0.04);
+    background: var(--bg-card, rgba(255,255,255,0.04));
     color: var(--text-primary);
     border: 1px solid var(--border);
     font-size: 13px;
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236e7681' d='M2 4l4 4 4-4'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    padding-right: 28px;
+}
+.settings-select option {
+    background: var(--bg-card, #161b22);
+    color: var(--text-primary, #e6edf3);
 }
 .settings-checkbox {
     display: flex;
@@ -1548,6 +1558,195 @@ body {
 
 .msg-content {
     white-space: pre-wrap;
+}
+
+/* ── Summarize Button ──────────────────────────────────────── */
+
+.btn-summarize {
+    background: linear-gradient(135deg, #8b5cf6, #6366f1);
+    color: white;
+    border: none;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+.btn-summarize:hover { opacity: 0.85; }
+.btn-summarize:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Session Summary Box ───────────────────────────────────── */
+
+.session-summary {
+    margin: 12px 16px;
+    padding: 14px 16px;
+    background: linear-gradient(135deg, rgba(139,92,246,0.08), rgba(99,102,241,0.05));
+    border: 1px solid rgba(139,92,246,0.25);
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+}
+.session-summary .summary-header {
+    font-size: 11px;
+    font-weight: 600;
+    color: #8b5cf6;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* ── Message Role Filters ──────────────────────────────────── */
+
+.msg-filters {
+    display: flex;
+    gap: 4px;
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--border);
+}
+.msg-filter-btn {
+    padding: 4px 10px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.msg-filter-btn.active {
+    background: var(--accent-blue);
+    color: white;
+    border-color: var(--accent-blue);
+}
+.msg-filter-btn:hover:not(.active) {
+    background: var(--bg-card-hover);
+}
+
+/* ── Load More Button ──────────────────────────────────────── */
+
+.load-more-bar {
+    text-align: center;
+    padding: 12px;
+    border-top: 1px solid var(--border);
+}
+.load-more-btn {
+    padding: 8px 24px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+}
+.load-more-btn:hover { background: var(--bg-card-hover); }
+
+/* ── Progressive Loading Indicator ─────────────────────────── */
+
+.messages-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 20px;
+    color: var(--text-muted);
+    font-size: 13px;
+}
+.messages-loading .spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent-blue);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Light theme overrides for summary & summarize button */
+[data-theme="light"] .session-summary {
+    background: linear-gradient(135deg, rgba(139,92,246,0.06), rgba(99,102,241,0.04));
+    border-color: rgba(139,92,246,0.2);
+}
+[data-theme="light"] .session-summary .summary-header {
+    color: #7c3aed;
+}
+[data-theme="light"] .btn-summarize {
+    background: linear-gradient(135deg, #7c3aed, #4f46e5);
+}
+
+/* ── Detail Summary Box ────────────────────────────────────── */
+
+.detail-summary {
+    margin: 12px 0;
+    padding: 14px 16px;
+    background: linear-gradient(135deg, rgba(139,92,246,0.08), rgba(99,102,241,0.05));
+    border: 1px solid rgba(139,92,246,0.25);
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+}
+.detail-summary .summary-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+.detail-summary .summary-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: #8b5cf6;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.detail-summary .summary-content {
+    white-space: pre-wrap;
+    font-size: 13px;
+}
+.detail-summary .summary-unavailable {
+    color: var(--text-muted);
+    font-style: italic;
+}
+[data-theme="light"] .detail-summary {
+    background: linear-gradient(135deg, rgba(139,92,246,0.06), rgba(99,102,241,0.04));
+    border-color: rgba(139,92,246,0.2);
+}
+[data-theme="light"] .detail-summary .summary-label {
+    color: #7c3aed;
+}
+
+/* ── Detail Message Filters ───────────────────────────────── */
+
+.detail-msg-filters {
+    display: flex;
+    gap: 4px;
+    margin: 12px 0 4px;
+}
+.detail-msg-filters .filter-btn {
+    padding: 4px 12px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.detail-msg-filters .filter-btn.active {
+    background: var(--accent-blue);
+    color: white;
+    border-color: var(--accent-blue);
+}
+.detail-msg-filters .filter-btn:hover:not(.active) {
+    background: var(--bg-card-hover);
+}
+
+/* ── Detail Load More ─────────────────────────────────────── */
+
+.detail-load-more {
+    text-align: center;
+    padding: 12px 0;
 }
 
 /* ── Commits ────────────────────────────────────────────────── */

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -256,6 +256,32 @@ body {
 .search-box:focus { border-color: var(--accent-blue); }
 .search-box::placeholder { color: var(--text-muted); }
 
+.search-mode-group {
+    display: flex;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+.search-mode-btn {
+    background: var(--bg-card);
+    border: none;
+    padding: 6px 10px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.15s;
+    border-right: 1px solid var(--border);
+}
+.search-mode-btn:last-child { border-right: none; }
+.search-mode-btn:hover { background: var(--bg-card-hover); }
+.search-mode-btn.active {
+    background: var(--accent-blue);
+    color: #fff;
+    font-weight: 600;
+}
+
 .toolbar-btn {
     background: var(--bg-card);
     border: 1px solid var(--border);

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -575,6 +575,19 @@ body {
     color: var(--accent-green);
     white-space: nowrap;
 }
+.group-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 2px 7px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 600;
+    background: rgba(168,85,247,0.18);
+    color: #c084fc;
+    white-space: nowrap;
+    cursor: help;
+}
 [data-theme="light"] .cost-badge {
     background: rgba(52,199,89,0.12);
 }
@@ -2470,6 +2483,104 @@ body {
     line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
+}
+
+/* ── Analytics live banner + progress ───────────────────────── */
+
+.analytics-live-banner {
+    background: linear-gradient(90deg, rgba(96,165,250,0.12), rgba(96,165,250,0.04));
+    border: 1px solid rgba(96,165,250,0.35);
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin: 0 20px 16px;
+}
+.analytics-live-banner .alb-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 4px;
+}
+.analytics-live-banner .alb-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--accent-blue, #60a5fa);
+    flex: 1;
+}
+.analytics-live-banner .alb-elapsed {
+    font-size: 12px;
+    color: var(--text-secondary, #aaa);
+    font-variant-numeric: tabular-nums;
+}
+.analytics-live-banner .alb-phase {
+    font-size: 11px;
+    color: var(--text-secondary, #aaa);
+    margin-bottom: 8px;
+    font-variant-numeric: tabular-nums;
+}
+.analytics-live-banner .alb-pulse {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #60a5fa;
+    box-shadow: 0 0 0 0 rgba(96,165,250,0.7);
+    animation: alb-pulse 1.5s infinite;
+}
+@keyframes alb-pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(96,165,250,0.7); }
+    70%  { box-shadow: 0 0 0 8px rgba(96,165,250,0); }
+    100% { box-shadow: 0 0 0 0 rgba(96,165,250,0); }
+}
+.analytics-live-banner .progress-bar-outer {
+    width: 100%;
+    height: 6px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 3px;
+    overflow: hidden;
+}
+.analytics-live-banner .progress-bar-inner {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue, #60a5fa), #3b82f6);
+    transition: width 0.5s ease-out;
+}
+
+.analytics-progress {
+    max-width: 520px;
+    margin: 60px auto;
+    padding: 28px 32px;
+    border: 1px solid var(--border-color, #333);
+    border-radius: 8px;
+    background: var(--panel-bg, #1a1a1a);
+    text-align: center;
+}
+.analytics-progress .progress-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary, #eee);
+    margin-bottom: 8px;
+}
+.analytics-progress .progress-phase {
+    font-size: 13px;
+    color: var(--text-secondary, #aaa);
+    margin-bottom: 16px;
+    font-variant-numeric: tabular-nums;
+}
+.analytics-progress .progress-bar-outer {
+    width: 100%;
+    height: 8px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+.analytics-progress .progress-bar-inner {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-blue, #60a5fa), var(--accent-blue, #3b82f6));
+    transition: width 0.4s ease-out;
+}
+.analytics-progress .progress-subtle {
+    font-size: 11px;
+    color: var(--text-muted, #777);
 }
 
 /* ── Cost Analytics ─────────────────────────────────────────── */

--- a/src/server.js
+++ b/src/server.js
@@ -564,8 +564,8 @@ function startServer(host, port, openBrowser = true) {
     // ── Full-text search ──────────────────────
     else if (req.method === 'GET' && pathname === '/api/search') {
       const q = parsed.searchParams.get('q') || '';
-      // Uses SQLite FTS5 index directly — no loadSessions needed
-      const results = searchFullText(q, []);
+      // Prefer the SQLite FTS5 index, but provide sessions so in-memory fallback can work
+      const results = searchFullText(q, loadSessions());
       json(res, results);
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -64,6 +64,7 @@ async function _runAnalyticsJob(filterFrom, filterTo, includeHelpers) {
 
     job.progress = { done: 0, total: sessions.length, phase: 'aggregating' };
     const agg = createCostAggregator();
+    agg.setTotalSessionsAll(sessions.length);
     const CHUNK = 50;
     for (let i = 0; i < sessions.length; i += CHUNK) {
       const slice = sessions.slice(i, i + CHUNK);
@@ -367,7 +368,12 @@ function startServer(host, port, openBrowser = true) {
     else if (req.method === 'GET' && pathname.startsWith('/api/session/') && !pathname.includes('/export')) {
       const sessionId = pathname.split('/').pop();
       const project = parsed.searchParams.get('project') || '';
-      const data = loadSessionDetail(sessionId, project);
+      const rawOffset = parsed.searchParams.get('offset');
+      const rawLimit = parsed.searchParams.get('limit');
+      const opts = {};
+      if (rawOffset !== null) opts.offset = parseInt(rawOffset) || 0;
+      if (rawLimit !== null) opts.limit = parseInt(rawLimit) || 50;
+      const data = loadSessionDetail(sessionId, project, Object.keys(opts).length > 0 ? opts : undefined);
       json(res, data);
     }
 
@@ -773,6 +779,49 @@ function startServer(host, port, openBrowser = true) {
       });
     }
 
+    // ── Summarize session via LLM ──────────────
+    else if (req.method === 'POST' && pathname.startsWith('/api/summarize/')) {
+      const sessionId = pathname.split('/').pop();
+      const project = parsed.searchParams.get('project') || '';
+      const config = loadLLMConfig();
+      if (!config.url || !config.apiKey) {
+        json(res, { ok: false, error: 'LLM not configured. Connect GitHub Copilot in Settings.' }, 400);
+        return;
+      }
+      try {
+        const detail = loadSessionDetail(sessionId, project);
+        const msgs = detail.messages || [];
+        if (msgs.length === 0) {
+          json(res, { ok: false, error: 'Session not found or empty' }, 404);
+          return;
+        }
+        // First 10 + last 10 (deduped), truncated to 500 chars each
+        const first10 = msgs.slice(0, 10);
+        const last10 = msgs.slice(-10);
+        const seen = new Set();
+        const selected = [];
+        for (const m of first10.concat(last10)) {
+          const key = (m.uuid || '') + (m.role || '') + (m.content || '').slice(0, 50);
+          if (!seen.has(key)) { seen.add(key); selected.push(m); }
+        }
+        const conversation = selected.map(function(m) {
+          var text = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+          if (text.length > 500) text = text.slice(0, 500) + '...';
+          return (m.role === 'user' ? 'User' : 'Assistant') + ': ' + text;
+        }).join('\n\n');
+
+        callLLM(config, conversation, msgs.length, 'summarize').then(function(summary) {
+          log('LLM', `summary generated (${summary.length} chars)`);
+          json(res, { ok: true, summary });
+        }).catch(function(e) {
+          log('ERROR', `summarize failed: ${e.message}`);
+          json(res, { ok: false, error: e.message }, 500);
+        });
+      } catch (e) {
+        json(res, { ok: false, error: e.message }, 500);
+      }
+    }
+
     // ── Leaderboard stats ────────────────────
     // ── Leaderboard (async job + live partial) ─────────────────
     else if (req.method === 'GET' && pathname === '/api/leaderboard') {
@@ -892,12 +941,8 @@ function startServer(host, port, openBrowser = true) {
     else if (req.method === 'GET' && pathname === '/api/version') {
       const pkg = require('../package.json');
       const current = pkg.version;
-      // Fetch latest from npm registry
-      fetchLatestVersion(pkg.name).then(latest => {
-        json(res, { current, latest, updateAvailable: latest && latest !== current && isNewer(latest, current) });
-      }).catch(() => {
-        json(res, { current, latest: null, updateAvailable: false });
-      });
+      // Always return updateAvailable: false — banner disabled for dev/fork builds
+      json(res, { current, latest: current, updateAvailable: false });
     }
 
     // ── 404 ─────────────────────────────────
@@ -1453,9 +1498,26 @@ function saveLLMConfig(config) {
   }, null, 2));
 }
 
-function callLLM(config, conversation, totalMessages) {
+function callLLM(config, conversation, totalMessages, mode) {
   return new Promise((resolve, reject) => {
-    const systemPrompt = `<MAIN_ROLE>
+    let systemPrompt, userPrompt, maxTokens;
+
+    if (mode === 'summarize') {
+      systemPrompt = `<MAIN_ROLE>
+You are a coding session summarizer. You read coding conversations and produce a concise but informative summary.
+</MAIN_ROLE>
+
+<MAIN_GUIDELINES>
+- Write 3-6 sentences summarizing the session: what was discussed, decided, and accomplished
+- Mention specific: technologies, files, features, bugs, architectural decisions
+- Write in the SAME language the user used in the conversation
+- Use plain text, no markdown or formatting
+- Respond ONLY with the summary text, nothing else
+</MAIN_GUIDELINES>`;
+      userPrompt = `Coding session: ${totalMessages} messages total. First and last messages below. Summarize what happened.\n\n${conversation}`;
+      maxTokens = 500;
+    } else {
+      systemPrompt = `<MAIN_ROLE>
 You are a coding session summarizer. You read coding conversations and produce a single short concrete title describing what was done.
 </MAIN_ROLE>
 
@@ -1474,18 +1536,17 @@ BAD: "Coding session about project" — too vague
 BAD: "Bug fix and improvements" — no specifics
 BAD: "Working with code" — meaningless
 </MAIN_GUIDELINES>`;
-
-    const prompt = `Coding session: ${totalMessages} messages total. First and last messages below.
-
-${conversation}`;
+      userPrompt = `Coding session: ${totalMessages} messages total. First and last messages below.\n\n${conversation}`;
+      maxTokens = 200;
+    }
 
     const body = JSON.stringify({
       model: config.model,
       messages: [
         { role: 'system', content: systemPrompt },
-        { role: 'user', content: prompt },
+        { role: 'user', content: userPrompt },
       ],
-      max_tokens: 200,
+      max_tokens: maxTokens,
       temperature: 0.3,
     });
 
@@ -1522,6 +1583,11 @@ ${conversation}`;
             // Log full response for debugging
             log('ERROR', 'LLM empty content, full response: ' + JSON.stringify(result).slice(0, 500));
             reject(new Error('LLM returned empty content. If using a reasoning model, it may not support structured output.'));
+            return;
+          }
+          // Summarize mode: return raw text content directly
+          if (mode === 'summarize') {
+            resolve(content.trim());
             return;
           }
           let title;

--- a/src/server.js
+++ b/src/server.js
@@ -365,16 +365,22 @@ function startServer(host, port, openBrowser = true) {
       json(res, filtered);
     }
 
-    else if (req.method === 'GET' && pathname.startsWith('/api/session/') && !pathname.includes('/export')) {
+    else if (req.method === 'GET' && pathname.startsWith('/api/session/') && !pathname.includes('/export') && !pathname.includes('/stream')) {
       const sessionId = pathname.split('/').pop();
       const project = parsed.searchParams.get('project') || '';
+      const data = loadSessionDetail(sessionId, project);
+      // Pagination: ?offset=0&limit=50
       const rawOffset = parsed.searchParams.get('offset');
       const rawLimit = parsed.searchParams.get('limit');
-      const opts = {};
-      if (rawOffset !== null) opts.offset = parseInt(rawOffset) || 0;
-      if (rawLimit !== null) opts.limit = parseInt(rawLimit) || 50;
-      const data = loadSessionDetail(sessionId, project, Object.keys(opts).length > 0 ? opts : undefined);
-      json(res, data);
+      if (rawOffset !== null || rawLimit !== null) {
+        const msgs = data.messages || [];
+        const offset = Math.max(0, parseInt(rawOffset) || 0);
+        const limit = Math.max(1, parseInt(rawLimit) || 50);
+        const slice = msgs.slice(offset, offset + limit);
+        json(res, { messages: slice, total: msgs.length, offset, limit, hasMore: offset + limit < msgs.length });
+      } else {
+        json(res, data);
+      }
     }
 
     // ── Export Markdown ─────────────────────
@@ -779,13 +785,24 @@ function startServer(host, port, openBrowser = true) {
       });
     }
 
-    // ── Summarize session via LLM ──────────────
+    // ── Copilot status ──────────────────────
+    else if (req.method === 'GET' && pathname === '/api/copilot/status') {
+      try {
+        const copilot = require('./copilot-client');
+        json(res, { available: copilot.isAvailable(), ...copilot.getStatus() });
+      } catch (e) {
+        json(res, { available: false, error: e.message });
+      }
+    }
+
+    // ── Summarize session via Copilot LLM ──────────────
     else if (req.method === 'POST' && pathname.startsWith('/api/summarize/')) {
       const sessionId = pathname.split('/').pop();
       const project = parsed.searchParams.get('project') || '';
-      const config = loadLLMConfig();
-      if (!config.url || !config.apiKey) {
-        json(res, { ok: false, error: 'LLM not configured. Connect GitHub Copilot in Settings.' }, 400);
+      let copilot;
+      try { copilot = require('./copilot-client'); } catch {}
+      if (!copilot || !copilot.isAvailable()) {
+        json(res, { ok: false, error: 'GitHub Copilot not configured. Install Copilot CLI or VS Code extension.' }, 503);
         return;
       }
       try {
@@ -795,22 +812,7 @@ function startServer(host, port, openBrowser = true) {
           json(res, { ok: false, error: 'Session not found or empty' }, 404);
           return;
         }
-        // First 10 + last 10 (deduped), truncated to 500 chars each
-        const first10 = msgs.slice(0, 10);
-        const last10 = msgs.slice(-10);
-        const seen = new Set();
-        const selected = [];
-        for (const m of first10.concat(last10)) {
-          const key = (m.uuid || '') + (m.role || '') + (m.content || '').slice(0, 50);
-          if (!seen.has(key)) { seen.add(key); selected.push(m); }
-        }
-        const conversation = selected.map(function(m) {
-          var text = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
-          if (text.length > 500) text = text.slice(0, 500) + '...';
-          return (m.role === 'user' ? 'User' : 'Assistant') + ': ' + text;
-        }).join('\n\n');
-
-        callLLM(config, conversation, msgs.length, 'summarize').then(function(summary) {
+        copilot.summarizeSession(msgs).then(function(summary) {
           log('LLM', `summary generated (${summary.length} chars)`);
           json(res, { ok: true, summary });
         }).catch(function(e) {

--- a/src/server.js
+++ b/src/server.js
@@ -591,15 +591,36 @@ function startServer(host, port, openBrowser = true) {
       }
     }
 
-    // ── Embedding status ──────────────────────
+    // ── Embedding status + config ──────────────────────
     else if (req.method === 'GET' && pathname === '/api/embeddings/status') {
       let embeddings;
       try { embeddings = require('./embeddings'); } catch {}
       json(res, {
         available: embeddings ? embeddings.isAvailable() : false,
-        model: embeddings ? embeddings.MODEL_ID : null,
-        dim: embeddings ? embeddings.EMBEDDING_DIM : 0,
+        model: embeddings ? embeddings.getModelId() : null,
+        dim: embeddings ? embeddings.getModelDim() : 0,
         count: embeddings ? embeddings.getEmbeddingCount() : 0,
+        models: embeddings ? embeddings.MODELS : {},
+        config: embeddings ? embeddings.loadConfig() : {},
+        pipeline: {
+          rrf_k: embeddings ? embeddings.RRF_K : 60,
+          bm25_weight: embeddings ? embeddings.BM25_WEIGHT : 0.3,
+          embedding_weight: embeddings ? embeddings.EMBEDDING_WEIGHT : 0.7,
+        },
+      });
+    }
+
+    // ── Search utility tracking (for reranking) ──────
+    else if (req.method === 'POST' && pathname === '/api/search/utility') {
+      readBody(req, body => {
+        try {
+          const { sessionId, queryHash, outcome } = JSON.parse(body);
+          const embeddings = require('./embeddings');
+          embeddings.recordUtility(sessionId, queryHash, outcome || 'click');
+          json(res, { ok: true });
+        } catch (e) {
+          json(res, { ok: false, error: e.message }, 400);
+        }
       });
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -606,26 +606,47 @@ function startServer(host, port, openBrowser = true) {
           if (from) filtered = filtered.filter(s => s.date >= from);
           if (to) filtered = filtered.filter(s => s.date <= to);
           const fingerprint = _analyticsFingerprint(filtered, from, to, includeHelpers ? 'h1' : 'h0');
+          const placeholderJob = {
+            state: 'running',
+            key,
+            result: null,
+            partialResult: null,
+            progress: { done: 0, total: filtered.length, phase: 'cache' },
+            error: null,
+            startedAt: Date.now(),
+            finishedAt: null,
+          };
+          _jobs.analytics = placeholderJob;
           sqliteIndex.getAggregateCacheAsync('analytics', fingerprint).then(cached => {
             if (served) return;
             if (cached && cached.result) {
               served = true;
-              _jobs.analytics = {
-                state: 'done', key, result: cached.result, partialResult: null,
-                progress: { done: filtered.length, total: filtered.length, phase: 'cached' },
-                error: null, startedAt: cached.computedAt, finishedAt: cached.computedAt,
-              };
+              if (_jobs.analytics === placeholderJob) {
+                _jobs.analytics = {
+                  state: 'done', key, result: cached.result, partialResult: null,
+                  progress: { done: filtered.length, total: filtered.length, phase: 'cached' },
+                  error: null, startedAt: cached.computedAt, finishedAt: cached.computedAt,
+                };
+              }
               json(res, { status: 'done', ...cached.result, _cached: true });
             } else {
               served = true;
-              _runAnalyticsJob(from, to, includeHelpers);
-              json(res, _jobResponse(_jobs.analytics));
+              if (_jobs.analytics === placeholderJob) {
+                _runAnalyticsJob(from, to, includeHelpers);
+                json(res, _jobResponse(_jobs.analytics));
+              } else {
+                json(res, _jobResponse(_jobs.analytics));
+              }
             }
           }).catch(() => {
             if (served) return;
             served = true;
-            _runAnalyticsJob(from, to, includeHelpers);
-            json(res, _jobResponse(_jobs.analytics));
+            if (_jobs.analytics === placeholderJob) {
+              _runAnalyticsJob(from, to, includeHelpers);
+              json(res, _jobResponse(_jobs.analytics));
+            } else {
+              json(res, _jobResponse(_jobs.analytics));
+            }
           });
         } catch (e) {
           if (!served) {

--- a/src/server.js
+++ b/src/server.js
@@ -561,12 +561,46 @@ function startServer(host, port, openBrowser = true) {
       json(res, messages);
     }
 
-    // ── Full-text search ──────────────────────
+    // ── Full-text + semantic search ──────────────────────
     else if (req.method === 'GET' && pathname === '/api/search') {
       const q = parsed.searchParams.get('q') || '';
-      // Prefer the SQLite FTS5 index, but provide sessions so in-memory fallback can work
-      const results = searchFullText(q, loadSessions());
-      json(res, results);
+      const mode = parsed.searchParams.get('mode') || 'text'; // text|semantic|hybrid
+      if (mode === 'semantic' || mode === 'hybrid') {
+        // Vector / hybrid search (async — needs model load on first call)
+        let embeddings;
+        try { embeddings = require('./embeddings'); } catch {}
+        if (!embeddings || !embeddings.isAvailable()) {
+          // Fallback to text search
+          const results = searchFullText(q, loadSessions());
+          json(res, results);
+        } else {
+          const fn = mode === 'hybrid' ? embeddings.hybridSearch : embeddings.semanticSearch;
+          fn(q, 50).then(results => {
+            json(res, results);
+          }).catch(e => {
+            log('ERROR', `${mode} search failed: ${e.message}`);
+            // Fallback to text
+            const results = searchFullText(q, loadSessions());
+            json(res, results);
+          });
+        }
+      } else {
+        // Pure text search (FTS5)
+        const results = searchFullText(q, loadSessions());
+        json(res, results);
+      }
+    }
+
+    // ── Embedding status ──────────────────────
+    else if (req.method === 'GET' && pathname === '/api/embeddings/status') {
+      let embeddings;
+      try { embeddings = require('./embeddings'); } catch {}
+      json(res, {
+        available: embeddings ? embeddings.isAvailable() : false,
+        model: embeddings ? embeddings.MODEL_ID : null,
+        dim: embeddings ? embeddings.EMBEDDING_DIM : 0,
+        count: embeddings ? embeddings.getEmbeddingCount() : 0,
+      });
     }
 
     // ── Session cost ──────────────────────

--- a/src/server.js
+++ b/src/server.js
@@ -3,20 +3,299 @@ const http = require('http');
 const https = require('https');
 const { URL } = require('url');
 const { exec } = require('child_process');
-const { loadSessions, loadSessionDetail, deleteSession, getGitCommits, exportSessionMarkdown, getSessionPreview, searchFullText, getActiveSessions, getSessionReplay, getCostAnalytics, computeSessionCost, getProjectGitInfo, getLeaderboardStats } = require('./data');
+const { loadSessions, loadSessionsAsync, getWarmingStatus, getSqliteBackfillStatus, createCostAggregator, computeSessionCostForAnalytics, buildOpencodeCostCache, loadSessionDetail, deleteSession, getGitCommits, exportSessionMarkdown, getSessionPreview, searchFullText, getActiveSessions, getSessionReplay, getCostAnalytics, computeSessionCost, getProjectGitInfo, getLeaderboardStats } = require('./data');
+const sqliteIndex = require('./sqlite-index');
 const { detectTerminals, openInTerminal, focusTerminalByPid } = require('./terminals');
 const { convertSession } = require('./convert');
 const { generateHandoff } = require('./handoff');
 const { CHANGELOG } = require('./changelog');
 const { getHTML } = require('./html');
 
+// ── Background jobs for long-running stats ────────────────
+// Analytics and leaderboard run as async tasks that publish live partial
+// results. The HTTP endpoint returns progress + partial snapshot so the UI
+// can show numbers climbing in real time instead of a blank loading screen.
+const _jobs = {
+  analytics: null,
+  leaderboard: null,
+};
+
+// Fingerprint for persistent cache lookup. Quantized to 5-min buckets so
+// that codex sessions appending their files every second don't invalidate
+// the cache on every request.
+function _analyticsFingerprint(sessions, filterFrom, filterTo, extra) {
+  let maxTs = 0;
+  for (const s of sessions) if (s.last_ts > maxTs) maxTs = s.last_ts;
+  const bucket = Math.floor(maxTs / (5 * 60000));
+  return [sessions.length, bucket, filterFrom || '', filterTo || '', extra || ''].join('|');
+}
+
+async function _runAnalyticsJob(filterFrom, filterTo, includeHelpers) {
+  const key = (filterFrom || '') + '|' + (filterTo || '') + '|h' + (includeHelpers ? '1' : '0');
+  const job = {
+    state: 'running',
+    progress: { done: 0, total: 0, phase: 'scanning files' },
+    result: null, partialResult: null, error: null, key,
+    startedAt: Date.now(), finishedAt: 0,
+  };
+  _jobs.analytics = job;
+  try {
+    let sessions = await loadSessionsAsync((p) => {
+      job.progress = { done: p.done || 0, total: p.total || 0, phase: p.phase || 'parsing' };
+    });
+    if (!includeHelpers) sessions = sessions.filter(s => !s.is_helper);
+    if (filterFrom) sessions = sessions.filter(s => s.date >= filterFrom);
+    if (filterTo) sessions = sessions.filter(s => s.date <= filterTo);
+
+    const fingerprint = _analyticsFingerprint(sessions, filterFrom, filterTo, includeHelpers ? 'h1' : 'h0');
+    try {
+      const cached = await sqliteIndex.getAggregateCacheAsync('analytics', fingerprint);
+      if (cached && cached.result) {
+        job.result = cached.result;
+        job.state = 'done';
+        job.finishedAt = Date.now();
+        log('JOB', `analytics served from cache`);
+        return;
+      }
+    } catch (e) { log('WARN', 'analytics cache read failed: ' + e.message); }
+
+    job.progress.phase = 'opencode batch query';
+    const opencodeCostCache = buildOpencodeCostCache(sessions);
+
+    job.progress = { done: 0, total: sessions.length, phase: 'aggregating' };
+    const agg = createCostAggregator();
+    const CHUNK = 50;
+    for (let i = 0; i < sessions.length; i += CHUNK) {
+      const slice = sessions.slice(i, i + CHUNK);
+      for (const s of slice) {
+        try {
+          const cost = computeSessionCostForAnalytics(s, opencodeCostCache);
+          agg.merge(s, cost);
+        } catch {}
+      }
+      job.progress.done = Math.min(i + CHUNK, sessions.length);
+      try { job.partialResult = agg.finalize(); } catch {}
+      await new Promise(r => setImmediate(r));
+    }
+
+    job.result = agg.finalize();
+    job.partialResult = null;
+    job.state = 'done';
+    job.finishedAt = Date.now();
+    log('JOB', `analytics done in ${job.finishedAt - job.startedAt}ms (${sessions.length} sessions)`);
+    try { await sqliteIndex.setAggregateCache('analytics', fingerprint, job.result); } catch {}
+  } catch (e) {
+    job.state = 'error';
+    job.error = e.message || String(e);
+    job.finishedAt = Date.now();
+    log('ERROR', `analytics job failed: ${job.error}`);
+  }
+}
+
+async function _runLeaderboardJob(includeHelpers) {
+  const job = {
+    state: 'running',
+    progress: { done: 0, total: 0, phase: 'scanning files' },
+    result: null, partialResult: null, error: null, key: 'lb|h' + (includeHelpers ? '1' : '0'),
+    startedAt: Date.now(), finishedAt: 0,
+  };
+  _jobs.leaderboard = job;
+  try {
+    let sessions = await loadSessionsAsync((p) => {
+      job.progress = { done: p.done || 0, total: p.total || 0, phase: p.phase || 'parsing' };
+    });
+    if (!includeHelpers) sessions = sessions.filter(s => !s.is_helper);
+    // Dedupe to conversation groups. Strategy:
+    //   - count of sessions = unique groups (612)
+    //   - msgs/hours = sum over REPRESENTATIVES only (avoids counting
+    //     agent→agent turns from 900 retries of the same prompt)
+    //   - cost = sum over ALL sessions (real money actually spent)
+    // The representative is the session with the MOST user_messages
+    // within the group (so we keep the "fullest" run).
+    const groupMap = new Map();
+    const allRollouts = sessions; // keep for cost sum
+    for (const s of sessions) {
+      const k = s.group_key || s.id;
+      const existing = groupMap.get(k);
+      if (!existing || (s.user_messages || 0) > (existing.user_messages || 0)) {
+        groupMap.set(k, s);
+      }
+    }
+    const representatives = Array.from(groupMap.values());
+    const uniqueSessionCount = representatives.length;
+    sessions = representatives; // the per-session loop iterates representatives
+    const fingerprint = _analyticsFingerprint(sessions, '', '', includeHelpers ? 'h1' : 'h0');
+    try {
+      const cached = await sqliteIndex.getAggregateCacheAsync('leaderboard', fingerprint);
+      if (cached && cached.result) {
+        job.result = cached.result;
+        job.state = 'done';
+        job.finishedAt = Date.now();
+        log('JOB', 'leaderboard served from cache');
+        return;
+      }
+    } catch {}
+
+    const opencodeCostCache = buildOpencodeCostCache(allRollouts);
+
+    // Real cost = sum over ALL rollouts (not deduped). Real money spent.
+    let realTotalCost = 0;
+    for (const s of allRollouts) {
+      try { realTotalCost += computeSessionCostForAnalytics(s, opencodeCostCache).cost || 0; } catch {}
+    }
+
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const fmtDay = (ts) => {
+      const d = new Date(ts);
+      return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+    };
+    const byDay = {};
+    const ensureDay = (date) => {
+      if (!byDay[date]) byDay[date] = { date, sessions: 0, messages: 0, hours: 0, cost: 0, agents: {} };
+      return byDay[date];
+    };
+    let totalMessages = 0, totalHours = 0, totalCost = 0;
+    const agentTotals = {};
+
+    job.progress = { done: 0, total: sessions.length, phase: 'aggregating' };
+    const CHUNK = 50;
+    for (let i = 0; i < sessions.length; i += CHUNK) {
+      const slice = sessions.slice(i, i + CHUNK);
+      for (const s of slice) {
+        try {
+          if (!s.first_ts || !s.last_ts) continue;
+          const tool = s.tool || 'unknown';
+          const cost = computeSessionCostForAnalytics(s, opencodeCostCache).cost || 0;
+          const day = s.date || fmtDay(s.last_ts);
+          const d = ensureDay(day);
+          d.sessions++;
+          // Only count EXACT user_messages (parsed from JSONL). Sessions
+          // without parsed metadata yet contribute 0 — numbers grow as the
+          // background warmer finishes. This avoids the msgs*0.5 estimate
+          // that massively inflates totals on Claude (tool_results) and on
+          // partially-parsed runs.
+          const msgs = s.user_messages > 0 ? s.user_messages : 0;
+          d.messages += msgs;
+          d.hours += Math.min((s.last_ts - s.first_ts) / 3600000, 16);
+          d.cost += cost;
+          d.agents[tool] = (d.agents[tool] || 0) + 1;
+          totalMessages += msgs;
+          totalHours += Math.min((s.last_ts - s.first_ts) / 3600000, 16);
+          totalCost += cost;
+          agentTotals[tool] = (agentTotals[tool] || 0) + 1;
+        } catch {}
+      }
+      job.progress.done = Math.min(i + CHUNK, sessions.length);
+      try {
+        const daily = Object.values(byDay).sort((a, b) => b.date.localeCompare(a.date));
+        let streak = 0;
+        const dt = new Date();
+        for (let k = 0; k < 365; k++) {
+          const d2 = dt.toISOString().slice(0, 10);
+          if (byDay[d2]) { streak++; dt.setDate(dt.getDate() - 1); } else break;
+        }
+        job.partialResult = {
+          anon: { id: '', name: 'You' },
+          today: byDay[todayStr] || { sessions: 0, messages: 0, hours: 0, cost: 0, agents: {} },
+          totals: {
+            sessions: uniqueSessionCount,
+            messages: totalMessages,
+            hours: Math.round(totalHours * 10) / 10,
+            cost: Math.round(realTotalCost * 100) / 100,
+          },
+          agents: agentTotals,
+          streak,
+          daily: daily.slice(0, 30),
+          activeDays: daily.length,
+        };
+      } catch {}
+      await new Promise(r => setImmediate(r));
+    }
+
+    let anon = { id: '', name: 'anon' };
+    try {
+      const { getOrCreateAnonId } = require('./data');
+      anon = getOrCreateAnonId();
+    } catch {}
+    const daily = Object.values(byDay).sort((a, b) => b.date.localeCompare(a.date));
+    let streak = 0;
+    const dt = new Date();
+    for (let k = 0; k < 365; k++) {
+      const d2 = dt.toISOString().slice(0, 10);
+      if (byDay[d2]) { streak++; dt.setDate(dt.getDate() - 1); } else break;
+    }
+    job.result = {
+      anon,
+      today: byDay[todayStr] || { sessions: 0, messages: 0, hours: 0, cost: 0, agents: {} },
+      totals: {
+        sessions: uniqueSessionCount,
+        messages: totalMessages,
+        hours: Math.round(totalHours * 10) / 10,
+        cost: Math.round(realTotalCost * 100) / 100,
+      },
+      agents: agentTotals,
+      streak,
+      daily: daily.slice(0, 30),
+      activeDays: daily.length,
+    };
+    job.partialResult = null;
+    job.state = 'done';
+    job.finishedAt = Date.now();
+    log('JOB', `leaderboard done in ${job.finishedAt - job.startedAt}ms (${sessions.length} sessions)`);
+    try { await sqliteIndex.setAggregateCache('leaderboard', fingerprint, job.result); } catch {}
+  } catch (e) {
+    job.state = 'error';
+    job.error = e.message || String(e);
+    job.finishedAt = Date.now();
+    log('ERROR', `leaderboard job failed: ${job.error}`);
+  }
+}
+
+function _jobResponse(job) {
+  if (!job) return { status: 'idle' };
+  if (job.state === 'done') {
+    return { status: 'done', result: job.result, ms: job.finishedAt - job.startedAt };
+  }
+  if (job.state === 'error') {
+    return { status: 'error', error: job.error };
+  }
+  return {
+    status: 'running',
+    progress: job.progress,
+    partialResult: job.partialResult || null,
+    elapsedMs: Date.now() - job.startedAt,
+  };
+}
+
 // ── Logging ──────────────────────────────────
-const LOG_VERBOSE = process.env.CODEDASH_LOG !== '0';
+// CODEDASH_LOG=0 (default) → quiet stdout (only ERROR/WARN/JOB), full log to
+// ~/.codedash/logs/server.log. CODEDASH_LOG=1 → verbose stdout mirror.
+const fs_log = require('fs');
+const path_log = require('path');
+const os_log = require('os');
+const LOG_DIR = path_log.join(os_log.homedir(), '.codedash', 'logs');
+try { fs_log.mkdirSync(LOG_DIR, { recursive: true }); } catch {}
+const LOG_FILE = path_log.join(LOG_DIR, 'server.log');
+let _logStream = null;
+try { _logStream = fs_log.createWriteStream(LOG_FILE, { flags: 'a' }); } catch {}
+
+const LOG_MODE = (process.env.CODEDASH_LOG === '1' || process.env.CODEDASH_LOG === 'verbose') ? 'verbose' : 'quiet';
+const STDOUT_TAGS = new Set(['ERROR', 'WARN', 'JOB']);
 
 function log(tag, msg, data) {
-  if (!LOG_VERBOSE && tag !== 'ERROR') return;
   const ts = new Date().toLocaleTimeString('en-GB');
-  const color = tag === 'ERROR' ? '\x1b[31m' : tag === 'WARN' ? '\x1b[33m' : tag === 'API' ? '\x1b[36m' : '\x1b[2m';
+  if (_logStream) {
+    try {
+      let plain = `${ts} [${tag}] ${msg}`;
+      if (data !== undefined) {
+        const str = typeof data === 'object' ? JSON.stringify(data) : String(data);
+        plain += ' ' + (str.length > 500 ? str.slice(0, 500) + '...' : str);
+      }
+      _logStream.write(plain + '\n');
+    } catch {}
+  }
+  if (LOG_MODE !== 'verbose' && !STDOUT_TAGS.has(tag)) return;
+  const color = tag === 'ERROR' ? '\x1b[31m' : tag === 'WARN' ? '\x1b[33m' : tag === 'API' ? '\x1b[36m' : tag === 'JOB' ? '\x1b[32m' : '\x1b[2m';
   let line = `  ${color}${ts} [${tag}]\x1b[0m ${msg}`;
   if (data !== undefined) {
     const str = typeof data === 'object' ? JSON.stringify(data) : String(data);
@@ -33,7 +312,7 @@ function startServer(host, port, openBrowser = true) {
 
     // Log all API requests (skip static & frequent polls)
     const isApi = pathname.startsWith('/api/');
-    const isFrequent = pathname === '/api/active' || pathname === '/api/version';
+    const isFrequent = pathname === '/api/active' || pathname === '/api/version' || pathname === '/api/warming' || pathname === '/api/sessions' || pathname === '/api/sqlite-status';
     if (isApi && !isFrequent) {
       const params = Object.fromEntries(parsed.searchParams);
       log('API', `${req.method} ${pathname}`, Object.keys(params).length ? params : undefined);
@@ -66,12 +345,23 @@ function startServer(host, port, openBrowser = true) {
     // ── Sessions API ────────────────────────
     else if (req.method === 'GET' && pathname === '/api/sessions') {
       const sessions = loadSessions();
+      // By default hide codex_exec helper sessions (sub-agent runs) — the
+      // user can request them via ?include_helpers=1. Counts for helpers are
+      // sent as a header so the UI can show a "N helper sessions hidden" toggle.
+      const includeHelpers = parsed.searchParams.get('include_helpers') === '1';
+      const helperCount = sessions.filter(s => s.is_helper).length;
+      const filtered = includeHelpers ? sessions : sessions.filter(s => !s.is_helper);
+      // Preserve transient flags on the array
+      filtered._loading = sessions._loading;
+      filtered._warming = sessions._warming;
+      filtered._warmingProgress = sessions._warmingProgress;
+
       const byTool = {};
-      sessions.forEach(s => { byTool[s.tool] = (byTool[s.tool] || 0) + 1; });
-      log('DATA', `loaded ${sessions.length} sessions${sessions._loading ? ' (cursor loading...)' : ''}`, byTool);
-      // Send _loading flag as header to avoid polluting array response
+      filtered.forEach(s => { byTool[s.tool] = (byTool[s.tool] || 0) + 1; });
+      log('DATA', `loaded ${filtered.length} sessions (hidden ${helperCount} helpers)${sessions._loading ? ' (cursor loading...)' : ''}`, byTool);
       if (sessions._loading) res.setHeader('X-Loading', '1');
-      json(res, sessions);
+      if (helperCount > 0) res.setHeader('X-Helper-Count', String(helperCount));
+      json(res, filtered);
     }
 
     else if (req.method === 'GET' && pathname.startsWith('/api/session/') && !pathname.includes('/export')) {
@@ -162,6 +452,17 @@ function startServer(host, port, openBrowser = true) {
       const project = parsed.searchParams.get('project') || '';
       const info = getProjectGitInfo(project);
       json(res, info || { error: 'No git repo found' });
+    }
+
+    // ── Warming + SQLite index status ─────────
+    else if (req.method === 'GET' && pathname === '/api/warming') {
+      json(res, getWarmingStatus());
+    }
+
+    else if (req.method === 'GET' && pathname === '/api/sqlite-status') {
+      let indexStatus = {};
+      try { indexStatus = sqliteIndex.getIndexStatus(); } catch {}
+      json(res, { backfill: getSqliteBackfillStatus(), index: indexStatus });
     }
 
     // ── Active sessions ─────────────────────
@@ -263,8 +564,8 @@ function startServer(host, port, openBrowser = true) {
     // ── Full-text search ──────────────────────
     else if (req.method === 'GET' && pathname === '/api/search') {
       const q = parsed.searchParams.get('q') || '';
-      const sessions = loadSessions();
-      const results = searchFullText(q, sessions);
+      // Uses SQLite FTS5 index directly — no loadSessions needed
+      const results = searchFullText(q, []);
       json(res, results);
     }
 
@@ -284,15 +585,56 @@ function startServer(host, port, openBrowser = true) {
       json(res, data);
     }
 
-    // ── Cost analytics ──────────────────────
+    // ── Cost analytics (async job + live partial) ──────────────────
     else if (req.method === 'GET' && pathname === '/api/analytics/cost') {
-      let sessions = loadSessions();
-      const from = parsed.searchParams.get('from');
-      const to = parsed.searchParams.get('to');
-      if (from) sessions = sessions.filter(s => s.date >= from);
-      if (to) sessions = sessions.filter(s => s.date <= to);
-      const data = getCostAnalytics(sessions);
-      json(res, data);
+      const from = parsed.searchParams.get('from') || '';
+      const to = parsed.searchParams.get('to') || '';
+      const includeHelpers = parsed.searchParams.get('include_helpers') === '1';
+      const key = from + '|' + to + '|h' + (includeHelpers ? '1' : '0');
+      const job = _jobs.analytics;
+      if (job && job.state === 'done' && job.key === key) {
+        json(res, { status: 'done', ...job.result });
+      } else if (job && job.state === 'running' && job.key === key) {
+        json(res, _jobResponse(job));
+      } else {
+        // Try persistent cache FIRST so repeat visits don't trigger a rerun.
+        // Uses the sync in-memory sessions cache (fast when hot).
+        let served = false;
+        try {
+          const sessions = loadSessions();
+          let filtered = includeHelpers ? sessions : sessions.filter(s => !s.is_helper);
+          if (from) filtered = filtered.filter(s => s.date >= from);
+          if (to) filtered = filtered.filter(s => s.date <= to);
+          const fingerprint = _analyticsFingerprint(filtered, from, to, includeHelpers ? 'h1' : 'h0');
+          sqliteIndex.getAggregateCacheAsync('analytics', fingerprint).then(cached => {
+            if (served) return;
+            if (cached && cached.result) {
+              served = true;
+              _jobs.analytics = {
+                state: 'done', key, result: cached.result, partialResult: null,
+                progress: { done: filtered.length, total: filtered.length, phase: 'cached' },
+                error: null, startedAt: cached.computedAt, finishedAt: cached.computedAt,
+              };
+              json(res, { status: 'done', ...cached.result, _cached: true });
+            } else {
+              served = true;
+              _runAnalyticsJob(from, to, includeHelpers);
+              json(res, _jobResponse(_jobs.analytics));
+            }
+          }).catch(() => {
+            if (served) return;
+            served = true;
+            _runAnalyticsJob(from, to, includeHelpers);
+            json(res, _jobResponse(_jobs.analytics));
+          });
+        } catch (e) {
+          if (!served) {
+            served = true;
+            _runAnalyticsJob(from, to, includeHelpers);
+            json(res, _jobResponse(_jobs.analytics));
+          }
+        }
+      }
     }
 
     // ── LLM Config ────────────────────────────
@@ -356,9 +698,51 @@ function startServer(host, port, openBrowser = true) {
     }
 
     // ── Leaderboard stats ────────────────────
+    // ── Leaderboard (async job + live partial) ─────────────────
     else if (req.method === 'GET' && pathname === '/api/leaderboard') {
-      const stats = getLeaderboardStats();
-      json(res, stats);
+      const includeHelpers = parsed.searchParams.get('include_helpers') === '1';
+      const expectedKey = 'lb|h' + (includeHelpers ? '1' : '0');
+      const job = _jobs.leaderboard;
+      if (job && job.state === 'done' && job.key === expectedKey) {
+        json(res, { status: 'done', ...job.result });
+      } else if (job && job.state === 'running' && job.key === expectedKey) {
+        json(res, _jobResponse(job));
+      } else {
+        // Try persistent cache first (instant on repeat visits)
+        let served = false;
+        try {
+          const sessions = loadSessions();
+          const filtered = includeHelpers ? sessions : sessions.filter(s => !s.is_helper);
+          const fingerprint = _analyticsFingerprint(filtered, '', '', includeHelpers ? 'h1' : 'h0');
+          sqliteIndex.getAggregateCacheAsync('leaderboard', fingerprint).then(cached => {
+            if (served) return;
+            if (cached && cached.result) {
+              served = true;
+              _jobs.leaderboard = {
+                state: 'done', key: expectedKey, result: cached.result, partialResult: null,
+                progress: { done: filtered.length, total: filtered.length, phase: 'cached' },
+                error: null, startedAt: cached.computedAt, finishedAt: cached.computedAt,
+              };
+              json(res, { status: 'done', ...cached.result, _cached: true });
+            } else {
+              served = true;
+              _runLeaderboardJob(includeHelpers);
+              json(res, _jobResponse(_jobs.leaderboard));
+            }
+          }).catch(() => {
+            if (served) return;
+            served = true;
+            _runLeaderboardJob(includeHelpers);
+            json(res, _jobResponse(_jobs.leaderboard));
+          });
+        } catch (e) {
+          if (!served) {
+            served = true;
+            _runLeaderboardJob(includeHelpers);
+            json(res, _jobResponse(_jobs.leaderboard));
+          }
+        }
+      }
     }
 
     else if (req.method === 'POST' && pathname === '/api/leaderboard/sync') {

--- a/src/server.js
+++ b/src/server.js
@@ -735,26 +735,51 @@ function startServer(host, port, openBrowser = true) {
           const sessions = loadSessions();
           const filtered = includeHelpers ? sessions : sessions.filter(s => !s.is_helper);
           const fingerprint = _analyticsFingerprint(filtered, '', '', includeHelpers ? 'h1' : 'h0');
+          // Install a synchronous placeholder job BEFORE the async cache
+          // read so concurrent requests for the same key don't each kick
+          // off their own _runLeaderboardJob. Only the request that owns
+          // the placeholder proceeds to start the real job.
+          const placeholderJob = {
+            state: 'running',
+            key: expectedKey,
+            result: null,
+            partialResult: null,
+            progress: { done: 0, total: filtered.length, phase: 'cache' },
+            error: null,
+            startedAt: Date.now(),
+            finishedAt: null,
+          };
+          _jobs.leaderboard = placeholderJob;
           sqliteIndex.getAggregateCacheAsync('leaderboard', fingerprint).then(cached => {
             if (served) return;
             if (cached && cached.result) {
               served = true;
-              _jobs.leaderboard = {
-                state: 'done', key: expectedKey, result: cached.result, partialResult: null,
-                progress: { done: filtered.length, total: filtered.length, phase: 'cached' },
-                error: null, startedAt: cached.computedAt, finishedAt: cached.computedAt,
-              };
+              if (_jobs.leaderboard === placeholderJob) {
+                _jobs.leaderboard = {
+                  state: 'done', key: expectedKey, result: cached.result, partialResult: null,
+                  progress: { done: filtered.length, total: filtered.length, phase: 'cached' },
+                  error: null, startedAt: cached.computedAt, finishedAt: cached.computedAt,
+                };
+              }
               json(res, { status: 'done', ...cached.result, _cached: true });
             } else {
               served = true;
-              _runLeaderboardJob(includeHelpers);
-              json(res, _jobResponse(_jobs.leaderboard));
+              if (_jobs.leaderboard === placeholderJob) {
+                _runLeaderboardJob(includeHelpers);
+                json(res, _jobResponse(_jobs.leaderboard));
+              } else {
+                json(res, _jobResponse(_jobs.leaderboard));
+              }
             }
           }).catch(() => {
             if (served) return;
             served = true;
-            _runLeaderboardJob(includeHelpers);
-            json(res, _jobResponse(_jobs.leaderboard));
+            if (_jobs.leaderboard === placeholderJob) {
+              _runLeaderboardJob(includeHelpers);
+              json(res, _jobResponse(_jobs.leaderboard));
+            } else {
+              json(res, _jobResponse(_jobs.leaderboard));
+            }
           });
         } catch (e) {
           if (!served) {

--- a/src/sqlite-index.js
+++ b/src/sqlite-index.js
@@ -1,0 +1,479 @@
+// SQLite + FTS5 index for sessions, messages, and full-text search.
+//
+// Why SQLite: (1) codedash already shells to `sqlite3` CLI for opencode/kiro,
+// zero new deps. (2) FTS5 is built into modern sqlite3 and is the best
+// local full-text search engine available. (3) Persistent, mmap'd B-tree —
+// billions of rows possible, queries in milliseconds.
+//
+// Schema:
+//   sessions          one row per session (metadata + aggregated cost)
+//   messages          one row per user/assistant message, chronological
+//   messages_fts      FTS5 virtual table shadowing messages.content
+//   files_seen        (path, mtime, size) for incremental ingest
+//
+// All ingest goes through SQL transactions. Queries avoid Node ↔ child_process
+// overhead by using a single sqlite3 invocation per call.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn, spawnSync } = require('child_process');
+
+const DB_DIR = path.join(os.homedir(), '.codedash', 'cache');
+try { fs.mkdirSync(DB_DIR, { recursive: true }); } catch {}
+const DB_FILE = path.join(DB_DIR, 'index.sqlite');
+
+// ── sqlite3 CLI helpers ─────────────────────────────────────
+// Query path stays sync via spawnSync (fast, small SQL). Write path (large
+// batches) goes through async spawn so it doesn't block the event loop.
+
+// Use sqlite3 -cmd to set busy_timeout before running the query. This sets
+// it on the connection without producing extra JSON output rows.
+const _CMD_BUSY = '.timeout 30000';
+
+function _exec(sql, opts) {
+  opts = opts || {};
+  const args = ['-cmd', _CMD_BUSY, DB_FILE];
+  if (opts.json) args.push('-json');
+  args.push(sql);
+  const r = spawnSync('sqlite3', args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: opts.timeout || 60000,
+    windowsHide: true,
+  });
+  if (r.error) throw r.error;
+  if (r.status !== 0) throw new Error('sqlite3 exit ' + r.status + ': ' + r.stderr);
+  return r.stdout || '';
+}
+
+function _execJson(sql, opts) {
+  const out = _exec(sql, Object.assign({}, opts || {}, { json: true })).trim();
+  if (!out) return [];
+  try { return JSON.parse(out); } catch { return []; }
+}
+
+// Async variant: streams SQL to sqlite3 stdin without blocking the event loop.
+// Returns a Promise<string> with stdout.
+function _execAsync(sql, opts) {
+  opts = opts || {};
+  return new Promise((resolve, reject) => {
+    const args = ['-cmd', _CMD_BUSY, DB_FILE];
+    if (opts.json) args.push('-json');
+    const child = spawn('sqlite3', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let finished = false;
+    const to = setTimeout(() => {
+      if (!finished) {
+        finished = true;
+        try { child.kill('SIGKILL'); } catch {}
+        reject(new Error('sqlite3 timeout'));
+      }
+    }, opts.timeout || 120000);
+
+    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+    child.on('error', e => { if (!finished) { finished = true; clearTimeout(to); reject(e); } });
+    child.on('close', code => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(to);
+      if (code !== 0) return reject(new Error('sqlite3 exit ' + code + ': ' + stderr));
+      resolve(stdout);
+    });
+    // Write SQL to stdin and close
+    try {
+      child.stdin.write(sql);
+      child.stdin.end();
+    } catch (e) {
+      if (!finished) { finished = true; clearTimeout(to); reject(e); }
+    }
+  });
+}
+
+// ── Schema ──────────────────────────────────────────────────
+
+const SCHEMA = `
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous  = NORMAL;
+PRAGMA temp_store   = MEMORY;
+PRAGMA mmap_size    = 268435456;
+PRAGMA busy_timeout = 30000;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id                  TEXT PRIMARY KEY,
+  tool                TEXT NOT NULL,
+  project             TEXT,
+  project_short       TEXT,
+  first_ts            REAL,
+  last_ts             REAL,
+  messages            INTEGER DEFAULT 0,
+  user_messages       INTEGER DEFAULT 0,
+  file_size           INTEGER DEFAULT 0,
+  cost                REAL DEFAULT 0,
+  input_tokens        INTEGER DEFAULT 0,
+  output_tokens       INTEGER DEFAULT 0,
+  cache_read_tokens   INTEGER DEFAULT 0,
+  cache_create_tokens INTEGER DEFAULT 0,
+  model               TEXT,
+  first_message       TEXT,
+  mcp_servers         TEXT,      -- JSON array
+  skills              TEXT,      -- JSON array
+  source_file         TEXT,
+  source_mtime        REAL,
+  source_size         INTEGER,
+  indexed_at          INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_tool    ON sessions(tool);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_ts ON sessions(last_ts DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
+
+CREATE TABLE IF NOT EXISTS messages (
+  rowid      INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  seq        INTEGER NOT NULL,
+  role       TEXT NOT NULL,
+  ts         REAL,
+  content    TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+  content,
+  session_id UNINDEXED,
+  role       UNINDEXED,
+  seq        UNINDEXED,
+  tokenize = 'porter unicode61'
+);
+
+CREATE TABLE IF NOT EXISTS daily_stats (
+  session_id TEXT NOT NULL,
+  day        TEXT NOT NULL,
+  messages   INTEGER DEFAULT 0,
+  hours      REAL DEFAULT 0,
+  tool       TEXT,
+  PRIMARY KEY (session_id, day)
+);
+CREATE INDEX IF NOT EXISTS idx_daily_day ON daily_stats(day);
+
+CREATE TABLE IF NOT EXISTS files_seen (
+  path       TEXT PRIMARY KEY,
+  mtime      REAL,
+  size       INTEGER,
+  session_id TEXT,
+  indexed_at INTEGER
+);
+
+-- Persistent aggregate result cache (analytics, leaderboard, ...)
+-- Keyed by query fingerprint; holds a single JSON blob row per kind.
+CREATE TABLE IF NOT EXISTS aggregate_cache (
+  kind         TEXT NOT NULL,    -- 'analytics' | 'leaderboard' | ...
+  fingerprint  TEXT NOT NULL,    -- input hash (filters + data version)
+  result_json  TEXT NOT NULL,
+  computed_at  INTEGER NOT NULL,
+  PRIMARY KEY (kind, fingerprint)
+);
+`;
+
+let _schemaReady = false;
+function ensureSchema() {
+  if (_schemaReady) return;
+  try {
+    _exec(SCHEMA);
+    _schemaReady = true;
+  } catch (e) {
+    throw new Error('Failed to init SQLite index: ' + e.message);
+  }
+}
+
+// ── Incremental ingest ───────────────────────────────────────
+
+function sqlEscape(s) {
+  if (s === null || s === undefined) return 'NULL';
+  return "'" + String(s).replace(/'/g, "''") + "'";
+}
+
+// Check if a file path is already indexed with matching mtime+size.
+function isFileCurrent(filePath) {
+  ensureSchema();
+  let stat;
+  try { stat = fs.statSync(filePath); } catch { return false; }
+  const rows = _execJson(
+    `SELECT mtime, size FROM files_seen WHERE path = ${sqlEscape(filePath)} LIMIT 1`
+  );
+  if (rows.length === 0) return false;
+  return rows[0].mtime === stat.mtimeMs && rows[0].size === stat.size;
+}
+
+// Bulk version: load the entire files_seen map into memory in a single query.
+// Used by the backfill loop to avoid an N×sync-SQL fanout.
+function loadAllFilesSeen() {
+  ensureSchema();
+  const rows = _execJson(`SELECT path, mtime, size FROM files_seen`);
+  const map = new Map();
+  for (const r of rows) map.set(r.path, { mtime: r.mtime, size: r.size });
+  return map;
+}
+
+// Bulk-index a batch of sessions + messages asynchronously.
+// Builds a single transaction SQL blob, pipes to sqlite3 via async spawn.
+// Returns a Promise that resolves when sqlite3 finishes writing.
+function indexBatchAsync(batch) {
+  if (!batch || batch.length === 0) return Promise.resolve();
+  ensureSchema();
+
+  const now = Date.now();
+  const parts = ['BEGIN;'];
+
+  for (const item of batch) {
+    const s = item.session;
+    if (!s || !s.id) continue;
+
+    // Delete old rows for this session (re-ingest case)
+    parts.push(`DELETE FROM sessions WHERE id = ${sqlEscape(s.id)};`);
+    parts.push(`DELETE FROM messages WHERE session_id = ${sqlEscape(s.id)};`);
+    parts.push(`DELETE FROM messages_fts WHERE session_id = ${sqlEscape(s.id)};`);
+    parts.push(`DELETE FROM daily_stats WHERE session_id = ${sqlEscape(s.id)};`);
+
+    // Insert session
+    parts.push(
+      `INSERT INTO sessions (id, tool, project, project_short, first_ts, last_ts, messages, user_messages, file_size, cost, input_tokens, output_tokens, cache_read_tokens, cache_create_tokens, model, first_message, mcp_servers, skills, source_file, source_mtime, source_size, indexed_at) VALUES (` +
+      [
+        sqlEscape(s.id),
+        sqlEscape(s.tool || 'unknown'),
+        sqlEscape(s.project || ''),
+        sqlEscape(s.project_short || ''),
+        s.first_ts || 0,
+        s.last_ts || 0,
+        s.messages || 0,
+        s.user_messages || 0,
+        s.file_size || 0,
+        s.cost || 0,
+        s.input_tokens || 0,
+        s.output_tokens || 0,
+        s.cache_read_tokens || 0,
+        s.cache_create_tokens || 0,
+        sqlEscape(s.model || ''),
+        sqlEscape((s.first_message || '').slice(0, 500)),
+        sqlEscape(JSON.stringify(s.mcp_servers || [])),
+        sqlEscape(JSON.stringify(s.skills || [])),
+        sqlEscape(item.filePath || ''),
+        s.source_mtime || 0,
+        s.source_size || 0,
+        now,
+      ].join(', ') + ');'
+    );
+
+    // Messages + FTS
+    const msgs = item.messages || [];
+    for (const m of msgs) {
+      if (!m.content) continue;
+      const esc = sqlEscape(m.content.slice(0, 8000));
+      parts.push(
+        `INSERT INTO messages (session_id, seq, role, ts, content) VALUES (` +
+        [
+          sqlEscape(s.id),
+          m.seq || 0,
+          sqlEscape(m.role || ''),
+          m.ts || 0,
+          esc,
+        ].join(', ') + ');'
+      );
+      parts.push(
+        `INSERT INTO messages_fts (content, session_id, role, seq) VALUES (` +
+        [esc, sqlEscape(s.id), sqlEscape(m.role || ''), m.seq || 0].join(', ') + ');'
+      );
+    }
+
+    // Daily breakdown
+    const daily = item.daily || {};
+    for (const day in daily) {
+      const d = daily[day];
+      parts.push(
+        `INSERT INTO daily_stats (session_id, day, messages, hours, tool) VALUES (` +
+        [
+          sqlEscape(s.id),
+          sqlEscape(day),
+          d.messages || 0,
+          d.hours || 0,
+          sqlEscape(s.tool || 'unknown'),
+        ].join(', ') + ');'
+      );
+    }
+
+    // Record file stamp
+    if (item.filePath && s.source_mtime && s.source_size) {
+      parts.push(
+        `INSERT OR REPLACE INTO files_seen (path, mtime, size, session_id, indexed_at) VALUES (` +
+        [
+          sqlEscape(item.filePath),
+          s.source_mtime,
+          s.source_size,
+          sqlEscape(s.id),
+          now,
+        ].join(', ') + ');'
+      );
+    }
+  }
+
+  parts.push('COMMIT;');
+  return _execAsync(parts.join('\n'), { timeout: 120000 }).catch((e) => {
+    // Try to rollback via sync exec (fire and forget)
+    try { _exec('ROLLBACK;'); } catch {}
+    throw e;
+  });
+}
+
+// Alias for backward compat — returns the promise.
+const indexBatch = indexBatchAsync;
+
+// ── Query API ───────────────────────────────────────────────
+
+function search(query, limit) {
+  ensureSchema();
+  if (!query || query.trim().length < 2) return [];
+  limit = Math.max(1, Math.min(500, limit || 100));
+
+  // Escape FTS5 special chars — we treat the input as a phrase
+  const phrase = '"' + query.replace(/"/g, '""') + '"';
+  const sql = `
+    SELECT session_id, role, seq,
+      snippet(messages_fts, 0, '<<', '>>', '...', 20) AS snippet
+    FROM messages_fts
+    WHERE content MATCH ${sqlEscape(phrase)}
+    ORDER BY rank
+    LIMIT ${limit};
+  `;
+  try {
+    return _execJson(sql, { timeout: 15000 });
+  } catch {
+    return [];
+  }
+}
+
+function getSessionStats() {
+  ensureSchema();
+  const rows = _execJson(`
+    SELECT
+      COUNT(*) AS session_count,
+      SUM(messages) AS total_messages,
+      SUM(user_messages) AS total_user_messages,
+      SUM(cost) AS total_cost,
+      SUM(input_tokens + output_tokens + cache_read_tokens + cache_create_tokens) AS total_tokens
+    FROM sessions;
+  `);
+  return rows[0] || {};
+}
+
+function getDailyStats(limit) {
+  ensureSchema();
+  limit = limit || 30;
+  return _execJson(`
+    SELECT day,
+           SUM(messages) AS messages,
+           SUM(hours) AS hours,
+           COUNT(DISTINCT session_id) AS sessions
+    FROM daily_stats
+    GROUP BY day
+    ORDER BY day DESC
+    LIMIT ${limit};
+  `);
+}
+
+function getCountByTool() {
+  ensureSchema();
+  return _execJson(`SELECT tool, COUNT(*) AS n FROM sessions GROUP BY tool ORDER BY n DESC;`);
+}
+
+// ── Aggregate result cache ──────────────────────────────────
+// Persistent cache for pre-computed analytics/leaderboard results.
+// The caller decides the fingerprint (e.g. max(session.last_ts) + session
+// count + filter). On cache hit: O(1) SQL read, milliseconds.
+
+function getAggregateCache(kind, fingerprint) {
+  ensureSchema();
+  const rows = _execJson(
+    `SELECT result_json, computed_at FROM aggregate_cache WHERE kind = ${sqlEscape(kind)} AND fingerprint = ${sqlEscape(fingerprint)} LIMIT 1`
+  );
+  if (rows.length === 0) return null;
+  try {
+    return {
+      result: JSON.parse(rows[0].result_json),
+      computedAt: rows[0].computed_at,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getAggregateCacheAsync(kind, fingerprint) {
+  ensureSchema();
+  const out = await _execAsync(
+    `SELECT result_json, computed_at FROM aggregate_cache WHERE kind = ${sqlEscape(kind)} AND fingerprint = ${sqlEscape(fingerprint)} LIMIT 1`,
+    { json: true, timeout: 10000 }
+  );
+  let rows;
+  try { rows = JSON.parse(out.trim() || '[]'); } catch { return null; }
+  if (!rows || rows.length === 0) return null;
+  try {
+    return {
+      result: JSON.parse(rows[0].result_json),
+      computedAt: rows[0].computed_at,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function setAggregateCache(kind, fingerprint, result) {
+  ensureSchema();
+  const json = JSON.stringify(result);
+  const sql =
+    `DELETE FROM aggregate_cache WHERE kind = ${sqlEscape(kind)};\n` +  // keep only latest per kind
+    `INSERT INTO aggregate_cache (kind, fingerprint, result_json, computed_at) VALUES (` +
+    [sqlEscape(kind), sqlEscape(fingerprint), sqlEscape(json), Date.now()].join(', ') +
+    `);`;
+  try { await _execAsync(sql, { timeout: 30000 }); } catch {}
+}
+
+function getIndexStatus() {
+  ensureSchema();
+  const sess = _execJson(`SELECT COUNT(*) AS n FROM sessions`);
+  const msgs = _execJson(`SELECT COUNT(*) AS n FROM messages`);
+  const files = _execJson(`SELECT COUNT(*) AS n FROM files_seen`);
+  let size = 0;
+  try { size = fs.statSync(DB_FILE).size; } catch {}
+  return {
+    sessions: (sess[0] || {}).n || 0,
+    messages: (msgs[0] || {}).n || 0,
+    files: (files[0] || {}).n || 0,
+    db_bytes: size,
+    db_path: DB_FILE,
+  };
+}
+
+module.exports = {
+  DB_FILE,
+  ensureSchema,
+  isFileCurrent,
+  indexBatch,
+  indexBatchAsync,
+  loadAllFilesSeen,
+  search,
+  getSessionStats,
+  getDailyStats,
+  getCountByTool,
+  getIndexStatus,
+  getAggregateCache,
+  getAggregateCacheAsync,
+  setAggregateCache,
+  _exec,
+  _execAsync,
+  _execJson,
+};

--- a/src/sqlite-index.js
+++ b/src/sqlite-index.js
@@ -33,9 +33,12 @@ const _CMD_BUSY = '.timeout 30000';
 
 function _exec(sql, opts) {
   opts = opts || {};
-  const args = ['-cmd', _CMD_BUSY, DB_FILE];
+  // sqlite3 CLI stops option parsing once it sees the database filename, so
+  // all flags (including -json) must come BEFORE DB_FILE or they're treated
+  // as part of the SQL input and silently ignored.
+  const args = ['-cmd', _CMD_BUSY];
   if (opts.json) args.push('-json');
-  args.push(sql);
+  args.push(DB_FILE, sql);
   const r = spawnSync('sqlite3', args, {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
@@ -58,8 +61,10 @@ function _execJson(sql, opts) {
 function _execAsync(sql, opts) {
   opts = opts || {};
   return new Promise((resolve, reject) => {
-    const args = ['-cmd', _CMD_BUSY, DB_FILE];
+    // Options must come BEFORE DB_FILE (see _exec comment)
+    const args = ['-cmd', _CMD_BUSY];
     if (opts.json) args.push('-json');
+    args.push(DB_FILE);
     const child = spawn('sqlite3', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,

--- a/src/terminals.js
+++ b/src/terminals.js
@@ -251,9 +251,11 @@ function focusTerminalByPid(pid) {
         return focusCmuxWorkspace(pid);
       }
 
-      // iTerm2: activate and select the right tab/window by tty
+      // iTerm2: activate and select the right tab/window/session by tty
       if (detectedTerminal === 'iTerm2' || !detectedTerminal) {
         try {
+          // Normalize tty: "ttys005" → "ttys005", "/dev/ttys005" → "ttys005"
+          const ttyNorm = ttyOut.replace('/dev/', '');
           const script = `
             tell application "iTerm"
               activate
@@ -261,9 +263,10 @@ function focusTerminalByPid(pid) {
                 repeat with t in tabs of w
                   repeat with s in sessions of t
                     set sessionTTY to tty of s
-                    if sessionTTY contains "${ttyOut}" or "${ttyOut}" contains sessionTTY then
+                    if sessionTTY contains "${ttyNorm}" then
                       select w
                       tell w to select t
+                      tell t to select s
                       return "found"
                     end if
                   end repeat

--- a/tests/copilot-client.test.js
+++ b/tests/copilot-client.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests for src/copilot-client.js
+ *
+ * Runnable with: node tests/copilot-client.test.js
+ * Uses only Node.js built-in assert module (zero deps).
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// Module under test
+const copilot = require('../src/copilot-client');
+
+async function runTests() {
+  console.log('copilot-client tests');
+  let passed = 0;
+
+  // ── Test 1: isAvailable returns boolean ────────────────────────
+  console.log('  test isAvailable returns boolean...');
+  {
+    const result = copilot.isAvailable();
+    assert.strictEqual(typeof result, 'boolean', 'isAvailable() must return a boolean');
+    console.log(`    isAvailable() = ${result}`);
+    passed++;
+  }
+
+  // ── Test 2: getStatus returns expected shape ───────────────────
+  console.log('  test getStatus returns expected shape...');
+  {
+    const status = copilot.getStatus();
+    assert.ok(status !== null && typeof status === 'object', 'getStatus() must return an object');
+    assert.strictEqual(typeof status.authenticated, 'boolean', 'status.authenticated must be boolean');
+    assert.strictEqual(typeof status.model, 'string', 'status.model must be string');
+    assert.strictEqual(typeof status.api_base, 'string', 'status.api_base must be string');
+    assert.ok('token_expires_at' in status, 'status must have token_expires_at');
+    assert.strictEqual(typeof status.token_expires_at, 'number', 'status.token_expires_at must be number');
+    // Default model should be gpt-4.1
+    assert.strictEqual(status.model, 'gpt-4.1', 'default model should be gpt-4.1');
+    console.log(`    status = ${JSON.stringify(status)}`);
+    passed++;
+  }
+
+  // ── Test 3: token loading from credential file ─────────────────
+  console.log('  test token loading from credential file...');
+  {
+    const credPath = path.join(os.homedir(), '.copilot', 'auth', 'credential.json');
+    const appsPath = path.join(os.homedir(), '.config', 'github-copilot', 'apps.json');
+    const hasCredFile = fs.existsSync(credPath);
+    const hasAppsFile = fs.existsSync(appsPath);
+
+    if (hasCredFile) {
+      // Verify the file is valid JSON with a token field
+      const data = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+      assert.ok(data.token && typeof data.token === 'string', 'credential.json should have a string token');
+      assert.ok(data.token.length > 0, 'token should not be empty');
+      console.log(`    credential.json found, token starts with: ${data.token.substring(0, 8)}...`);
+    } else if (hasAppsFile) {
+      const data = JSON.parse(fs.readFileSync(appsPath, 'utf8'));
+      const ghKey = Object.keys(data).find(k => k.startsWith('github.com'));
+      assert.ok(ghKey, 'apps.json should have a github.com key');
+      assert.ok(data[ghKey].oauth_token, 'apps.json github.com entry should have oauth_token');
+      console.log(`    apps.json found, key: ${ghKey}`);
+    } else {
+      console.log('    (no credential files found, skipping content verification)');
+    }
+
+    // isAvailable should match file presence
+    const available = copilot.isAvailable();
+    assert.strictEqual(available, hasCredFile || hasAppsFile,
+      `isAvailable() should be ${hasCredFile || hasAppsFile} given credential file presence`);
+    passed++;
+  }
+
+  // ── Test 4: summarizeSession integration (skip if no token) ────
+  console.log('  test summarizeSession integration...');
+  {
+    if (!copilot.isAvailable()) {
+      console.log('    SKIPPED: no Copilot credentials available');
+    } else {
+      try {
+        const testMessages = [
+          { role: 'user', content: 'Create a hello world function in JavaScript' },
+          { role: 'assistant', content: 'function helloWorld() { console.log("Hello, World!"); }' },
+          { role: 'user', content: 'Add a parameter for the name' },
+          { role: 'assistant', content: 'function helloWorld(name) { console.log(`Hello, ${name}!`); }' },
+        ];
+        const summary = await copilot.summarizeSession(testMessages);
+        assert.strictEqual(typeof summary, 'string', 'summary must be a string');
+        assert.ok(summary.length > 0, 'summary should not be empty');
+        console.log(`    summary (${summary.length} chars): ${summary.substring(0, 120)}...`);
+        passed++;
+      } catch (err) {
+        // Auth might fail even if file exists (expired token, network issues)
+        if (err.message.includes('auth error') || err.message.includes('timed out') || err.message.includes('token exchange')) {
+          console.log(`    SKIPPED: ${err.message.substring(0, 80)}`);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+
+  // ── Test 5: chatCompletion with gpt-4.1 ───────────────────────
+  console.log('  test chatCompletion with gpt-4.1...');
+  {
+    if (!copilot.isAvailable()) {
+      console.log('    SKIPPED: no Copilot credentials available');
+    } else {
+      try {
+        const result = await copilot.chatCompletion(
+          [{ role: 'user', content: 'Reply with exactly: PONG' }],
+          { model: 'gpt-4.1', max_tokens: 50 }
+        );
+        assert.ok(result !== null && typeof result === 'object', 'result must be an object');
+        assert.strictEqual(typeof result.content, 'string', 'result.content must be a string');
+        assert.strictEqual(typeof result.model, 'string', 'result.model must be a string');
+        assert.ok(result.usage !== null && typeof result.usage === 'object', 'result.usage must be an object');
+        assert.ok(result.content.length > 0, 'response content should not be empty');
+        console.log(`    model=${result.model}, content="${result.content.substring(0, 60)}"`);
+        passed++;
+      } catch (err) {
+        if (err.message.includes('auth error') || err.message.includes('timed out') || err.message.includes('token exchange')) {
+          console.log(`    SKIPPED: ${err.message.substring(0, 80)}`);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+
+  // ── Test 6: chatCompletion with gpt-5-mini + reasoning_effort ──
+  console.log('  test chatCompletion with gpt-5-mini and reasoning_effort xhigh...');
+  {
+    if (!copilot.isAvailable()) {
+      console.log('    SKIPPED: no Copilot credentials available');
+    } else {
+      try {
+        const result = await copilot.chatCompletion(
+          [{ role: 'user', content: 'What is 2 + 2? Reply with just the number.' }],
+          { model: 'gpt-5-mini', max_tokens: 50, reasoning_effort: 'xhigh' }
+        );
+        assert.ok(result !== null && typeof result === 'object', 'result must be an object');
+        assert.strictEqual(typeof result.content, 'string', 'result.content must be a string');
+        assert.strictEqual(typeof result.model, 'string', 'result.model must be a string');
+        assert.ok(result.usage !== null && typeof result.usage === 'object', 'result.usage must be an object');
+        assert.ok(result.content.length > 0, 'response content should not be empty');
+        console.log(`    model=${result.model}, content="${result.content.substring(0, 60)}"`);
+        passed++;
+      } catch (err) {
+        if (err.message.includes('auth error') || err.message.includes('timed out') || err.message.includes('token exchange') || err.message.includes('API error')) {
+          console.log(`    SKIPPED: ${err.message.substring(0, 100)}`);
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+
+  // ── Test 7: error handling when no credentials exist ───────────
+  console.log('  test error handling with missing credentials...');
+  {
+    // We test the module's exported functions handle absence gracefully.
+    // isAvailable() should not throw regardless.
+    let threw = false;
+    try {
+      copilot.isAvailable();
+    } catch (err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'isAvailable() must never throw');
+
+    // getStatus() should not throw regardless.
+    threw = false;
+    try {
+      copilot.getStatus();
+    } catch (err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'getStatus() must never throw');
+
+    // chatCompletion should throw/reject when credentials are absent
+    // (we can only fully test this if credentials are NOT present)
+    if (!copilot.isAvailable()) {
+      try {
+        await copilot.chatCompletion([{ role: 'user', content: 'test' }]);
+        assert.fail('chatCompletion should throw when no credentials exist');
+      } catch (err) {
+        assert.ok(err.message.includes('No GitHub Copilot OAuth token found'),
+          `Expected credential error, got: ${err.message}`);
+        console.log(`    chatCompletion correctly threw: ${err.message.substring(0, 80)}`);
+      }
+    } else {
+      console.log('    (credentials present; verified isAvailable/getStatus never throw)');
+    }
+    passed++;
+  }
+
+  console.log(`\nAll tests passed! (${passed} tests)`);
+}
+
+runTests().catch(e => { console.error('FAIL:', e); process.exit(1); });

--- a/tests/embeddings.test.js
+++ b/tests/embeddings.test.js
@@ -1,0 +1,258 @@
+/**
+ * Tests for src/embeddings.js
+ *
+ * Runnable with: node tests/embeddings.test.js
+ * Uses only Node.js built-in assert module (zero deps).
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+// Module under test
+const embeddings = require('../src/embeddings');
+
+async function runTests() {
+  console.log('embeddings tests');
+  let passed = 0;
+
+  // ── Test 1: isAvailable returns boolean ────────────────────────
+  console.log('  test isAvailable returns boolean...');
+  {
+    const result = embeddings.isAvailable();
+    assert.strictEqual(typeof result, 'boolean', 'isAvailable() must return a boolean');
+    console.log(`    isAvailable() = ${result}`);
+    passed++;
+  }
+
+  // ── Test 2: embedTFIDF fallback always works ───────────────────
+  console.log('  test embedTFIDF fallback...');
+  {
+    // Single string input
+    const single = embeddings.embedTFIDF('hello world test embedding');
+    assert.ok(Array.isArray(single), 'embedTFIDF must return an array');
+    assert.strictEqual(single.length, 1, 'single input should yield 1 embedding');
+    assert.ok(Array.isArray(single[0]), 'each embedding must be an array');
+    assert.strictEqual(single[0].length, 256, 'TF-IDF embedding dimension should be 256');
+
+    // Verify L2 normalization
+    let norm = 0;
+    for (const v of single[0]) norm += v * v;
+    norm = Math.sqrt(norm);
+    assert.ok(Math.abs(norm - 1.0) < 0.001, `embedding should be L2-normalized, got norm=${norm}`);
+
+    // Batch input
+    const batch = embeddings.embedTFIDF(['first text', 'second text', 'third text']);
+    assert.strictEqual(batch.length, 3, 'batch of 3 should yield 3 embeddings');
+    for (let i = 0; i < batch.length; i++) {
+      assert.strictEqual(batch[i].length, 256, `embedding ${i} should be 256-dim`);
+    }
+
+    // Empty string should still produce a valid vector (all zeros normalized)
+    const empty = embeddings.embedTFIDF('');
+    assert.strictEqual(empty.length, 1, 'empty string should yield 1 embedding');
+    assert.strictEqual(empty[0].length, 256, 'empty embedding should be 256-dim');
+
+    // Different texts should produce different embeddings
+    const vecA = embeddings.embedTFIDF('javascript programming code')[0];
+    const vecB = embeddings.embedTFIDF('quantum physics experiment')[0];
+    let identical = true;
+    for (let i = 0; i < vecA.length; i++) {
+      if (vecA[i] !== vecB[i]) { identical = false; break; }
+    }
+    assert.ok(!identical, 'different texts should produce different TF-IDF embeddings');
+
+    // Same text should produce identical embeddings (deterministic)
+    const vec1 = embeddings.embedTFIDF('deterministic test')[0];
+    const vec2 = embeddings.embedTFIDF('deterministic test')[0];
+    let same = true;
+    for (let i = 0; i < vec1.length; i++) {
+      if (vec1[i] !== vec2[i]) { same = false; break; }
+    }
+    assert.ok(same, 'same text should produce identical TF-IDF embeddings');
+
+    console.log('    single, batch, empty, distinctness, determinism all OK');
+    passed++;
+  }
+
+  // ── Test 3: cosineSimilarity ───────────────────────────────────
+  console.log('  test cosineSimilarity...');
+  {
+    // Identical vectors should have similarity ~1.0
+    const vecA = embeddings.embedTFIDF('hello world')[0];
+    const sim = embeddings.cosineSimilarity(vecA, vecA);
+    assert.ok(Math.abs(sim - 1.0) < 0.001, `self-similarity should be ~1.0, got ${sim}`);
+
+    // Similar texts should have higher similarity than unrelated texts
+    const vecSimilar1 = embeddings.embedTFIDF('javascript function code programming nodejs express server')[0];
+    const vecSimilar2 = embeddings.embedTFIDF('javascript nodejs code function server express api')[0];
+    const vecDifferent = embeddings.embedTFIDF('ocean whale marine biology underwater coral reef diving')[0];
+    const simSimilar = embeddings.cosineSimilarity(vecSimilar1, vecSimilar2);
+    const simDifferent = embeddings.cosineSimilarity(vecSimilar1, vecDifferent);
+    assert.ok(simSimilar > simDifferent,
+      `similar texts should have higher cosine sim (${simSimilar}) than different texts (${simDifferent})`);
+
+    // Orthogonal-like vectors should have low similarity
+    assert.ok(simDifferent < 0.5,
+      `unrelated texts should have low similarity, got ${simDifferent}`);
+
+    // Mismatched dimensions should return 0
+    const mismatchSim = embeddings.cosineSimilarity([1, 0, 0], [1, 0]);
+    assert.strictEqual(mismatchSim, 0, 'mismatched dimensions should return 0');
+
+    // Empty vectors
+    const emptySim = embeddings.cosineSimilarity([], []);
+    assert.strictEqual(emptySim, 0, 'empty vectors should return 0');
+
+    console.log(`    self=${sim.toFixed(4)}, similar=${simSimilar.toFixed(4)}, different=${simDifferent.toFixed(4)}, mismatch=0, empty=0`);
+    passed++;
+  }
+
+  // ── Test 4: reciprocalRankFusion ───────────────────────────────
+  console.log('  test reciprocalRankFusion...');
+  {
+    const bm25 = [
+      { id: 'session-1' },
+      { id: 'session-2' },
+      { id: 'session-3' },
+    ];
+    const embRanked = [
+      { id: 'session-2' },
+      { id: 'session-4' },
+      { id: 'session-1' },
+    ];
+
+    const fused = embeddings.reciprocalRankFusion(bm25, embRanked, 0.3, 0.7);
+    assert.ok(Array.isArray(fused), 'RRF should return an array');
+    assert.ok(fused.length > 0, 'RRF should return results');
+
+    // All items from both lists should be present
+    const ids = new Set(fused.map(r => r.id));
+    assert.ok(ids.has('session-1'), 'session-1 should be in results');
+    assert.ok(ids.has('session-2'), 'session-2 should be in results');
+    assert.ok(ids.has('session-3'), 'session-3 should be in results');
+    assert.ok(ids.has('session-4'), 'session-4 should be in results');
+
+    // session-2 appears in both lists (rank 1 in BM25, rank 0 in emb) so it should score highest
+    assert.strictEqual(fused[0].id, 'session-2',
+      `session-2 should rank first (appears in both lists), got ${fused[0].id}`);
+
+    // Each result should have rrf_score
+    for (const r of fused) {
+      assert.ok(typeof r.rrf_score === 'number', `${r.id} should have numeric rrf_score`);
+      assert.ok(r.rrf_score > 0, `${r.id} rrf_score should be positive`);
+    }
+
+    // Results should be sorted descending by rrf_score
+    for (let i = 1; i < fused.length; i++) {
+      assert.ok(fused[i - 1].rrf_score >= fused[i].rrf_score,
+        `results should be sorted descending by rrf_score`);
+    }
+
+    // Empty inputs should return empty
+    const emptyResult = embeddings.reciprocalRankFusion([], [], 0.3, 0.7);
+    assert.strictEqual(emptyResult.length, 0, 'empty inputs should return empty');
+
+    // Single-source graceful degradation
+    const bm25Only = embeddings.reciprocalRankFusion(bm25, [], 0.3, 0.7);
+    assert.ok(bm25Only.length === 3, 'BM25-only should return 3 results');
+    // When only BM25 is present, effective weight becomes 1.0
+    const embOnly = embeddings.reciprocalRankFusion([], embRanked, 0.3, 0.7);
+    assert.ok(embOnly.length === 3, 'embedding-only should return 3 results');
+
+    console.log(`    fused ${fused.length} items, top=${fused[0].id} (score=${fused[0].rrf_score.toFixed(6)}), graceful degradation OK`);
+    passed++;
+  }
+
+  // ── Test 5: hybridSearch integration ───────────────────────────
+  console.log('  test hybridSearch integration...');
+  {
+    // hybridSearch requires sqlite-index to be available
+    let sqAvailable = false;
+    try {
+      require('../src/sqlite-index');
+      sqAvailable = true;
+    } catch {
+      // sqlite-index not available (no DB, or module load error)
+    }
+
+    if (!sqAvailable) {
+      console.log('    SKIPPED: sqlite-index not available (no SQLite DB built)');
+    } else {
+      try {
+        const results = await embeddings.hybridSearch('test query', 5);
+        assert.ok(Array.isArray(results), 'hybridSearch must return an array');
+        // Results may be empty if no sessions are indexed
+        for (const r of results) {
+          assert.ok(typeof r.session_id === 'string', 'result must have string session_id');
+          assert.ok(typeof r.fused_score === 'number', 'result must have numeric fused_score');
+          assert.ok(typeof r.search_type === 'string', 'result must have string search_type');
+          assert.ok(['hybrid', 'text', 'semantic'].includes(r.search_type),
+            `search_type must be hybrid|text|semantic, got ${r.search_type}`);
+        }
+        console.log(`    hybridSearch returned ${results.length} results`);
+        passed++;
+      } catch (err) {
+        console.log(`    SKIPPED: hybridSearch error — ${err.message.substring(0, 80)}`);
+      }
+    }
+  }
+
+  // ── Test 6: constants are exported correctly ───────────────────
+  console.log('  test exported constants...');
+  {
+    assert.strictEqual(embeddings.RRF_K, 60, 'RRF_K should be 60');
+    assert.strictEqual(embeddings.BM25_WEIGHT, 0.3, 'BM25_WEIGHT should be 0.3');
+    assert.strictEqual(embeddings.EMBEDDING_WEIGHT, 0.7, 'EMBEDDING_WEIGHT should be 0.7');
+    assert.strictEqual(embeddings.EMBEDDING_DIM, 384, 'EMBEDDING_DIM should be 384');
+    assert.ok(embeddings.MODELS && typeof embeddings.MODELS === 'object', 'MODELS should be exported');
+    assert.ok(embeddings.MODELS.minilm, 'MODELS should have minilm');
+    assert.ok(embeddings.MODELS.qwen3, 'MODELS should have qwen3');
+    assert.strictEqual(embeddings.MODELS.minilm.dim, 384, 'minilm dim should be 384');
+    assert.strictEqual(embeddings.MODELS.qwen3.dim, 1024, 'qwen3 dim should be 1024');
+    console.log('    all constants correct');
+    passed++;
+  }
+
+  // ── Test 7: embed() fallback chain resolves to TF-IDF ─────────
+  console.log('  test embed() fallback chain...');
+  {
+    // embed() should always succeed because TF-IDF is the final fallback
+    const result = await embeddings.embed('test input for embedding');
+    assert.ok(Array.isArray(result), 'embed() must return an array');
+    assert.strictEqual(result.length, 1, 'single input should yield 1 embedding');
+    assert.ok(Array.isArray(result[0]), 'each embedding must be an array');
+    assert.ok(result[0].length > 0, 'embedding should have non-zero dimension');
+
+    // Batch input
+    const batchResult = await embeddings.embed(['text one', 'text two']);
+    assert.strictEqual(batchResult.length, 2, 'batch of 2 should yield 2 embeddings');
+
+    console.log(`    embed() returned ${result[0].length}-dim vector (fallback chain OK)`);
+    passed++;
+  }
+
+  // ── Test 8: getModelId and getModelDim ─────────────────────────
+  console.log('  test getModelId and getModelDim...');
+  {
+    const modelId = embeddings.getModelId();
+    assert.strictEqual(typeof modelId, 'string', 'getModelId() must return a string');
+    assert.ok(modelId.length > 0, 'model ID should not be empty');
+
+    const modelDim = embeddings.getModelDim();
+    assert.strictEqual(typeof modelDim, 'number', 'getModelDim() must return a number');
+    assert.ok(modelDim > 0, 'model dim should be positive');
+
+    // Default should be minilm
+    const validIds = Object.values(embeddings.MODELS).map(m => m.id);
+    assert.ok(validIds.includes(modelId), `model ID "${modelId}" should be a known model`);
+
+    console.log(`    modelId=${modelId}, dim=${modelDim}`);
+    passed++;
+  }
+
+  console.log(`\nAll tests passed! (${passed} tests)`);
+}
+
+runTests().catch(e => { console.error('FAIL:', e); process.exit(1); });


### PR DESCRIPTION
## Summary

- Non-blocking `loadSessions()` cold path + async background warmer for parse/cost caches
- Async `/api/analytics/cost` and `/api/leaderboard` jobs with **live partial results** (UI shows `$0 → $5562 → $11344 → ... → final` as sessions aggregate)
- Persistent **SQLite + FTS5 index** (`~/.codedash/cache/index.sqlite`) for sessions, messages, daily stats, and aggregate result cache
- Shared `groupSessionsByConversation` helper used by Timeline / All Sessions / Projects / Cloud Sync / Activity — collapses `codex exec` retries of the same prompt into one representative card with `+N more` badge
- Fixes `getActiveSessions` O(N) `lsof` blocking (80s → 350ms), broken regex that missed `codex-up` / `codex-up-exec`, and `lsof -a` flag so pid filter actually applies
- Fixes massive user_messages overcount: Claude `type=user` entries include `tool_result` blocks (28x inflation measured on a real session)
- Detects scripted sub-agent runs (`originator=codex_exec` + 9 first-prompt regex patterns) and hides them from default counts; `?include_helpers=1` opts in

## Why

On a corpus of 4873 sessions / 1.1 GB of JSONL the GUI hung:
- `loadSessions()` cold: **109 seconds** (re-parsed every Claude file sync, plus 112s of sync `git rev-parse` × 56 projects, plus sync `parseClaudeSessionFile` on a 199 MB file)
- `/api/active`: **80 seconds** (matched 34 processes named `codex-up*` and ran per-pid `lsof` + `loadSessions` inside the loop)
- `/api/analytics/cost` + `/api/leaderboard`: blocking, client got `ERR_TIMED_OUT`
- Spammed `[ACTIVE] pid=... codex/waiting` on every `/api/active` poll

Chrome tabs accumulated hung keep-alive connections and the server eventually looked dead.

## After

| metric                         | v6.15.10 cold           | this branch           |
|-------------------------------|--------------------------|-----------------------|
| `loadSessions()`               | 109 s                   | 72 ms (cacheOnly)     |
| `/api/active`                  | 80 s (34 procs)         | 350 ms cold, 0 ms warm |
| `searchFullText`               | 3–10 s (in-mem rebuild) | 5 ms (FTS5 `MATCH`)   |
| `/api/analytics/cost` first byte | ~30 s blocking         | ~20 ms (partial)      |
| Full analytics cold run         | 30+ s blocking         | ~15 s (with live UI)  |
| Full analytics repeat visit     | 30+ s (recomputed)     | instant (SQLite `aggregate_cache` hit) |

On the test corpus leaderboard counts went from **2869 sessions / 867k prompts** (inflated by retries + tool_results + scripted helpers) to a realistic **612 unique conversations / 8458 real user prompts / $53,637 real spend / 9-day streak**.

## Architectural notes

- **WAL-mode SQLite** via `_execAsync(sql)` that spawns `sqlite3 -cmd '.timeout 30000' <db>` and streams SQL into stdin, so concurrent writers wait instead of erroring with `database is locked`. Reads don't block writers.
- **Fingerprint** for aggregate_cache is quantized to 5-minute buckets so live codex processes appending to their rollout files don't invalidate the cache on every request.
- **Persistent cache dir** at `~/.codedash/cache/` (was `os.tmpdir()` — macOS tmpdir cleanup wipes hours of parse work). Legacy tmpdir paths are migrated once on load.
- **Helper detection** — two signals:
  1. `session_meta.payload.originator === 'codex_exec'` (standard `codex exec`)
  2. Regex match on first user prompt: `^You are in /`, `^Read-only task\.`, `^Work (only )?in /`, `^Pair-local .* lane`, `^## X Y Agent`, `^Read $OMX_`, etc.

## New endpoints

- `GET /api/warming` — `{running, done, total, phase}` for background parse
- `GET /api/sqlite-status` — `{backfill, index: {sessions, messages, files, db_bytes}}`
- `GET /api/analytics/cost` now returns `{status: 'running'|'done'|'error', progress, partialResult, result}` (backwards-compat: `done` spreads `result` fields at the top level so existing UI code still works)
- `GET /api/leaderboard` — same async job shape
- `GET /api/sessions?include_helpers=1` — opt in to scripted helper sessions (default hidden; `X-Helper-Count` header reports the filtered count)

## Upgrade note

After installing users should do a hard-reload (Cmd+Shift+R) once — the poll loops in the split frontend modules are new code and old cached JS will show a stuck `Loading…` spinner.

## Test plan

- [x] 4873-session corpus: cold `loadSessions` 109 s → 72 ms
- [x] Live partial result visible in Analytics poll loop
- [x] Cache hit path: after first computation, subsequent `/api/analytics/cost` returns `status: 'done'` with the cached result
- [x] SQLite FTS5 search: `analytics` query returns 3 highlighted snippets in 58 ms on a 1.2M-message corpus
- [x] Helper filter: 4873 → 2869 sessions by default, `?include_helpers=1` restores full set
- [x] `getActiveSessions` correctly picks up `codex-up` processes with cwd `/Volumes/external/sources/nanochat` (not kernel addresses)
- [x] Server survives SIGTERM with periodic cache flush (no lost parse work)
- [x] Persistent aggregate_cache survives process restart — verified via `sqlite3 ~/.codedash/cache/index.sqlite "SELECT kind, length(result_json) FROM aggregate_cache"`