### PR TITLE
fix: detail panel star button sync

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -281,6 +281,12 @@ function toggleStar(id) {
   else stars.push(id);
   localStorage.setItem('codedash-stars', JSON.stringify(stars));
   render();
+  var detailBtn = document.querySelector('.detail-star');
+  if (detailBtn) {
+    var nowStarred = stars.indexOf(id) >= 0;
+    detailBtn.className = 'star-btn detail-star' + (nowStarred ? ' active' : '');
+    detailBtn.innerHTML = '&#9733; ' + (nowStarred ? 'Starred' : 'Star');
+  }
 }
 
 // ── AI Titles ─────────────────────────────────────────────────


### PR DESCRIPTION
## User-facing issue

When a user opened a session in the detail panel and clicked the star button, the session was starred or unstarred in storage, but the button inside the open detail panel did not immediately update its label or active state. This made the UI look stale and left users unsure whether the action worked until they manually refreshed or closed and reopened the panel.

## Root cause

The shared `toggleStar()` logic already updated persisted star state and rerendered the session views, but the live frontend no longer refreshed the open detail panel button after the action completed. The older backup implementation had an extra DOM update for the `.detail-star` element, and that behavior was missing from the current code path.

## Fix

I restored the missing detail-panel-specific update in `toggleStar()` so that, after the star list is updated and the main views rerender, the open `.detail-star` button is also updated in place.

This keeps the detail panel label and active styling aligned with the new star state immediately.

## Why this is safe

- The change is localized to one shared helper in `src/frontend/app.js`.
- It only affects the open detail panel button, using an existing `.detail-star` selector that is already present in the detail panel markup.
- The existing rerender behavior is preserved, so list cards and other views still refresh exactly as before.
- No data format, API call, or persistence logic changed, so the fix is purely presentational and low risk.
