### PR TITLE
fix: bind vs browser URL handling for remote access

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,7 @@
 const http = require('http');
 const https = require('https');
 const { URL } = require('url');
-const { exec } = require('child_process');
+const { exec, execFile } = require('child_process');
 const { loadSessions, loadSessionDetail, deleteSession, getGitCommits, exportSessionMarkdown, getSessionPreview, searchFullText, getActiveSessions, getSessionReplay, getCostAnalytics, computeSessionCost, getProjectGitInfo, getLeaderboardStats } = require('./data');
 const { detectTerminals, openInTerminal, focusTerminalByPid } = require('./terminals');
 const { convertSession } = require('./convert');
@@ -12,6 +12,7 @@ const { getHTML } = require('./html');
 
 // ── Logging ──────────────────────────────────
 const LOG_VERBOSE = process.env.CODEDASH_LOG !== '0';
+const DEFAULT_HOST = '127.0.0.1';
 
 function log(tag, msg, data) {
   if (!LOG_VERBOSE && tag !== 'ERROR') return;
@@ -26,8 +27,11 @@ function log(tag, msg, data) {
 }
 
 function startServer(host, port, openBrowser = true) {
+  const browserUrl = getBrowserUrl(host, port);
   const server = http.createServer((req, res) => {
-    const parsed = new URL(req.url, `http://${host}:${port}`);
+    // req.url is usually relative, so this base is only for URL parsing.
+    // Keep it stable instead of reusing the bind host, which may be a wildcard listen address.
+    const parsed = new URL(req.url, `http://localhost:${port}`);
     const pathname = parsed.pathname;
     const reqStart = Date.now();
 
@@ -422,26 +426,23 @@ function startServer(host, port, openBrowser = true) {
     }
   });
 
-  const bindAddr = host === 'localhost' ? '127.0.0.1' : host;
-  const displayHost = host === '0.0.0.0' ? 'localhost' : host;
-  const displayUrl = `http://${displayHost}:${port}`;
-
+  const bindAddr = host === 'localhost' ? DEFAULT_HOST : host;
   server.listen(port, bindAddr, () => {
     console.log('');
     console.log('  \x1b[36m\x1b[1mcodedash\x1b[0m — Claude & Codex Sessions Dashboard');
-    console.log(`  \x1b[2m${displayUrl}\x1b[0m`);
-    if (host === '0.0.0.0') {
+    console.log(`  \x1b[2mbind ${bindAddr}:${port}\x1b[0m`);
+    console.log(`  \x1b[2m${browserUrl}\x1b[0m`);
+    if (host === '0.0.0.0' || host === '::' || host === '[::]') {
       console.log('  \x1b[2mListening on all interfaces\x1b[0m');
     }
     console.log('  \x1b[2mPress Ctrl+C to stop\x1b[0m');
     console.log('');
 
     if (openBrowser) {
-      const browserUrl = `http://localhost:${port}`;
       if (process.platform === 'darwin') {
-        exec(`open ${browserUrl}`);
+        execFile('open', [browserUrl]);
       } else if (process.platform === 'linux') {
-        exec(`xdg-open ${browserUrl}`);
+        execFile('xdg-open', [browserUrl]);
       }
     }
 
@@ -756,6 +757,26 @@ function readBody(req, cb) {
   let body = '';
   req.on('data', chunk => body += chunk);
   req.on('end', () => cb(body));
+}
+
+function getBrowserUrl(host, port) {
+  const browserHost = getBrowserHost(host);
+  const wrappedHost = browserHost.includes(':') && !browserHost.startsWith('[')
+    ? `[${browserHost}]`
+    : browserHost;
+  return `http://${wrappedHost}:${port}`;
+}
+
+function getBrowserHost(host) {
+  if (!host || host === DEFAULT_HOST || host === 'localhost' || host === '::1') {
+    return 'localhost';
+  }
+  if (host === '0.0.0.0' || host === '::' || host === '[::]') {
+    // This URL is only used to show/open the app locally on the machine that started it.
+    // Wildcard bind addresses are valid listen targets, but they are not usable browser hosts.
+    return 'localhost';
+  }
+  return host;
 }
 
 // ── npm version check ───────────────────


### PR DESCRIPTION
Picked from #37

This PR fixes startup URL handling when CodeDash is configured to listen on a non-localhost bind address such as `0.0.0.0`.

From the user point of view, the issue was confusing startup output in remote-access setups. CodeDash could be listening correctly, but the printed address mixed together two different concerns:

- the address the server binds to
- the address a browser should actually open

This change separates those two concepts explicitly. The server still binds to the requested host, while the startup output and browser-facing URL stay usable for the machine that launched CodeDash.

## Why this change is needed

In remote-access mode, users can intentionally start CodeDash with a wildcard or non-localhost bind host so that other devices on the local network can reach it.

Before this fix, the startup path reused the bind host too broadly. That created two practical problems:

- startup output was less clear because it did not distinguish the real listen target from the user-friendly browser URL
- wildcard bind values such as `0.0.0.0` are valid for `server.listen(...)` but are not the right host to present as a browser URL

For users, that means CodeDash can appear misconfigured even when it is working. The app is listening correctly, but the displayed/opened URL is not the most usable or least surprising one.

## Root cause

The startup logic treated the configured host as if it were a single canonical address for all purposes.

That assumption is wrong for wildcard bind hosts:

- `0.0.0.0`, `::`, and similar values are valid bind targets
- those same values are not the right browser-facing address to show or open locally

There was also coupling between the bind host and the base URL used for request URL parsing, even though that base is only a helper for parsing relative request paths and does not need to reflect the listen host.

## What changed

- Added explicit browser URL derivation via `getBrowserUrl()` / `getBrowserHost()`
- Kept `server.listen(...)` on the actual bind address
- Updated request URL parsing to use a stable localhost base instead of reusing the bind host
- Updated startup logs to print both:
  - the effective bind target
  - the browser-facing URL
- Kept wildcard bind hosts browser-friendly by mapping them to `localhost` for display/open behavior
- Used `execFile(...)` for browser launch so the URL is passed as an argument instead of through a shell command string

## Why this does not break anything

- Default behavior is unchanged. If CodeDash is started with the normal localhost configuration, it still behaves the same way.
- The HTTP server still listens on the exact configured host. This PR changes presentation and startup URL selection, not the underlying binding behavior.
- API routing and request handling are unchanged. The request parsing base URL is only used to parse relative paths, so switching it to a stable localhost base does not alter endpoint behavior.
- Wildcard binds become safer and clearer, not different in network semantics. `0.0.0.0` still means "listen on all interfaces".
- `execFile(...)` does not change intended behavior for opening the browser. It just uses the more appropriate process-spawn primitive for a fixed command plus arguments.
- No session loading, search, conversion, cloud sync, frontend rendering, or stored data paths are affected.

## User impact

Before:

- users running CodeDash with a remote-access bind host could see startup output that was technically tied to the bind address but not ideal as a browser URL
- wildcard bind setups were more confusing than they needed to be

After:

- startup output clearly shows where CodeDash is bound
- startup output also shows a usable local browser URL
- wildcard remote-access setups remain reachable remotely while still presenting `localhost` for local browser use

## Verification

- Run CodeDash with `CODEDASH_HOST=0.0.0.0`
- Confirm startup output shows:
  - `bind 0.0.0.0:<port>`
  - `http://localhost:<port>`
  - `Listening on all interfaces`
- Confirm the server is reachable locally on `localhost:<port>`
- Confirm the server is still reachable remotely through the host machine IP on the same LAN
