### PR TITLE
feat: add configurable MCP/Skills badges visibility for session rows

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -28,6 +28,7 @@ let stars = JSON.parse(localStorage.getItem('codedash-stars') || '[]');
 let tags = JSON.parse(localStorage.getItem('codedash-tags') || '{}');
 let sessionTitles = JSON.parse(localStorage.getItem('codedash-titles') || '{}');
 let showAITitles = localStorage.getItem('codedash-ai-titles') !== 'false';
+let showAllSessionsListBadges = localStorage.getItem('codedash-all-sessions-list-badges') !== 'false';
 
 // ── Color palette for projects ─────────────────────────────────
 
@@ -288,6 +289,12 @@ function toggleStar(id) {
 function toggleAITitles(checked) {
   showAITitles = checked;
   localStorage.setItem('codedash-ai-titles', checked ? 'true' : 'false');
+  render();
+}
+
+function toggleAllSessionsListBadges(checked) {
+  showAllSessionsListBadges = checked;
+  localStorage.setItem('codedash-all-sessions-list-badges', checked ? 'true' : 'false');
   render();
 }
 
@@ -748,6 +755,7 @@ function renderListCard(s, idx) {
   var isFocused = focusedIndex === idx;
   var projName = getProjectName(s.project);
   var projColor = getProjectColor(projName);
+  var showBadges = showAllSessionsListBadges;
 
   var classes = 'list-row';
   if (isSelected) classes += ' selected';
@@ -756,12 +764,12 @@ function renderListCard(s, idx) {
   var html = '<div class="' + classes + '" data-id="' + s.id + '" onclick="onCardClick(\'' + s.id + '\', event)">';
   var listToolLabel = s.tool === 'claude-ext' ? 'claude ext' : s.tool;
   html += '<span class="tool-badge tool-' + s.tool + '">' + escHtml(listToolLabel) + '</span>';
-  if (s.mcp_servers && s.mcp_servers.length > 0) {
+  if (showBadges && s.mcp_servers && s.mcp_servers.length > 0) {
     s.mcp_servers.forEach(function(m) {
       html += '<span class="tool-badge badge-mcp">' + escHtml(m) + '</span>';
     });
   }
-  if (s.skills && s.skills.length > 0) {
+  if (showBadges && s.skills && s.skills.length > 0) {
     s.skills.forEach(function(sk) {
       html += '<span class="tool-badge badge-skill">' + escHtml(sk) + '</span>';
     });
@@ -1534,6 +1542,7 @@ function renderSettings(container) {
   var savedTheme = localStorage.getItem('codedash-theme') || 'dark';
   var savedTerminal = localStorage.getItem('codedash-terminal') || '';
   var aiTitlesOn = localStorage.getItem('codedash-ai-titles') === 'true';
+  var allSessionsListBadgesOn = localStorage.getItem('codedash-all-sessions-list-badges') !== 'false';
   var savedGroupingMode = normalizeGroupingMode(localStorage.getItem('codedash-grouping-mode'));
 
   var html = '<div class="settings-page">';
@@ -1570,6 +1579,15 @@ function renderSettings(container) {
   html += '<div class="settings-checkbox">';
   html += '<input type="checkbox" id="settingsAiToggle"' + (aiTitlesOn ? ' checked' : '') + ' onchange="toggleAITitles(this.checked)">';
   html += '<span style="font-size:13px;color:var(--text-secondary)">Show generated titles</span>';
+  html += '</div>';
+  html += '</div>';
+
+  // All Sessions list badges
+  html += '<div class="settings-group">';
+  html += '<label class="settings-label">Session List Badges</label>';
+  html += '<div class="settings-checkbox">';
+  html += '<input type="checkbox" id="settingsAllSessionsBadgesToggle"' + (allSessionsListBadgesOn ? ' checked' : '') + ' onchange="toggleAllSessionsListBadges(this.checked)">';
+  html += '<span style="font-size:13px;color:var(--text-secondary)">Show MCP and Skills badges in list-view session rows</span>';
   html += '</div>';
   html += '</div>';
 


### PR DESCRIPTION
## Why

MCP and Skill badges are useful context, but in list-based session rows they compete directly with the most important piece of information: the session title or first message.

In practice, sessions that use multiple MCP servers or skills can accumulate enough badges to consume a large part of the row width. When that happens, the text preview becomes heavily truncated or harder to scan, which makes the list view less effective as a dense overview of sessions.

This is mainly a list-view problem:

1. List rows are horizontally constrained and rely on a single line of text for fast scanning.
2. Grid cards have more room, so badges are much less likely to hide the useful session summary.

Because of that, users need a way to reduce visual noise in list rows without losing badges everywhere else.

## What changed

Added a new setting in **Settings** to control MCP/Skills badge visibility in list-based session rows.

- New setting: `Session List Badges`
- Default: enabled
- When enabled: list rows render MCP and Skill badges as before
- When disabled: list rows hide MCP and Skill badges
- Grid cards are unchanged

The setting is persisted in `localStorage`, so the preference survives reloads.

## Scope

The setting applies to session views that reuse the shared list-row renderer, not just the plain `All Sessions` screen.

That includes:

- `All Sessions` when shown in list layout
- tool-filtered session views that route through the same list renderer
- other session-list contexts that reuse the same list row component

It does not affect:

- grid layout
- project cards
- running sessions view
- any backend parsing or session metadata extraction

## Why this does not break anything

This change is intentionally safe and backward-compatible.

- The default remains the current behavior: badges are visible unless the user explicitly turns them off.
- The underlying session data is unchanged. We still extract and keep `mcp_servers` and `skills`; the setting only changes whether those badges are rendered in list rows.
- Grid view is untouched, so the richer card layout keeps the existing badge behavior.
- The change is presentation-only. It does not alter filtering, grouping, sorting, search, or detail views.
- Because the same shared list-row renderer is used across multiple session-list contexts, the behavior stays consistent instead of introducing a one-off exception for a single screen.

In short, this adds a user-controlled display preference rather than changing session semantics or removing metadata.

## User-facing result

Users who rely on badges can keep the current experience.

Users who prefer denser text scanning can disable list-row badges and recover horizontal space for session names and first-message previews, while still keeping badges visible in grid view.

## Testing

1. Open **Settings** and confirm `Session List Badges` is enabled by default.
2. Switch to list layout in `All Sessions` and verify MCP/Skills badges are visible.
3. Disable `Session List Badges` and verify MCP/Skills badges disappear from list-based session rows.
4. Verify the session title / first message gets more usable horizontal space in list rows.
5. Switch to grid layout and verify MCP/Skills badges still render there.
6. Check another session-list context that reuses the list row renderer and verify the setting behaves consistently there.
