### PR TITLE
feat: add Factory Droid (droid) agent support

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -165,11 +165,14 @@ const CURSOR_GLOBAL_DB = path.join(CURSOR_APP_DATA, 'User', 'globalStorage', 'st
 const CURSOR_WORKSPACE_STORAGE = path.join(CURSOR_APP_DATA, 'User', 'workspaceStorage');
 const HISTORY_FILE = path.join(CLAUDE_DIR, 'history.jsonl');
 const PROJECTS_DIR = path.join(CLAUDE_DIR, 'projects');
+const DROID_DIR = path.join(ALL_HOMES[0], '.factory');
+const DROID_SESSIONS_DIR = path.join(DROID_DIR, 'sessions');
 
 // On WSL, collect all alternative data dirs
 const EXTRA_CLAUDE_DIRS = ALL_HOMES.slice(1).map(h => path.join(h, '.claude')).filter(d => fs.existsSync(d));
 const EXTRA_CODEX_DIRS = ALL_HOMES.slice(1).map(h => path.join(h, '.codex')).filter(d => fs.existsSync(d));
 const EXTRA_CURSOR_DIRS = ALL_HOMES.slice(1).map(h => path.join(h, '.cursor')).filter(d => fs.existsSync(d));
+const EXTRA_DROID_DIRS = ALL_HOMES.slice(1).map(h => path.join(h, '.factory')).filter(d => fs.existsSync(d));
 
 // Extra OpenCode/Kiro DBs on Windows side
 const EXTRA_OPENCODE_DBS = ALL_HOMES.slice(1).map(h => path.join(h, 'AppData', 'Local', 'opencode', 'opencode.db')).filter(d => fs.existsSync(d));
@@ -181,6 +184,7 @@ if (IS_WSL) {
   if (EXTRA_CLAUDE_DIRS.length) console.log('  \x1b[36m[WSL]\x1b[0m Windows-side Claude dirs:', EXTRA_CLAUDE_DIRS.join(', '));
   if (EXTRA_CODEX_DIRS.length) console.log('  \x1b[36m[WSL]\x1b[0m Windows-side Codex dirs:', EXTRA_CODEX_DIRS.join(', '));
   if (EXTRA_CURSOR_DIRS.length) console.log('  \x1b[36m[WSL]\x1b[0m Windows-side Cursor dirs:', EXTRA_CURSOR_DIRS.join(', '));
+  if (EXTRA_DROID_DIRS.length) console.log('  \x1b[36m[WSL]\x1b[0m Windows-side Droid dirs:', EXTRA_DROID_DIRS.join(', '));
 }
 
 // ── Helpers ────────────────────────────────────────────────
@@ -1448,6 +1452,132 @@ function scanCodexSessions() {
   return sessions;
 }
 
+// ── Factory Droid ──────────────────────────────────────────
+
+function parseDroidSessionFile(sessionFile) {
+  if (!fs.existsSync(sessionFile)) return null;
+
+  let stat;
+  let lines;
+  try {
+    stat = fs.statSync(sessionFile);
+    lines = readLines(sessionFile);
+  } catch {
+    return null;
+  }
+
+  let projectPath = '';
+  let sessionTitle = '';
+  let msgCount = 0;
+  let userMsgCount = 0;
+  let firstMsg = '';
+  let firstTs = stat.mtimeMs;
+  let lastTs = stat.mtimeMs;
+  const mcpSet = new Set();
+
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+
+      // session_start → extract cwd and title
+      if (entry.type === 'session_start') {
+        if (entry.cwd && !projectPath) projectPath = entry.cwd;
+        if (entry.sessionTitle) sessionTitle = entry.sessionTitle;
+        continue;
+      }
+
+      // message → same format as Claude Code: {type: "message", message: {role, content: [blocks]}}
+      if (entry.type === 'message') {
+        const ts = entry.timestamp ? Date.parse(entry.timestamp) : NaN;
+        if (Number.isFinite(ts)) {
+          if (ts < firstTs) firstTs = ts;
+          if (ts > lastTs) lastTs = ts;
+        }
+
+        const msg = entry.message || {};
+        const role = msg.role;
+        if (role !== 'user' && role !== 'assistant') continue;
+
+        const content = extractContent(msg.content);
+        if (!content || isSystemMessage(content)) continue;
+
+        // MCP tool_use detection from assistant content blocks
+        if (role === 'assistant' && Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block.type === 'tool_use') {
+              const name = block.name || '';
+              if (name.startsWith('mcp__')) {
+                const parts = name.split('__');
+                if (parts.length >= 3) mcpSet.add(parts[1]);
+              }
+            }
+          }
+        }
+
+        msgCount++;
+        if (role === 'user') userMsgCount++;
+        if (!firstMsg) firstMsg = content.slice(0, 200);
+      }
+    } catch {}
+  }
+
+  return {
+    projectPath,
+    sessionTitle,
+    msgCount,
+    userMsgCount,
+    firstMsg,
+    firstTs,
+    lastTs,
+    fileSize: stat.size,
+    mcpServers: Array.from(mcpSet),
+  };
+}
+
+function scanDroidSessions() {
+  const sessions = [];
+  if (!fs.existsSync(DROID_SESSIONS_DIR)) return sessions;
+
+  try {
+    // Structure: ~/.factory/sessions/<project-key>/<uuid>.jsonl
+    for (const projDir of fs.readdirSync(DROID_SESSIONS_DIR)) {
+      const projPath = path.join(DROID_SESSIONS_DIR, projDir);
+      try {
+        if (!fs.statSync(projPath).isDirectory()) continue;
+      } catch { continue; }
+
+      for (const file of fs.readdirSync(projPath)) {
+        if (!file.endsWith('.jsonl')) continue;
+        const sid = file.replace('.jsonl', '');
+        if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(sid)) continue;
+
+        const fp = path.join(projPath, file);
+        const summary = parseDroidSessionFile(fp);
+        if (!summary) continue;
+
+        sessions.push({
+          id: sid,
+          tool: 'droid',
+          project: summary.projectPath,
+          project_short: summary.projectPath ? summary.projectPath.replace(os.homedir(), '~') : '',
+          first_ts: summary.firstTs,
+          last_ts: summary.lastTs,
+          messages: summary.msgCount,
+          first_message: summary.sessionTitle || summary.firstMsg || '',
+          has_detail: true,
+          file_size: summary.fileSize,
+          detail_messages: summary.msgCount,
+          user_messages: summary.userMsgCount || 0,
+          mcp_servers: summary.mcpServers || [],
+          skills: [],
+        });
+      }
+    }
+  } catch {}
+
+  return sessions;
+}
+
 // ── Git root resolver ───────────────────────────────────────
 //
 // Priority order for determining the git root of a session:
@@ -1550,6 +1680,7 @@ const SESSIONS_CACHE_TTL = 60000; // 60 seconds — hot cache, invalidated by fi
 let _historyMtime = 0;
 let _historySize = 0;
 let _projectsDirMtime = 0;
+let _droidDirMtime = 0;
 
 function _sessionsNeedRescan() {
   // Check if history.jsonl or projects dir changed since last scan
@@ -1561,6 +1692,10 @@ function _sessionsNeedRescan() {
     if (fs.existsSync(PROJECTS_DIR)) {
       const st = fs.statSync(PROJECTS_DIR);
       if (st.mtimeMs !== _projectsDirMtime) return true;
+    }
+    if (fs.existsSync(DROID_SESSIONS_DIR)) {
+      const st = fs.statSync(DROID_SESSIONS_DIR);
+      if (st.mtimeMs !== _droidDirMtime) return true;
     }
   } catch {}
   return false;
@@ -1575,6 +1710,9 @@ function _updateScanMarkers() {
     }
     if (fs.existsSync(PROJECTS_DIR)) {
       _projectsDirMtime = fs.statSync(PROJECTS_DIR).mtimeMs;
+    }
+    if (fs.existsSync(DROID_SESSIONS_DIR)) {
+      _droidDirMtime = fs.statSync(DROID_SESSIONS_DIR).mtimeMs;
     }
   } catch {}
 }
@@ -1800,6 +1938,16 @@ function loadSessions() {
       sessions[ks.id] = ks;
     }
   } catch {}
+
+  // Load Droid sessions
+  if (fs.existsSync(DROID_DIR)) {
+    try {
+      const droidSessions = scanDroidSessions();
+      for (const ds of droidSessions) {
+        sessions[ds.id] = ds;
+      }
+    } catch {}
+  }
 
   // WSL: also load from Windows-side dirs
   for (const extraClaudeDir of EXTRA_CLAUDE_DIRS) {
@@ -2037,6 +2185,22 @@ function loadSessionDetail(sessionId, project) {
             messages.push(msg);
           }
         }
+      } else if (found.format === 'droid') {
+        // Droid format: same as Claude — {type: "message", message: {role, content: [blocks]}}
+        if (entry.type !== 'message') continue;
+        const msg = entry.message || {};
+        const role = msg.role;
+        if (role === 'user' || role === 'assistant') {
+          const content = extractContent(msg.content);
+          if (content && !isSystemMessage(content)) {
+            const m = { role, content: content.slice(0, 2000), uuid: entry.id || '' };
+            if (role === 'assistant' && Array.isArray(msg.content)) {
+              const tools = extractTools(msg.content);
+              if (tools.length > 0) m.tools = tools;
+            }
+            messages.push(m);
+          }
+        }
       } else {
         // Codex format: response_item with payload
         if (entry.type === 'response_item' && entry.payload) {
@@ -2186,12 +2350,7 @@ function exportSessionMarkdown(sessionId, project) {
 
   // For non-Claude formats, use the detail loader for markdown export
   if (found && found.format !== 'claude') {
-    const detail =
-      found.format === 'cursor' ? loadCursorDetail(sessionId) :
-      found.format === 'opencode' ? loadOpenCodeDetail(sessionId) :
-      found.format === 'kiro' ? loadKiroDetail(sessionId) :
-      found.format === 'kilo' ? loadKiloCliDetail(sessionId) :
-      null;
+    const detail = loadSessionDetail(sessionId, project);
     if (detail && detail.messages && detail.messages.length > 0) {
       const parts = [`# Session ${sessionId}\n\n**Project:** ${project || '(none)'}\n`];
       for (const msg of detail.messages) {
@@ -2303,6 +2462,25 @@ function _buildSessionFileIndex() {
     } catch {}
   }
 
+  // Index Droid project files
+  if (fs.existsSync(DROID_SESSIONS_DIR)) {
+    try {
+      const walkDir = (dir) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) walkDir(full);
+          else if (entry.name.endsWith('.jsonl')) {
+            const uuidMatch = entry.name.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/);
+            if (uuidMatch && !_sessionFileIndex[uuidMatch[1]]) {
+              _sessionFileIndex[uuidMatch[1]] = { file: full, format: 'droid' };
+            }
+          }
+        }
+      };
+      walkDir(DROID_SESSIONS_DIR);
+    } catch {}
+  }
+
   _sessionFileIndexTs = now;
 }
 
@@ -2396,6 +2574,24 @@ function findSessionFile(sessionId, project) {
     } catch {}
   }
 
+  // Try Droid projects dir (walk recursively)
+  if (fs.existsSync(DROID_SESSIONS_DIR)) {
+    const walkDir = (dir) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          const result = walkDir(full);
+          if (result) return result;
+        } else if (entry.name.includes(sessionId) && entry.name.endsWith('.jsonl')) {
+          return full;
+        }
+      }
+      return null;
+    };
+    const droidFile = walkDir(DROID_SESSIONS_DIR);
+    if (droidFile) return { file: droidFile, format: 'droid' };
+  }
+
   return null;
 }
 
@@ -2411,6 +2607,9 @@ function isSystemMessage(text) {
   // Codex developer role system prompts
   if (t.startsWith('You are Codex')) return true;
   if (t.startsWith('Filesystem sandboxing')) return true;
+  // Droid system prompts
+  if (t.startsWith('You are Droid')) return true;
+  if (t.startsWith('<factory_config')) return true;
   return false;
 }
 
@@ -2512,6 +2711,18 @@ function getSessionPreview(sessionId, project, limit) {
           const content = extractContent((entry.message || {}).content);
           if (content) {
             messages.push({ role: entry.type, content: content.slice(0, 300) });
+          }
+        }
+      } else if (found.format === 'droid') {
+        // Droid: same as Claude — {type: "message", message: {role, content: [blocks]}}
+        if (entry.type === 'message') {
+          const msg = entry.message || {};
+          const role = msg.role;
+          if (role === 'user' || role === 'assistant') {
+            const content = extractContent(msg.content);
+            if (content && !isSystemMessage(content)) {
+              messages.push({ role: role, content: content.slice(0, 300) });
+            }
           }
         }
       } else {
@@ -2739,6 +2950,13 @@ function getSessionReplay(sessionId, project) {
           if (entry.type !== 'user' && entry.type !== 'assistant') continue;
           role = entry.type;
           content = extractContent((entry.message || {}).content);
+          ts = entry.timestamp || '';
+        } else if (found.format === 'droid') {
+          if (entry.type !== 'message') continue;
+          const msg = entry.message || {};
+          role = msg.role;
+          if (role !== 'user' && role !== 'assistant') continue;
+          content = extractContent(msg.content);
           ts = entry.timestamp || '';
         } else {
           if (entry.type !== 'response_item' || !entry.payload) continue;
@@ -3004,6 +3222,18 @@ function computeSessionCost(sessionId, project) {
     } catch {}
   }
 
+  // Fallback for Droid sessions without usage data
+  if (totalCost === 0 && found.format === 'droid') {
+    try {
+      const size = fs.statSync(found.file).size;
+      const tokens = size / 4;
+      const pricing = MODEL_PRICING['claude-sonnet-4-6'];
+      totalInput = Math.round(tokens * 0.3);
+      totalOutput = Math.round(tokens * 0.7);
+      totalCost = totalInput * pricing.input + totalOutput * pricing.output;
+    } catch {}
+  }
+
   const result = { cost: totalCost, inputTokens: totalInput, outputTokens: totalOutput, cacheReadTokens: totalCacheRead, cacheCreateTokens: totalCacheCreate, contextPctSum, contextTurnCount, model };
   if (cacheKey) _costDiskCache[cacheKey] = result;
   _costMemCache[sessionId] = result;
@@ -3207,6 +3437,7 @@ function _computeCostAnalytics(sessions) {
     byAgent[agent].sessions++;
     byAgent[agent].tokens += tokens;
     if (agent === 'codex') byAgent[agent].estimated = true;
+    if (agent === 'droid') byAgent[agent].estimated = true;
     if (agent === 'cursor' && costData.model && costData.model.includes('-estimated')) byAgent[agent].estimated = true;
     if (agent === 'opencode' && !costData.model) byAgent[agent].estimated = true;
     if (agent === 'kilo' && !costData.model) byAgent[agent].estimated = true;
@@ -3320,6 +3551,7 @@ function getActiveSessions() {
     { pattern: 'kiro', tool: 'kiro', match: /kiro-cli/ },
     { pattern: 'cursor-agent', tool: 'cursor', match: /cursor-agent/ },
     { pattern: 'kilo', tool: 'kilo', match: /@kilocode\/cli|\/bin\/kilo\s|^kilo\s/ },
+    { pattern: 'droid', tool: 'droid', match: /\bdroid\b/ },
   ];
 
   // Skip process scanning on Windows (no ps/grep)
@@ -3327,7 +3559,7 @@ function getActiveSessions() {
 
   try {
     const psOut = execSync(
-      'ps aux 2>/dev/null | grep -E "claude|codex|opencode|kiro-cli|cursor-agent|kilo" | grep -v grep || true',
+      'ps aux 2>/dev/null | grep -E "claude|codex|opencode|kiro-cli|cursor-agent|kilo|droid" | grep -v grep || true',
       { encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'] }
     );
 
@@ -3497,6 +3729,14 @@ function _computeSessionDailyBreakdown(s, found) {
           const c = (entry.message || {}).content;
           if (Array.isArray(c)) { for (const p of c) { if (p.type === 'text' && p.text && p.text.replace(/<\/?user_query>/g,'').trim()) { hasText = true; break; } } }
           else if (typeof c === 'string' && c.trim()) hasText = true;
+        } else if (found.format === 'droid') {
+          if (entry.type !== 'message') continue;
+          const msg = entry.message || {};
+          if (msg.role !== 'user') continue;
+          isUser = true;
+          ts = entry.timestamp ? Date.parse(entry.timestamp) : s.first_ts;
+          const c = extractContent(msg.content);
+          if (c && c.trim()) hasText = true;
         } else if (found.format === 'codex') {
           if (entry.type === 'response_item' && entry.payload && entry.payload.role === 'user') {
             isUser = true;
@@ -3711,6 +3951,7 @@ module.exports = {
   KILO_DB,
   HISTORY_FILE,
   PROJECTS_DIR,
+  DROID_DIR,
   __test: {
     parseWslDistroList,
     getWslDistroList,

--- a/src/frontend/analytics.js
+++ b/src/frontend/analytics.js
@@ -72,6 +72,10 @@ async function renderAnalytics(container) {
         coverageparts.push(byAgent['opencode'].estimated
           ? '<span class="coverage-est">OpenCode ~est.</span>'
           : '<span class="coverage-ok">OpenCode \u2713</span>');
+      if (byAgent['droid'] && byAgent['droid'].sessions > 0)
+        coverageparts.push(byAgent['droid'].estimated
+          ? '<span class="coverage-est">Factory Droid ~est.</span>'
+          : '<span class="coverage-ok">Factory Droid \u2713</span>');
       ['cursor', 'kiro'].forEach(function(a) {
         if (noCost[a] > 0)
           coverageparts.push('<span class="coverage-none">' + a + ' \u2717 (no token data)</span>');
@@ -222,7 +226,7 @@ async function renderAnalytics(container) {
       agentEntries.forEach(function(entry) {
         var name = entry[0]; var info = entry[1];
         var pct = maxAgentCost > 0 ? (info.cost / maxAgentCost * 100) : 0;
-        var label = { 'claude': 'Claude Code', 'claude-ext': 'Claude Ext', 'codex': 'Codex', 'opencode': 'OpenCode', 'cursor': 'Cursor', 'kiro': 'Kiro', 'kilo': 'Kilo CLI' }[name] || name;
+        var label = { 'claude': 'Claude Code', 'claude-ext': 'Claude Ext', 'codex': 'Codex', 'opencode': 'OpenCode', 'cursor': 'Cursor', 'kiro': 'Kiro', 'kilo': 'Kilo CLI', 'droid': 'Factory Droid' }[name] || name;
         var estMark = info.estimated ? ' <span style="font-size:10px;opacity:0.6">~est.</span>' : '';
         html += '<div class="hbar-row">';
         html += '<span class="hbar-name">' + label + estMark + '</span>';

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1792,6 +1792,12 @@ var AGENT_INSTALL = {
     alt: null,
     url: 'https://kilo.ai',
   },
+  droid: {
+    name: 'Factory Droid',
+    cmd: 'curl -fsSL https://app.factory.ai/cli | sh',
+    alt: 'npm i -g droid',
+    url: 'https://factory.ai',
+  },
 };
 
 function installAgent(agent) {

--- a/src/frontend/calendar.js
+++ b/src/frontend/calendar.js
@@ -196,6 +196,9 @@ function setView(view) {
   } else if (view === 'kilo-only') {
     toolFilter = toolFilter === 'kilo' ? null : 'kilo';
     currentView = 'sessions';
+  } else if (view === 'droid-only') {
+    toolFilter = toolFilter === 'droid' ? null : 'droid';
+    currentView = 'sessions';
   } else {
     toolFilter = null;
     currentView = view;

--- a/src/frontend/detail.js
+++ b/src/frontend/detail.js
@@ -279,7 +279,9 @@ function launchSession(sessionId, tool, project, flags) {
 function copyResume(sessionId, tool) {
   var s = allSessions.find(function(x) { return x.id === sessionId; });
   var cmd;
-  if (tool === 'codex') {
+  if (tool === 'droid') {
+    cmd = 'droid --resume ' + sessionId;
+  } else if (tool === 'codex') {
     cmd = 'codex resume ' + sessionId;
   } else if (tool === 'kilo') {
     cmd = 'kilo resume ' + sessionId;

--- a/src/frontend/heatmap.js
+++ b/src/frontend/heatmap.js
@@ -179,7 +179,7 @@ function renderHeatmap(container) {
   // Per-tool breakdown
   var toolTotals = {};
   allSessions.forEach(function(s) { if (s.date >= yearStart) { toolTotals[s.tool] = (toolTotals[s.tool] || 0) + 1; } });
-  var toolColors = { claude: '#60a5fa', codex: '#22d3ee', opencode: '#c084fc', kiro: '#fb923c', kilo: '#34d399' };
+  var toolColors = { claude: '#60a5fa', codex: '#22d3ee', opencode: '#c084fc', kiro: '#fb923c', kilo: '#34d399', droid: '#4ade80' };
   html += '<div class="gh-tools">';
   Object.keys(toolTotals).sort(function(a,b) { return toolTotals[b] - toolTotals[a]; }).forEach(function(tool) {
     var pct = (toolTotals[tool] / Math.max(totalThisYear, 1) * 100).toFixed(0);

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -80,6 +80,10 @@
         </svg>
         Kilo
     </div>
+    <div class="sidebar-item" data-view="droid-only">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="11" width="14" height="10" rx="2"/><circle cx="12" cy="7" r="4"/><path d="M9 15h.01"/><path d="M15 15h.01"/><path d="M10 18h4"/></svg>
+        Droid
+    </div>
     <div class="sidebar-divider"></div>
     <div class="sidebar-section">Install Agents</div>
     <div class="sidebar-item" onclick="installAgent('claude')">
@@ -101,6 +105,10 @@
     <div class="sidebar-item" onclick="installAgent('kilo')">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
         Kilo CLI
+    </div>
+    <div class="sidebar-item" onclick="installAgent('droid')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+        Factory Droid
     </div>
     <div class="sidebar-divider"></div>
     <div class="sidebar-item" onclick="showExportDialog()">

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -299,6 +299,7 @@ body {
 .tool-chip:hover { color: var(--text-primary); }
 .tool-chip.active-claude { background: rgba(96, 165, 250, 0.2); border-color: var(--accent-blue); color: var(--accent-blue); }
 .tool-chip.active-codex { background: rgba(34, 211, 238, 0.2); border-color: var(--accent-cyan); color: var(--accent-cyan); }
+.tool-chip.active-droid { background: rgba(74, 222, 128, 0.2); border-color: var(--accent-green); color: var(--accent-green); }
 
 .stats { color: var(--text-muted); font-size: 13px; white-space: nowrap; }
 
@@ -1204,6 +1205,11 @@ body {
 .tool-kilo {
     background: rgba(52, 211, 153, 0.15);
     color: #34d399;
+}
+
+.tool-droid {
+    background: rgba(74, 222, 128, 0.15);
+    color: var(--accent-green);
 }
 
 /* ── MCP / Skill badges ──────────────────────────────────────── */

--- a/src/terminals.js
+++ b/src/terminals.js
@@ -196,7 +196,9 @@ function openInTerminal(sessionId, tool, flags, projectDir, terminalId) {
   const skipPerms = flags.includes('skip-permissions');
   let cmd;
 
-  if (tool === 'codex') {
+  if (tool === 'droid') {
+    cmd = `droid --resume ${sessionId}`;
+  } else if (tool === 'codex') {
     cmd = `codex resume ${sessionId}`;
   } else if (tool === 'kilo') {
     cmd = `kilo resume ${sessionId}`;


### PR DESCRIPTION
## Summary       
                                                                                                                                                                                                                      
  Adds Factory Droid (droid CLI by Factory AI) as a supported agent in CodeDash — session loading, detail view, preview, replay, search, cost estimation, active detection, and full UI integration.                  
                                                                                                                                                                                                                      
  ## What changed                                                                                                                                                                                                        
                                                                                                                                                                                                                      
  - add Droid session discovery from ~/.factory/sessions/<project-key>/*.jsonl with session_start metadata parsing (cwd, sessionTitle) and Claude-compatible message format ({type: "message", message: {role, content:
   [blocks]}})                                                                                                                                                                                                        
  - load Droid detail into the unified transcript format used by session detail, preview, replay, search, and export paths                                                                                            
  - include Droid sessions in active process detection (ps aux grep for droid), cache invalidation (mtime monitoring of ~/.factory/sessions/), and terminal launch/resume (droid --resume <id>)                       
  - extract MCP tool usage from assistant tool_use content blocks using the same extractTools() pipeline as Claude                                                                                                    
  - expose Droid throughout the UI: sidebar filter with robot icon, green badge (.tool-droid / --accent-green), filter chip, install command (curl -fsSL https://app.factory.ai/cli | sh), and calendar view toggle   
  - add file-size-based cost fallback for sessions without token usage metadata, using claude-sonnet-4-6 pricing as baseline estimate                                                                                 
  - add Droid system message filtering (You are Droid, <factory_config) to isSystemMessage()                                                                                                                          
  - add WSL support with EXTRA_DROID_DIRS for Windows-side ~/.factory detection                                                                                                                                       
                                                                                                                                                                                                                      
  ## Validation                                                                                                                                                                                                          
                                                                                                                                                                                                                      
  Manual checks run locally against real ~/.factory data (12 sessions across 4 projects):                                                                                                                             
                                                                                                                                                                                                                      
  - node -c src/data.js                                                                                                                                                                                               
  - node -c src/terminals.js                                                                                                                                                                                          
  - node -c src/frontend/app.js                                                                                                                                                                                       
  - node -c src/frontend/calendar.js                                                                                                                                                                                  
  - node -e "..." — confirmed 12 Droid sessions loaded with correct project paths, message counts, and session titles                                                                                                 
  - loadSessionDetail() — verified 32 messages parsed from a real session with correct role/content extraction                                                                                                        
  - getSessionPreview() — returns 10 preview messages                                                                                                                                                                 
  - computeSessionCost() — returns file-size-based cost estimate                                                                                                                                                      
  - node bin/cli.js run — dashboard starts cleanly, Droid sessions visible with green badges                                                                                                                          
                                                                                                                                                                                                                      
  ## Known limitations                                                                                                                                                                                                   
                                                                                                                                                                                                                      
  - Cost is estimated from file size (no per-turn token usage in Droid JSONL), so cost figures are approximate.                                                                                                       
  - droid --resume <id> command is assumed but not verified against the actual Droid CLI — may need adjustment to match the real resume flag.                                                                         
  - history.json (JSON array) is not used for session enrichment — all data comes from session JSONL files directly.