### PR TITLE
fix: block bulk delete when selected sessions are hidden by filter

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1266,9 +1266,32 @@ function updateBulkBar() {
   if (selectedIds.size > 0) {
     bar.style.display = 'flex';
     document.getElementById('bulkCount').textContent = selectedIds.size + ' selected';
+
+    // Warn if some selected sessions are hidden by the current filter
+    var visibleIds = new Set((filteredSessions || []).map(function(s) { return s.id; }));
+    var hiddenCount = 0;
+    selectedIds.forEach(function(id) { if (!visibleIds.has(id)) hiddenCount++; });
+    var warning = document.getElementById('bulkHiddenWarning');
+    var deleteBtn = document.getElementById('bulkDeleteBtn');
+    if (hiddenCount > 0) {
+      document.getElementById('bulkHiddenCount').textContent = hiddenCount;
+      if (warning) warning.style.display = 'inline';
+      if (deleteBtn) { deleteBtn.disabled = true; deleteBtn.title = 'Clear or deselect hidden sessions first'; }
+    } else {
+      if (warning) warning.style.display = 'none';
+      if (deleteBtn) { deleteBtn.disabled = false; deleteBtn.title = ''; }
+    }
   } else {
     bar.style.display = 'none';
   }
+}
+
+function clearHiddenSelections(event) {
+  if (event) event.preventDefault();
+  var visibleIds = new Set((filteredSessions || []).map(function(s) { return s.id; }));
+  selectedIds.forEach(function(id) { if (!visibleIds.has(id)) selectedIds.delete(id); });
+  updateBulkBar();
+  render();
 }
 
 function clearSelection() {

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -173,7 +173,8 @@
 
 <div class="bulk-bar" id="bulkBar" style="display:none">
     <span id="bulkCount">0 selected</span>
-    <button class="launch-btn btn-delete" onclick="bulkDelete()">Delete Selected</button>
+    <span id="bulkHiddenWarning" class="bulk-hidden-warning" style="display:none">⚠ <span id="bulkHiddenCount"></span> hidden by filter — <a href="#" onclick="clearHiddenSelections(event)">deselect hidden</a></span>
+    <button class="launch-btn btn-delete" id="bulkDeleteBtn" onclick="bulkDelete()">Delete Selected</button>
     <button class="launch-btn btn-secondary" onclick="clearSelection()">Cancel</button>
 </div>
 

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -1062,6 +1062,22 @@ body {
     border-color: var(--accent-red);
 }
 .bulk-bar button.bulk-delete:hover { opacity: 0.85; }
+.bulk-bar button:disabled { opacity: 0.4; cursor: not-allowed; }
+.bulk-bar button:disabled:hover { opacity: 0.4; }
+
+.bulk-hidden-warning {
+    font-size: 12px;
+    color: #f5a623;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.bulk-hidden-warning a {
+    color: #f5a623;
+    text-decoration: underline;
+    cursor: pointer;
+}
+.bulk-hidden-warning a:hover { opacity: 0.8; }
 
 [data-theme="light"] .bulk-bar {
     background: rgba(245,245,247,0.88);


### PR DESCRIPTION
## Problem

When a user selects sessions in select mode, then applies a search or filter, some selected sessions disappear from view — but remain in `selectedIds`. Clicking "Delete Selected" would silently delete those invisible sessions, with no warning.

This is a **silent data loss bug**.

## Fix

Three changes:

1. **`updateBulkBar()`** — compares `selectedIds` against `filteredSessions`. If any selected IDs are not visible, shows an amber warning: `⚠ N hidden by filter — deselect hidden`

2. **Delete button** — disabled (`disabled` + tooltip) while hidden selections exist. User cannot delete until the ambiguity is resolved.

3. **`clearHiddenSelections()`** — new function, triggered by the "deselect hidden" link. Removes only the invisible IDs from `selectedIds`, preserves the visible ones so the user can continue with bulk actions.

## Before / After

| Before | After |
|--------|-------|
| Select 5 sessions → filter → 2 hidden → Delete → 5 deleted silently | Select 5 sessions → filter → 2 hidden → ⚠ warning appears → Delete disabled → user clicks "deselect hidden" → 3 visible remain selected → Delete works |

## Test plan
- [ ] Select 3+ sessions → apply search that hides some → verify warning appears and Delete is disabled
- [ ] Click "deselect hidden" → verify hidden IDs removed, visible remain selected, Delete re-enables
- [ ] Clear filter → verify warning disappears, Delete re-enables with correct count
- [ ] Select sessions with no filter active → verify no warning, Delete works normally