### PR TITLE
feat: показывать recap (away_summary) Claude Code в заголовке сессии

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -252,7 +252,7 @@ function parseKiloMcpServer(toolName) {
 }
 
 // Disk cache for parsed Claude session files (keyed by path + mtime + size)
-const PARSED_CACHE_FILE = path.join(os.tmpdir(), 'codedash-parsed-cache.json');
+const PARSED_CACHE_FILE = path.join(os.tmpdir(), 'codedash-parsed-cache-v2.json');
 let _parsedDiskCache = null;
 let _parsedDiskCacheDirty = false;
 // Reverse index: file path -> cache key (avoids repeated fs.statSync)
@@ -318,6 +318,7 @@ function parseClaudeSessionFile(sessionFile) {
   let totalUserMsgs = 0;    // all user-type messages (including tool_result, sub-agents)
   let entrypointFound = false;
   let worktreeOriginalCwd = '';
+  let lastRecap = '';
   const mcpSet = new Set();
   const skillSet = new Set();
 
@@ -346,6 +347,10 @@ function parseClaudeSessionFile(sessionFile) {
       if (entry.type === 'custom-title' && typeof entry.customTitle === 'string') {
         const title = entry.customTitle.trim();
         if (title) customTitle = title.slice(0, 200);
+      }
+      if (entry.type === 'system' && entry.subtype === 'away_summary') {
+        const txt = (entry.content || '').trim();
+        if (txt) lastRecap = txt.slice(0, 300);
       }
       if (!firstMsg && entry.type === 'user' && entry.message && entry.message.content) {
         const content = extractContent(entry.message.content).trim();
@@ -383,6 +388,7 @@ function parseClaudeSessionFile(sessionFile) {
     lastTs,
     fileSize: stat.size,
     worktreeOriginalCwd,
+    lastRecap,
     mcpServers: Array.from(mcpSet),
     skills: Array.from(skillSet),
   };
@@ -417,6 +423,10 @@ function mergeClaudeSessionDetail(session, summary, sessionFile) {
 
   if (summary.customTitle) {
     session.session_name = summary.customTitle;
+  }
+
+  if (summary.lastRecap) {
+    session.recap = summary.lastRecap;
   }
 }
 
@@ -1867,6 +1877,7 @@ function loadSessions() {
               _claude_dir: extraClaudeDir,
               _session_file: fp,
               worktree_original_cwd: summary.worktreeOriginalCwd || '',
+              recap: summary.lastRecap || '',
             };
           }
         }
@@ -1940,6 +1951,7 @@ function loadSessions() {
             _claude_dir: CLAUDE_DIR,
             _session_file: filePath,
             worktree_original_cwd: summary.worktreeOriginalCwd || '',
+            recap: summary.lastRecap || '',
           };
         }
       }

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -91,9 +91,16 @@ function getSessionGroupInfo(session) {
   return { key: name, name: name };
 }
 
+function stripRecapSuffix(s) {
+  return (s || '').replace(/\s*\(disable recaps in \/config\)\s*$/, '');
+}
+
 function getSessionDisplayName(session) {
   if (!session) return '';
-  return session.session_name || session.first_message || '';
+  return session.session_name
+    || stripRecapSuffix(session.recap)
+    || session.first_message
+    || '';
 }
 
 // ── Utilities ──────────────────────────────────────────────────
@@ -601,6 +608,7 @@ function searchScore(query, session) {
   var q = query.toLowerCase();
   var fields = [
     session.session_name || '',
+    session.recap || '',
     session.first_message || '',
     session.project_short || '',
     session.project || '',
@@ -1220,6 +1228,7 @@ async function confirmDelete() {
         var remaining = allSessions.filter(function(s) {
           return (s.project || '').toLowerCase().indexOf(searchQuery.toLowerCase()) >= 0 ||
                  (s.session_name || '').toLowerCase().indexOf(searchQuery.toLowerCase()) >= 0 ||
+                 (s.recap || '').toLowerCase().indexOf(searchQuery.toLowerCase()) >= 0 ||
                  (s.first_message || '').toLowerCase().indexOf(searchQuery.toLowerCase()) >= 0;
         });
         if (remaining.length === 0) {

--- a/src/frontend/cloud.js
+++ b/src/frontend/cloud.js
@@ -89,7 +89,7 @@ async function renderCloud(container) {
       var btnHtml = inCloud
         ? '<span class="dim" style="font-size:10px;white-space:nowrap;">in cloud</span>'
         : '<button class="launch-btn btn-primary" style="padding:3px 8px;font-size:10px;" onclick="cloudPushOne(\'' + ls.id + '\',this)">Push</button>';
-      html += cloudRow(ls.tool, ((ls.session_name || ls.first_message || ls.id)).substring(0, 60), sub, btnHtml);
+      html += cloudRow(ls.tool, ((ls.session_name || stripRecapSuffix(ls.recap) || ls.first_message || ls.id)).substring(0, 60), sub, btnHtml);
     }
   } else {
     html += '<div class="dim" style="text-align:center;padding:20px;font-size:12px;">Loading...</div>';
@@ -116,7 +116,7 @@ async function renderCloud(container) {
       var csSub = (cs.project_short || '') + ' \u00b7 ' + cs.message_count + ' msgs \u00b7 ' + csDate;
       var csBtns = '<button class="launch-btn btn-secondary" style="padding:3px 8px;font-size:10px;" onclick="cloudPullOne(\'' + cs.session_id + '\',this)">Pull</button>';
       csBtns += '<button class="launch-btn btn-delete" style="padding:3px 6px;font-size:10px;" onclick="deleteCloudSession(\'' + cs.session_id + '\')">&times;</button>';
-      html += cloudRow(cs.agent, ((cs.session_name || cs.first_message || cs.session_id)).substring(0, 60), csSub, csBtns);
+      html += cloudRow(cs.agent, ((cs.session_name || stripRecapSuffix(cs.recap) || cs.first_message || cs.session_id)).substring(0, 60), csSub, csBtns);
     }
   }
   html += '</div></div>';


### PR DESCRIPTION
## Что

Claude Code 2.1.108+ пишет в JSONL сессии авто-резюме вида
`{"type":"system","subtype":"away_summary","content":"…~40 слов…"}`
когда пользователь возвращается после простоя 3–5+ минут.

PR добавляет парсинг этих записей и показывает последний recap как заголовок карточки сессии — когда он есть и когда не задан явный `session_name`.

## Приоритет заголовка

`session_name` (ручной кастомный) → `recap` (авто от Claude) → `first_message` (сырое первое сообщение).
AI-титулы (`sessionTitles`, localStorage) остаются поверх всего, как и раньше.

## Изменения

- `src/data.js`
  - `parseClaudeSessionFile`: извлекает последний `away_summary` в поле `lastRecap` (cap 300 символов).
  - `mergeClaudeSessionDetail`: пробрасывает `session.recap`.
  - Два inline-сборщика сессий тоже пробрасывают `recap`.
  - Имя дискового кэша бамп → `codedash-parsed-cache-v2.json`, чтобы одноразово перепарсить существующие записи и подхватить новое поле.
- `src/frontend/app.js`
  - `stripRecapSuffix` — срезает хвост `(disable recaps in /config)`, который Claude Code добавляет к тексту.
  - `getSessionDisplayName` учитывает recap в приоритете.
  - `searchScore` ищет и по recap.
- `src/frontend/cloud.js` — то же для локальных и облачных строк.

## Охват

Recap есть только там, где сработал авто-триггер на простой. В моём архиве (~800 сессий) — 2 с recap. Для сессий без него поведение не меняется.

## Проверка

\`\`\`bash
node -e "const d = require('./src/data.js'); const s = d.loadSessions().filter(x => x.recap); console.log(s.length, 'with recap'); s.slice(0,3).forEach(x => console.log(x.id.slice(0,8), '→', x.recap.slice(0,80)))"
\`\`\`

Параллельный порт этой же фичи в родственный проект terminal-mba: https://github.com/Graf-RAGov/terminal-mba/commit/565ee00