### PR TITLE
docs: sharpen README opener around core job

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codbash
 
-Dashboard + CLI for AI coding agent sessions. View, search, resume, convert, and hand off between 5 agents.
+Control room for AI coding sessions. Search, replay, and resume Claude Code, Codex, Cursor, OpenCode, and Kiro sessions without digging through scattered logs.
 
 [Russian / Русский](docs/README_RU.md) | [Chinese / 中文](docs/README_ZH.md)
 


### PR DESCRIPTION
This makes the README opener lead with the core job-to-be-done instead of feature breadth.

What changed:
- reframed the first line around the main user outcome
- moved specific agent/tool breadth into the supporting wording below

The goal is to help a new visitor understand the product faster on the first screen.