### PR TITLE
fix: prevent stale analytics data and add session auto-refresh

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -447,10 +447,17 @@ function generateAllTitles() {
 
 // ── Data loading ───────────────────────────────────────────────
 
+var _loadSessionsInFlight = false;
+
 async function loadSessions() {
+  if (_loadSessionsInFlight) return;
+  _loadSessionsInFlight = true;
   try {
     var resp = await fetch('/api/sessions');
     allSessions = await resp.json();
+    // Invalidate analytics cache so stale aggregates are not shown
+    _analyticsHtmlCache = null;
+    _analyticsCacheUrl = null;
     applyFilters();
     // Progressive loading: if server is still loading cursor vscdb sessions, auto-refresh
     if (resp.headers.get('X-Loading') === '1') {
@@ -458,6 +465,8 @@ async function loadSessions() {
     }
   } catch (e) {
     document.getElementById('content').innerHTML = '<div class="empty-state">Failed to load sessions. Is the server running?</div>';
+  } finally {
+    _loadSessionsInFlight = false;
   }
 }
 
@@ -1980,6 +1989,7 @@ function dismissUpdate() {
   loadTerminals();
   checkForUpdates();
   setInterval(checkForUpdates, 10000); // check every 10s
+  setInterval(loadSessions, 60000);    // refresh sessions + invalidate analytics cache every 60s
   startActivePolling();
 
   // Apply saved theme


### PR DESCRIPTION
## Problem

Two staleness bugs reported by users:

1. **Analytics tab showed stale data** — `_analyticsHtmlCache` was never invalidated after the initial render, so navigating away and back always showed the same cached HTML without refetching from `/api/analytics/cost`.

2. **Activity heatmap and analytics never updated** — `allSessions` was loaded once at startup and then only on manual Refresh click. New sessions created while the dashboard was open were never reflected.

## Changes

- **Cache invalidation**: `loadSessions()` now clears `_analyticsHtmlCache` and `_analyticsCacheUrl` on every successful fetch, so the Analytics tab refetches on next visit.
- **Auto-refresh**: `setInterval(loadSessions, 60000)` added in `init()` — sessions, activity heatmap, and analytics stay current automatically.
- **In-flight guard**: `_loadSessionsInFlight` flag prevents overlapping fetches when `setInterval` and the `X-Loading` progressive auto-refresh fire at the same time (e.g. after laptop sleep/wake).

## Test plan

- [ ] Open Analytics, note the data, wait 60s or click Refresh — data updates
- [ ] Open Activity heatmap, start a new session in another terminal, wait up to 60s — new day appears without manual refresh
- [ ] Throttle network to Slow 3G in DevTools, verify only one `/api/sessions` request is in-flight at a time (no duplicate requests in Network tab)