### PR TITLE
feat: add qwen terminal resume support

### DIFF
--- a/src/terminals.js
+++ b/src/terminals.js
@@ -198,6 +198,8 @@ function openInTerminal(sessionId, tool, flags, projectDir, terminalId) {
 
   if (tool === 'codex') {
     cmd = `codex resume ${sessionId}`;
+  } else if (tool === 'qwen') {
+    cmd = `qwen -r ${sessionId}`;
   } else if (tool === 'kilo') {
     cmd = `kilo resume ${sessionId}`;
   } else {


### PR DESCRIPTION
Adds Qwen Code terminal resume command.

### What changed
- `openInTerminal` now generates `qwen -r <sessionId>` for qwen sessions

### Depends on
- #201 (backend) — must be merged first so qwen sessions are detected and passed to the terminal launcher.

This is PR 3 of 3.