### PR TITLE
feat: Projects tab → Projects (launcher) + History subtabs + agent picker

### DIFF
--- a/docs/design/projects-tab-restructure.md
+++ b/docs/design/projects-tab-restructure.md
@@ -1,0 +1,203 @@
+# Projects Tab Restructure — design
+
+## Goal
+
+Reshape the Projects view from a single mixed surface (folders + sessions + launchers)
+into two clearly separated sub-pages, and add explicit agent selection (default + per-launch).
+
+```
+Projects (top-level sidebar item)
+├── Projects   (default subtab) — registered project launchers
+│                  cards: name + git url + ▶ New / ⟳ Last / ⏷ picker
+│                  toolbar: + Add Project · ⚙ Settings (default agent)
+│
+└── History    (subtab)         — everything Projects shows today
+                   group-by-project session list, drawer on click,
+                   collapse/expand, "Open >" filter. No behavior change.
+```
+
+## Why
+
+Today the Projects tab does three jobs at once:
+
+1. show every folder that has ever held a Claude/Cursor/Codex session,
+2. list those sessions grouped under the folder,
+3. host the launcher buttons (`▶ New`, `⟳ Last`) we shipped in #210.
+
+Adding agent picker + default-agent settings on top would push the surface
+past usability. Splitting into `Projects` (a registry) and `History`
+(observation) keeps each surface single-purpose.
+
+## Non-goals
+
+- No change to session loading, search index, drawer, or any current History behavior.
+- No change to the existing `/api/launch`, `/api/projects/*`, `/api/github/*` contracts beyond additive fields.
+- No removal of the GitHub OAuth or dual-token model from #210.
+- No new agents supported. We work with the 7 already in `terminals.js`.
+
+## Data inventory
+
+What we touch today:
+
+| Source | Path | Role | Change |
+|---|---|---|---|
+| projects.json | `~/.codedash/projects.json` | manual registry of folders | unchanged (additive only via #210 flow) |
+| github-profile.json | `~/.codedash/github-profile.json` | OAuth tokens (read:user, repo) | unchanged |
+| sessions index | various agent storage | renders History | unchanged |
+
+What we add:
+
+| Source | Path | Role |
+|---|---|---|
+| settings.json | `~/.codedash/settings.json` | UI-level settings (default agent, picker prefs) |
+
+Auto-register on first launch reads `projects.json` only — no separate state.
+
+## Component map
+
+### Producer (server)
+
+| File | Change |
+|---|---|
+| `src/settings.js` (new) | atomic 0600 read/write, single-key `defaultAgent`, mutex-serialized like `projects.js` |
+| `src/agents-detect.js` (new) | probe PATH + macOS app bundle paths for the 7 known agent binaries; result cached for server lifetime, refresh endpoint exposed |
+| `src/server.js` | 4 new routes: `GET /api/settings`, `PUT /api/settings`, `GET /api/agents/installed`, `POST /api/agents/refresh-detect`. `POST /api/launch` gains optional implicit auto-register when `mode:'fresh'` is given an unknown registered path |
+| `src/terminals.js` | unchanged (already handles fresh-mode + tool switch) |
+| `src/projects.js` | unchanged |
+
+### Consumer (frontend)
+
+| File | Change |
+|---|---|
+| `src/frontend/index.html` | extend `data-view="projects"` content to render a subtab strip; reuse Add Project modal; add Settings modal markup |
+| `src/frontend/app.js` | `currentProjectsSubtab` state ('projects' \| 'history'); two new render fns `renderProjectsLanding` and existing `renderProjects` re-aliased into `renderProjectsHistory`; `agentPicker(projectPath, anchorEl)` popover; `openSettings()` modal; deeplink `?projectFilter=<path>` switches to History with filter applied |
+| `src/frontend/styles.css` | subtab strip styles, picker popover, settings modal, split-button on cards |
+
+### Wiring
+
+- App load: fetch `/api/agents/installed`, fetch `/api/settings` → store in `window.codbashSettings`. Both endpoints idempotent and read-only at boot.
+- `▶ New` click priority: `lastUsedToolForProject(path)` → `settings.defaultAgent` → first detected → error toast.
+- `⏷` click: build popover from `installed` list, click = one-shot launch with that tool, no settings mutation.
+- Settings modal save: PUT `/api/settings` body `{ defaultAgent: 'claude' | ... }`; server validates against allow-list = currently detected agents (so the user cannot save an uninstalled default).
+- Auto-register: on successful `/api/launch` with `mode:'fresh'`, if `projectDir` matches no project in registry, server adds it with `source:'auto'`. Returns the new project entry. Front shows a toast "Added <name> to Projects". A new `'auto'` value is appended to `ALLOWED_SOURCES`.
+
+## API contracts (additive only)
+
+```ts
+// GET /api/settings
+type SettingsResponse = {
+  defaultAgent: 'claude' | 'codex' | 'cursor' | 'qwen' | 'kilo' | 'kiro' | 'opencode' | 'copilot' | 'copilot-chat' | null;
+};
+
+// PUT /api/settings
+type SettingsRequest = { defaultAgent: SettingsResponse['defaultAgent'] };
+// Returns 400 if defaultAgent is not in current /api/agents/installed.
+
+// GET /api/agents/installed
+type InstalledAgent = {
+  id: 'claude' | 'codex' | 'cursor' | 'qwen' | 'kilo' | 'kiro' | 'opencode' | 'copilot' | 'copilot-chat';
+  label: string;            // human-readable
+  detectedVia: 'path' | 'app-bundle';
+  binPath?: string;         // if detectedVia === 'path'
+};
+type InstalledResponse = { agents: InstalledAgent[]; refreshedAt: string };
+
+// POST /api/agents/refresh-detect → re-runs detection, returns same shape
+
+// POST /api/launch (existing) — additive fields:
+type LaunchRequest = {
+  project: string;
+  tool: 'claude' | /* ... */ ;
+  mode?: 'fresh' | 'resume';
+  sessionId?: string;
+  flags?: string[];
+  terminal?: string;
+  autoRegister?: boolean;   // NEW, default true; when true, fresh-launch in unknown path → addProject
+};
+type LaunchResponse = {
+  ok: boolean;
+  registered?: { id: string; name: string; path: string; source: 'auto' };  // NEW
+  error?: string;
+};
+```
+
+All error responses use the existing `{ error: string }` shape with `Content-Type: application/json`. No envelope change.
+
+## Frontend state machine
+
+```
+                              user clicks Projects sidebar
+                                          │
+                                          ▼
+                              ┌──────────────────────┐
+                              │  subtab = projects   │  (default)
+                              └──────────────────────┘
+                                          │
+                ┌─────────────────────────┼─────────────────────────┐
+                ▼                         ▼                         ▼
+        click "History" tab      click ▶ New / ⏷            click "View sessions →"
+                │                         │                         │
+                │                         │                         │
+                ▼                         ▼                         ▼
+        subtab = history          POST /api/launch          subtab = history,
+        render group list,        terminal opens,           gitProjectFilter = path,
+        full Projects-today       (auto-register toast      scroll into view
+        behavior preserved        if applicable)
+                │
+                ▼
+        click session → drawer (unchanged)
+```
+
+Subtab state lives in `window.currentProjectsSubtab`. Persisted to localStorage key `codedash-projects-subtab` so the user returns to the same view across reloads.
+
+## Filesystem layout
+
+```
+~/.codedash/
+├── projects.json        (existing)
+├── github-profile.json  (existing — mode 0600)
+└── settings.json        (NEW — mode 0600)
+       { "defaultAgent": "claude", "lastUsedByPath": { "<absPath>": "claude" } }
+```
+
+`lastUsedByPath` is written by the server when a launch succeeds, so the
+"last used for this project" preference survives across sessions even if
+the agent's own session storage is wiped.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Subtab introduces a back/forward inconsistency — user expects browser back to flip subtabs | Reflect subtab in `location.hash` (`#projects` / `#history`), wire `hashchange` to update state |
+| Auto-register could pollute the registry when user starts ad-hoc sessions in `/tmp` | Only auto-register when `projectDir` is under `$HOME` and is a git repo or has been launched ≥2 times |
+| Default agent setting drifts if the binary is uninstalled later | On boot, if `settings.defaultAgent` is not in `installed`, fall back to first installed and silently null the stored value next save |
+| Agent detection latency on slow disks | Cache result; only re-detect on explicit refresh or server restart |
+| macOS app-bundle detection (`/Applications/Cursor.app`) doesn't mean CLI is on PATH | Distinguish `detectedVia: 'app-bundle'`. For these, launch falls back to `open -a "Cursor"` instead of CLI command — out of scope for this PR; we mark them installed but the launch handler is left to a follow-up. Document in `impl-notes.md` |
+| Settings file race with rapid PUTs | Use the same mutex pattern as `projects.js` / `updateGitHubProfile` |
+
+## Test surface
+
+Each scenario from `specs/projects-tab-restructure.feature` becomes a failing test before implementation:
+
+1. Landing renders zero-state when registry is empty.
+2. Landing renders cards from `projects.json` with `▶ New` enabled only when ≥1 detected agent.
+3. Clicking `▶ New` with no `lastUsed` and `defaultAgent=null` falls back to first installed.
+4. Clicking `⏷` opens picker with only installed agents.
+5. Picker click launches with that specific tool, does not mutate `defaultAgent`.
+6. Settings PUT with uninstalled agent → 400.
+7. Auto-register fires when launching from a path not in registry; toast surfaced.
+8. `#history` deeplink with query param filter renders only that project's sessions.
+9. Tokens never appear in `/api/settings` or `/api/agents/installed` response bodies.
+
+## Migration & rollback
+
+- New files only: `src/settings.js`, `src/agents-detect.js`, `specs/projects-tab-restructure.feature`, `docs/design/projects-tab-restructure.md`.
+- Existing files modified additively: `src/server.js`, `src/frontend/{index.html,app.js,styles.css}`, `src/projects.js` (just `ALLOWED_SOURCES` enum extension).
+- Rollback = `git revert` of the merge commit; `settings.json` becomes orphaned in `~/.codedash/` but causes no harm (server tolerates its absence).
+
+## Out of scope
+
+- App-bundle launch handler (open -a for Cursor.app etc.) — flagged for a follow-up PR.
+- Per-project default agent override (only global default is configurable now).
+- Schedule-on-launch / templated launch (env vars, flags) — future work.
+- Windows-native detection (we cover macOS, Linux, WSL).

--- a/specs/projects-tab-restructure.feature
+++ b/specs/projects-tab-restructure.feature
@@ -1,0 +1,177 @@
+Feature: Projects tab restructure with launcher landing + History subtab
+
+  Background:
+    Given codbash is running locally on http://localhost:8765
+    And the registry file at ~/.codedash/projects.json exists
+    And the settings file at ~/.codedash/settings.json may or may not exist
+
+  # ─── Subtab navigation ────────────────────────────────────────
+
+  Scenario: Default landing on Projects subtab (happy)
+    Given the user has 2 registered projects
+    When the user clicks "Projects" in the sidebar
+    Then the URL hash becomes "#projects"
+    And the subtab strip shows "Projects" active and "History" inactive
+    And the page renders 2 launcher cards
+    And the page does NOT render grouped session lists
+
+  Scenario: Switch to History subtab preserves all today's behavior (happy)
+    Given the user is on Projects subtab
+    When the user clicks the "History" subtab
+    Then the URL hash becomes "#history"
+    And the page renders the same grouped-by-project session list that the
+        current Projects view renders today, with no behavioral change
+    And clicking any session opens the existing detail drawer
+    And the collapse/expand buttons still work
+
+  Scenario: Subtab choice persists across reload (edge)
+    Given the user is on the History subtab
+    When the user reloads the page
+    Then the History subtab is still active
+    And localStorage key "codedash-projects-subtab" equals "history"
+
+  Scenario: Deeplink from a launcher card to History filtered (happy)
+    Given the user is on Projects subtab
+    And the user has a registered project at "/Users/me/code/flow-tasks"
+    When the user clicks "View sessions →" on that card
+    Then the active subtab becomes History
+    And the History view is filtered to project path "/Users/me/code/flow-tasks"
+    And the URL hash includes both "history" and the filter
+
+  # ─── Launcher landing — default agent flow ────────────────────
+
+  Scenario: ▶ New uses last-used tool for that project (happy)
+    Given the user has launched flow-tasks with Claude Code previously
+    And settings.defaultAgent is "cursor"
+    When the user clicks "▶ New" on the flow-tasks card
+    Then /api/launch is POSTed with tool="claude" and mode="fresh"
+    And the terminal opens a Claude Code session
+    # last-used wins over default
+
+  Scenario: ▶ New falls back to default when no last-used (happy)
+    Given the user has never launched a session for "my-project"
+    And settings.defaultAgent is "cursor"
+    When the user clicks "▶ New" on the my-project card
+    Then /api/launch is POSTed with tool="cursor" and mode="fresh"
+
+  Scenario: ▶ New falls back to first installed when no last-used and no default (edge)
+    Given the user has never launched a session for "my-project"
+    And settings.defaultAgent is null
+    And the installed-agents list returns ["claude", "codex"] in that order
+    When the user clicks "▶ New"
+    Then /api/launch is POSTed with tool="claude"
+
+  Scenario: ▶ New fails gracefully when no agents are installed (negative)
+    Given the installed-agents list is empty
+    When the user clicks "▶ New" on any card
+    Then no /api/launch request is sent
+    And a toast appears with text containing "No agent installed"
+    And a link "Install agents →" points to the sidebar Install Agents section
+
+  # ─── Per-launch override picker ───────────────────────────────
+
+  Scenario: ⏷ picker shows only installed agents (happy)
+    Given the installed-agents list is ["claude", "cursor"]
+    When the user clicks "⏷" next to "▶ New" on a project card
+    Then a popover opens with exactly 2 items: "Claude Code" and "Cursor"
+    And no other agent ids appear in the popover DOM
+
+  Scenario: Picker launch does not mutate default (happy)
+    Given settings.defaultAgent is "claude"
+    When the user clicks "⏷" and selects "Cursor"
+    Then /api/launch is POSTed with tool="cursor"
+    And /api/settings is NOT called
+    And settings.defaultAgent remains "claude" after reload
+
+  Scenario: Picker dismisses on outside click (edge)
+    Given the picker popover is open
+    When the user clicks anywhere outside the popover
+    Then the popover closes without launching anything
+
+  # ─── Settings modal ───────────────────────────────────────────
+
+  Scenario: Settings modal lists installed agents only (happy)
+    Given the installed-agents list is ["claude", "codex", "cursor"]
+    When the user clicks the "⚙ Settings" button in the Projects toolbar
+    Then the Settings modal opens
+    And the "Default agent" select offers exactly: (none), Claude Code, Codex, Cursor
+
+  Scenario: Save default agent persists (happy)
+    Given the Settings modal is open
+    When the user selects "Cursor" and clicks Save
+    Then PUT /api/settings is called with {"defaultAgent":"cursor"}
+    And the response is 200
+    And ~/.codedash/settings.json contains "defaultAgent": "cursor"
+    And the file mode is 0600
+
+  Scenario: Cannot save an uninstalled agent as default (negative)
+    Given the installed-agents list is ["claude"]
+    When a client PUTs /api/settings with {"defaultAgent":"cursor"}
+    Then the response is HTTP 400
+    And the response body contains "not installed"
+    And ~/.codedash/settings.json is not modified
+
+  Scenario: Stale default falls back on boot (edge)
+    Given settings.defaultAgent is "cursor" but cursor was uninstalled
+    When codbash starts
+    Then GET /api/settings returns defaultAgent: null
+    And on next save the stale value is cleared from disk
+
+  # ─── Agent detection ──────────────────────────────────────────
+
+  Scenario: Detection finds CLI on PATH (happy)
+    Given /usr/local/bin/claude exists and is executable
+    When GET /api/agents/installed is called
+    Then the response contains an agent with id="claude", detectedVia="path"
+    And binPath is "/usr/local/bin/claude"
+
+  Scenario: Detection finds macOS app bundle (happy)
+    Given /Applications/Cursor.app exists
+    And cursor is not on PATH
+    When GET /api/agents/installed is called
+    Then the response contains an agent with id="cursor", detectedVia="app-bundle"
+
+  Scenario: Refresh re-runs detection (happy)
+    Given GET /api/agents/installed returned 1 agent at boot
+    And the user installs a second agent
+    When POST /api/agents/refresh-detect is called
+    Then the next GET /api/agents/installed returns 2 agents
+    And refreshedAt is newer
+
+  # ─── Auto-register on first launch ────────────────────────────
+
+  Scenario: Auto-register adds unknown path to registry (happy)
+    Given ~/.codedash/projects.json contains 0 projects
+    And the user has a git repo at "$HOME/code/new-thing"
+    When POST /api/launch is called with project="$HOME/code/new-thing", mode="fresh"
+    Then the launch succeeds
+    And the response body contains registered.source="auto"
+    And ~/.codedash/projects.json now contains 1 project at that path
+    And the frontend shows a toast "Added new-thing to Projects"
+
+  Scenario: Auto-register declines paths outside HOME (negative)
+    Given a fresh launch is requested for "/tmp/throwaway"
+    When the launch succeeds
+    Then the response body does NOT contain a "registered" field
+    And ~/.codedash/projects.json is unchanged
+
+  Scenario: Auto-register opt-out via flag (edge)
+    Given POST /api/launch is called with autoRegister=false
+    And the project is unknown
+    When the launch succeeds
+    Then no entry is added to projects.json
+    And no toast is shown
+
+  # ─── Security ─────────────────────────────────────────────────
+
+  Scenario: GitHub tokens never appear in new responses (negative)
+    Given ~/.codedash/github-profile.json contains a valid OAuth token
+    When the client calls /api/settings, /api/agents/installed, /api/agents/refresh-detect
+    Then none of the response bodies contain the substring "gho_"
+    And none contain a "token" or "repoToken" field
+
+  Scenario: settings.json is written with mode 0600 (happy)
+    Given /api/settings is PUT for the first time
+    When the write completes
+    Then ~/.codedash/settings.json has file mode 0600
+    And concurrent PUTs are serialized (last write wins, no partial file)

--- a/src/agents-detect.js
+++ b/src/agents-detect.js
@@ -17,6 +17,17 @@ const SAFE_BIN_NAME = /^[A-Za-z0-9._-]{1,64}$/;
 
 // Mapping: agent id → CLI binary name + optional macOS .app bundle name.
 // Ordering here defines the preference order returned by detect().
+//
+// Special detectors:
+// - `customCheck(ctx)` — runs an arbitrary predicate when a simple PATH or
+//   app-bundle lookup isn't enough. Used for Copilot variants because each
+//   ships as a *plugin* on top of an unrelated host:
+//     * copilot (CLI) = `gh-copilot` extension installed under `gh` —
+//       having `gh` on PATH is NOT enough.
+//     * copilot-chat = VS Code extension under `~/.vscode/extensions/` —
+//       having VS Code installed is NOT enough.
+//   This avoids false positives that confused users into thinking they had
+//   Copilot when they only had its host app.
 const AGENT_DEFS = Object.freeze([
   { id: 'claude',       label: 'Claude Code',  bin: 'claude' },
   { id: 'codex',        label: 'Codex',        bin: 'codex' },
@@ -25,10 +36,49 @@ const AGENT_DEFS = Object.freeze([
   { id: 'kilo',         label: 'Kilo',         bin: 'kilo' },
   { id: 'kiro',         label: 'Kiro CLI',     bin: 'kiro-cli' },
   { id: 'opencode',     label: 'OpenCode',     bin: 'opencode' },
-  { id: 'copilot',      label: 'Copilot CLI',  bin: 'gh' }, // requires `gh copilot`; presence of gh is the proxy
-  // copilot-chat is a VS Code extension only — detect via app bundle.
-  { id: 'copilot-chat', label: 'Copilot Chat', appBundle: 'Visual Studio Code.app' },
+  { id: 'copilot',      label: 'Copilot CLI',  customCheck: 'ghCopilotExtension' },
+  { id: 'copilot-chat', label: 'Copilot Chat', customCheck: 'vscodeCopilotChatExtension' },
 ]);
+
+// Custom detectors return { ok: true, detectedVia: <string> } or null.
+function ghCopilotExtension() {
+  // gh-copilot extension lives under the gh data dir. Locations vary by OS
+  // but the layout is stable: <data>/gh/extensions/gh-copilot/
+  var candidates = [
+    path.join(os.homedir(), '.local', 'share', 'gh', 'extensions', 'gh-copilot'),
+    // macOS sometimes uses XDG_DATA_HOME if set, otherwise still ~/.local/share
+    process.env.XDG_DATA_HOME ? path.join(process.env.XDG_DATA_HOME, 'gh', 'extensions', 'gh-copilot') : null,
+    // Windows: %LOCALAPPDATA%\GitHub CLI\extensions\gh-copilot
+    process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'GitHub CLI', 'extensions', 'gh-copilot') : null,
+  ].filter(Boolean);
+  for (var i = 0; i < candidates.length; i++) {
+    try {
+      if (fs.statSync(candidates[i]).isDirectory()) {
+        return { ok: true, detectedVia: 'gh-extension' };
+      }
+    } catch (_) { /* not present here */ }
+  }
+  return null;
+}
+
+function vscodeCopilotChatExtension() {
+  // VS Code extensions live in ~/.vscode/extensions/<publisher>.<name>-<version>/
+  // The Copilot Chat extension publishes as `github.copilot-chat`.
+  var extDir = path.join(os.homedir(), '.vscode', 'extensions');
+  try {
+    var entries = fs.readdirSync(extDir);
+    var hit = entries.some(function(name) {
+      return /^github\.copilot-chat(-.*)?$/.test(name);
+    });
+    if (hit) return { ok: true, detectedVia: 'vscode-extension' };
+  } catch (_) { /* extensions dir missing */ }
+  return null;
+}
+
+var CUSTOM_CHECKS = {
+  ghCopilotExtension: ghCopilotExtension,
+  vscodeCopilotChatExtension: vscodeCopilotChatExtension,
+};
 
 function realWhich(bin) {
   if (!SAFE_BIN_NAME.test(bin)) return null;
@@ -73,6 +123,7 @@ async function detect(ctx) {
   const platform = ctx.platform || process.platform;
   const which = ctx.which || realWhich;
   const appBundleExists = ctx.appBundleExists || realAppBundleExists;
+  const customChecks = ctx.customChecks || CUSTOM_CHECKS;
   const out = [];
   for (const def of AGENT_DEFS) {
     let detectedVia = null;
@@ -87,6 +138,13 @@ async function detect(ctx) {
     if (!detectedVia && def.appBundle && platform === 'darwin') {
       if (appBundleExists(def.appBundle)) {
         detectedVia = 'app-bundle';
+      }
+    }
+    if (!detectedVia && def.customCheck) {
+      const fn = customChecks[def.customCheck];
+      const result = typeof fn === 'function' ? fn() : null;
+      if (result && result.ok) {
+        detectedVia = result.detectedVia || 'custom';
       }
     }
     if (detectedVia) {

--- a/src/agents-detect.js
+++ b/src/agents-detect.js
@@ -1,0 +1,112 @@
+// Agent detection — probes PATH for known CLIs, falls back to /Applications/*.app
+// on macOS for agents that ship as an app bundle (notably Cursor.app).
+//
+// The result is cached for the server lifetime; the server exposes a refresh
+// endpoint that calls `detectRealOS({ force: true })` to re-run detection
+// after the user installs something new.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Defense-in-depth: the `bin` values come from a constant table, but if a
+// future change ever wires user input here, this regex bounds what we will
+// pass to a shell. POSIX binary names are letters, digits, ., _, -.
+const SAFE_BIN_NAME = /^[A-Za-z0-9._-]{1,64}$/;
+
+// Mapping: agent id → CLI binary name + optional macOS .app bundle name.
+// Ordering here defines the preference order returned by detect().
+const AGENT_DEFS = Object.freeze([
+  { id: 'claude',       label: 'Claude Code',  bin: 'claude' },
+  { id: 'codex',        label: 'Codex',        bin: 'codex' },
+  { id: 'cursor',       label: 'Cursor',       bin: 'cursor-agent', appBundle: 'Cursor.app' },
+  { id: 'qwen',         label: 'Qwen Code',    bin: 'qwen' },
+  { id: 'kilo',         label: 'Kilo',         bin: 'kilo' },
+  { id: 'kiro',         label: 'Kiro CLI',     bin: 'kiro-cli' },
+  { id: 'opencode',     label: 'OpenCode',     bin: 'opencode' },
+  { id: 'copilot',      label: 'Copilot CLI',  bin: 'gh' }, // requires `gh copilot`; presence of gh is the proxy
+  // copilot-chat is a VS Code extension only — detect via app bundle.
+  { id: 'copilot-chat', label: 'Copilot Chat', appBundle: 'Visual Studio Code.app' },
+]);
+
+function realWhich(bin) {
+  if (!SAFE_BIN_NAME.test(bin)) return null;
+  if (process.platform === 'win32') {
+    try {
+      const out = execFileSync('where', [bin], { encoding: 'utf8', timeout: 2000, windowsHide: true });
+      const first = out.split(/\r?\n/).map(s => s.trim()).find(Boolean);
+      return first || null;
+    } catch { return null; }
+  }
+  // Walk $PATH directly — avoids invoking a shell entirely. This is portable
+  // across macOS/Linux/WSL and removes any risk that a future change to the
+  // bin-name table could surface a shell metacharacter.
+  const pathDirs = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  for (const dir of pathDirs) {
+    const candidate = path.join(dir, bin);
+    try {
+      const st = fs.statSync(candidate);
+      if (st.isFile() && (st.mode & 0o111)) return candidate;
+    } catch { /* not present in this PATH entry */ }
+  }
+  return null;
+}
+
+function realAppBundleExists(name) {
+  if (process.platform !== 'darwin') return false;
+  // Use os.homedir() instead of process.env.HOME — `HOME` may be missing in
+  // sandboxed CI/launchd environments, which would otherwise turn the lookup
+  // into a relative path that matches cwd-local directories.
+  const candidates = [
+    path.join('/Applications', name),
+    path.join(os.homedir(), 'Applications', name),
+  ];
+  return candidates.some(p => {
+    try { return fs.statSync(p).isDirectory(); } catch { return false; }
+  });
+}
+
+// Pure detector — accepts a context object so tests can stub PATH and bundle
+// lookups deterministically. Real callers should use detectRealOS() below.
+async function detect(ctx) {
+  const platform = ctx.platform || process.platform;
+  const which = ctx.which || realWhich;
+  const appBundleExists = ctx.appBundleExists || realAppBundleExists;
+  const out = [];
+  for (const def of AGENT_DEFS) {
+    let detectedVia = null;
+    let binPath;
+    if (def.bin) {
+      const found = which(def.bin);
+      if (found) {
+        detectedVia = 'path';
+        binPath = found;
+      }
+    }
+    if (!detectedVia && def.appBundle && platform === 'darwin') {
+      if (appBundleExists(def.appBundle)) {
+        detectedVia = 'app-bundle';
+      }
+    }
+    if (detectedVia) {
+      const entry = { id: def.id, label: def.label, detectedVia };
+      if (binPath) entry.binPath = binPath;
+      out.push(entry);
+    }
+  }
+  return { agents: out, refreshedAt: new Date().toISOString() };
+}
+
+let _cache = null;
+async function detectRealOS({ force } = {}) {
+  if (_cache && !force) return _cache;
+  _cache = await detect({});
+  return _cache;
+}
+
+module.exports = {
+  detect,
+  detectRealOS,
+  AGENT_DEFS,
+};

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1428,7 +1428,9 @@ function renderLauncherCard(projKey, projInfo) {
   var projName = projInfo.name;
   var projPath = projInfo.path;
   var color = getProjectColor(projName);
-  var list = projInfo.list || [];
+  // Sort by last_ts desc so lastSession is reliably the most recent — the
+  // upstream sessions feed doesn't guarantee insertion order matches recency.
+  var list = (projInfo.list || []).slice().sort(function(a, b) { return (b.last_ts || 0) - (a.last_ts || 0); });
   var lastSession = list[0];
   var totalSessions = list.length;
 
@@ -1530,11 +1532,24 @@ function mergeRegistryWithSessions(sessions) {
 
 // Shared sort: most-recent session timestamp first; falls back to the
 // registry add date when no session exists yet.
+// Most-recent timestamp across all of a project's sessions; falls back to the
+// registry add date when there are no sessions yet. Used to sort the launcher
+// grid by activity (desc) so the project you used most recently is on top.
+function projectActivityTs(projInfo) {
+  if (projInfo.list && projInfo.list.length) {
+    var maxTs = 0;
+    for (var i = 0; i < projInfo.list.length; i++) {
+      var t = projInfo.list[i].last_ts;
+      if (t && t > maxTs) maxTs = t;
+    }
+    if (maxTs) return maxTs;
+  }
+  return projInfo._lastAdded ? Date.parse(projInfo._lastAdded) : 0;
+}
+
 function sortMergedEntries(byPath) {
   return Object.entries(byPath).sort(function(a, b) {
-    var aTs = a[1].list[0] ? a[1].list[0].last_ts : (a[1]._lastAdded ? Date.parse(a[1]._lastAdded) : 0);
-    var bTs = b[1].list[0] ? b[1].list[0].last_ts : (b[1]._lastAdded ? Date.parse(b[1]._lastAdded) : 0);
-    return bTs - aTs;
+    return projectActivityTs(b[1]) - projectActivityTs(a[1]);
   });
 }
 

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1354,11 +1354,21 @@ function switchProjectsSubtab(next) {
 // projects that have sessions but no registry entry yet (so the user can still
 // resume them with one click).
 function renderProjectsLanding(container, sessions) {
-  // Build the same merged map as History does, but only render the launcher
-  // surface. History still shows the grouped session lists with everything
-  // we had before.
+  // Projects landing shows ONLY the registry — projects you explicitly added
+  // via "+ Add Project", cloned from GitHub, or that got auto-registered on
+  // first launch. Session-derived folders (every directory that ever held a
+  // Claude/Cursor/Codex session) live exclusively in the History subtab.
+  // This keeps the launcher focused on "things I'm actively working on" and
+  // not a dump of every workspace I've ever opened.
   var byPath = mergeRegistryWithSessions(sessions);
-  var entries = sortMergedEntries(byPath);
+  // Filter to registry-only entries — `manualId` is set when the project came
+  // from projects.json (manual / github-clone / auto). Pure session-derived
+  // entries don't have it.
+  var registryOnly = {};
+  Object.keys(byPath).forEach(function(k) {
+    if (byPath[k].manualId) registryOnly[k] = byPath[k];
+  });
+  var entries = sortMergedEntries(registryOnly);
 
   // Loading guard — keep the "no agent installed" banner from flashing on
   // first paint while /api/agents/installed is still in flight.
@@ -1389,9 +1399,12 @@ function renderProjectsLanding(container, sessions) {
 
   if (entries.length === 0) {
     container.innerHTML = toolbar +
-      '<div class="projects-empty">No projects yet. ' +
-      '<button class="toolbar-btn toolbar-btn-primary" onclick="openAddProject()" style="margin:8px 0">+ Add Project</button><br>' +
-      '<span style="font-size:12px">Or start a fresh session in any folder under your home directory and it will be auto-registered.</span></div>';
+      '<div class="projects-empty">No registered projects yet.<br>' +
+      '<button class="toolbar-btn toolbar-btn-primary" onclick="openAddProject()" style="margin:12px 0">+ Add Project</button><br>' +
+      '<span style="font-size:12px">Register a local folder or clone one from GitHub. ' +
+      'You can also start a fresh session in any git repo under your home directory ' +
+      '— it will be auto-registered.<br><br>' +
+      'Previous sessions are still available in the <strong>History</strong> subtab above.</span></div>';
     return;
   }
 

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -2738,6 +2738,52 @@ function _uninstallModalFocusTrap() {
   _modalFocusReturn = null;
 }
 
+// Full agent catalogue (id + label + how it's detected) — used to render the
+// "Detected agents" list including the not-installed entries, so the user can
+// see why a given agent is missing and what install method we expected.
+const _ALL_AGENT_META = [
+  { id: 'claude',       label: 'Claude Code',  expects: 'claude on PATH' },
+  { id: 'codex',        label: 'Codex',        expects: 'codex on PATH' },
+  { id: 'cursor',       label: 'Cursor',       expects: 'cursor-agent on PATH, or Cursor.app on macOS' },
+  { id: 'qwen',         label: 'Qwen Code',    expects: 'qwen on PATH' },
+  { id: 'kilo',         label: 'Kilo',         expects: 'kilo on PATH' },
+  { id: 'kiro',         label: 'Kiro CLI',     expects: 'kiro-cli on PATH' },
+  { id: 'opencode',     label: 'OpenCode',     expects: 'opencode on PATH' },
+  { id: 'copilot',      label: 'Copilot CLI',  expects: '~/.local/share/gh/extensions/gh-copilot' },
+  { id: 'copilot-chat', label: 'Copilot Chat', expects: '~/.vscode/extensions/github.copilot-chat-*' },
+];
+
+function renderDetectedAgentsList(targetEl) {
+  if (!targetEl) return;
+  var installed = window.installedAgents || [];
+  var installedById = {};
+  installed.forEach(function(a) { installedById[a.id] = a; });
+
+  var html = '';
+  _ALL_AGENT_META.forEach(function(meta) {
+    var hit = installedById[meta.id];
+    if (hit) {
+      var viaLabel = hit.detectedVia === 'path' ? 'PATH'
+        : hit.detectedVia === 'app-bundle' ? 'macOS .app'
+        : hit.detectedVia === 'gh-extension' ? 'gh extension'
+        : hit.detectedVia === 'vscode-extension' ? 'VS Code extension'
+        : String(hit.detectedVia || 'detected');
+      html += '<div class="ps-detected-item installed">'
+        + '<span class="ps-detected-status installed" aria-label="Installed">✓ Installed</span>'
+        + '<span class="ps-detected-name">' + escHtml(meta.label) + '</span>'
+        + '<span class="ps-detected-via" title="Detected via ' + escHtml(viaLabel) + '">' + escHtml(viaLabel) + '</span>'
+        + '</div>';
+    } else {
+      html += '<div class="ps-detected-item missing">'
+        + '<span class="ps-detected-status missing" aria-label="Not installed">— Not installed</span>'
+        + '<span class="ps-detected-name">' + escHtml(meta.label) + '</span>'
+        + '<span class="ps-detected-via" title="Expected: ' + escHtml(meta.expects) + '">' + escHtml(meta.expects) + '</span>'
+        + '</div>';
+    }
+  });
+  targetEl.innerHTML = html;
+}
+
 function openProjectsSettings() {
   var overlay = document.getElementById('projectsSettingsOverlay');
   if (!overlay) return;
@@ -2752,7 +2798,8 @@ function openProjectsSettings() {
   if (select) select.innerHTML = html;
   var err = document.getElementById('psError'); if (err) err.textContent = '';
   var status = document.getElementById('psDetectStatus');
-  if (status) status.textContent = agents.length + ' agent' + (agents.length === 1 ? '' : 's') + ' detected';
+  if (status) status.textContent = agents.length + ' of ' + _ALL_AGENT_META.length + ' agents installed';
+  renderDetectedAgentsList(document.getElementById('psDetectedList'));
   overlay.classList.add('open');
   overlay.setAttribute('aria-hidden', 'false');
   _installModalFocusTrap(overlay);

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -24,6 +24,24 @@ let activeSessions = {}; // sessionId -> {status, cpu, memoryMB, pid}
 let renderLimit = 60; // pagination — render at most this many cards
 const RENDER_PAGE_SIZE = 60;
 
+// Projects tab subtab state — persisted across reloads via localStorage and
+// reflected in location.hash so back/forward navigates between subtabs.
+// Resolution: URL hash wins (so a shared link always opens the right subtab),
+// localStorage second (user's last choice), default 'projects'.
+let currentProjectsSubtab = (function() {
+  var fromHash = (location.hash || '').replace(/^#/, '');
+  if (fromHash === 'history') return 'history';
+  if (fromHash === 'projects') return 'projects';
+  try {
+    return localStorage.getItem('codedash-projects-subtab') === 'history' ? 'history' : 'projects';
+  } catch (e) { return 'projects'; }
+})();
+
+// Agent detection + UI settings — populated on boot from /api/agents/installed
+// and /api/settings. Kept on window so deep helpers can read without prop drilling.
+window.installedAgents = window.installedAgents || [];
+window.codbashSettings = window.codbashSettings || { defaultAgent: null, lastUsedByPath: {} };
+
 // Persisted in localStorage
 let stars = JSON.parse(localStorage.getItem('codedash-stars') || '[]');
 let tags = JSON.parse(localStorage.getItem('codedash-tags') || '{}');
@@ -154,8 +172,16 @@ function timeAgo(dateStr) {
 }
 
 function escHtml(s) {
-  if (!s) return '';
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  if (s === null || s === undefined) return '';
+  // Cover both quote characters so a future onclick string interpolation
+  // using single-quoted attributes is still safe. The cost is two extra
+  // string replacements; the win is consistent defense-in-depth.
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function showToast(msg) {
@@ -1245,41 +1271,339 @@ function renderQACard(s, idx) {
   return html;
 }
 
+// Dispatcher: routes Projects view to either the launcher landing or the
+// History sub-page based on currentProjectsSubtab. Keeps backwards-compat
+// callers (renderProjects(container, sessions)) working.
 function renderProjects(container, sessions) {
-  var byGit = {};   // key → { name, list, path, source, manualId }
+  var subtab = currentProjectsSubtab || 'projects';
+  // Keep URL hash in sync with the rendered subtab so copying the URL produces
+  // a link to what the user actually sees. replaceState avoids creating an
+  // extra history entry on each render.
+  var expectedHash = '#' + subtab;
+  if (location.hash !== expectedHash) {
+    try { history.replaceState(null, '', expectedHash); }
+    catch (e) { /* ignore — non-browser test envs */ }
+  }
+  var stripHtml = renderProjectsSubtabStrip(subtab);
+  if (subtab === 'history') {
+    container.innerHTML = stripHtml + '<div id="projectsHistoryContent" role="tabpanel" aria-labelledby="projectsSubtabHistory"></div>';
+    var historyEl = container.querySelector('#projectsHistoryContent');
+    renderProjectsHistory(historyEl, sessions);
+  } else {
+    container.innerHTML = stripHtml + '<div id="projectsLandingContent" role="tabpanel" aria-labelledby="projectsSubtabProjects"></div>';
+    var landingEl = container.querySelector('#projectsLandingContent');
+    renderProjectsLanding(landingEl, sessions);
+  }
+}
+
+function renderProjectsSubtabStrip(active) {
+  var safe = active === 'history' ? 'history' : 'projects';
+  // WAI-ARIA tab pattern: tablist + tab + tabpanel. The strip is keyboard-
+  // reachable via Tab, and left/right arrows are wired in onProjectsKeydown.
+  return '<div class="projects-subtabs" role="tablist" aria-label="Projects subtabs" onkeydown="onProjectsSubtabKey(event)">' +
+    '<button id="projectsSubtabProjects" class="projects-subtab' + (safe === 'projects' ? ' active' : '') + '" ' +
+      'role="tab" aria-selected="' + (safe === 'projects' ? 'true' : 'false') + '" ' +
+      'aria-controls="projectsLandingContent" tabindex="' + (safe === 'projects' ? '0' : '-1') + '" ' +
+      'onclick="switchProjectsSubtab(\'projects\')">Projects</button>' +
+    '<button id="projectsSubtabHistory" class="projects-subtab' + (safe === 'history' ? ' active' : '') + '" ' +
+      'role="tab" aria-selected="' + (safe === 'history' ? 'true' : 'false') + '" ' +
+      'aria-controls="projectsHistoryContent" tabindex="' + (safe === 'history' ? '0' : '-1') + '" ' +
+      'onclick="switchProjectsSubtab(\'history\')">History</button>' +
+    '</div>';
+}
+
+// Left/Right cycle between the two subtabs, Home/End jump to ends — standard
+// WAI-ARIA tablist behavior.
+function onProjectsSubtabKey(e) {
+  var k = e.key;
+  if (k === 'ArrowLeft' || k === 'ArrowRight' || k === 'Home' || k === 'End') {
+    e.preventDefault();
+    var next = (k === 'ArrowRight' || k === 'End') ? 'history' : 'projects';
+    setProjectsSubtab(next);
+    var focusId = next === 'projects' ? 'projectsSubtabProjects' : 'projectsSubtabHistory';
+    var el = document.getElementById(focusId);
+    if (el) el.focus();
+  }
+}
+
+// Single mutator for the subtab — every caller goes through here so the
+// localStorage value, the hash, and the variable can never drift apart.
+function setProjectsSubtab(next) {
+  if (next !== 'projects' && next !== 'history') return;
+  if (currentProjectsSubtab === next) {
+    // Even when value is unchanged we may need to re-render (e.g. filter
+    // changed). Caller is responsible for invoking render() if so.
+    return;
+  }
+  currentProjectsSubtab = next;
+  try { localStorage.setItem('codedash-projects-subtab', next); } catch (e) { /* private-mode safe */ }
+  // replaceState keeps the URL in sync without creating a fresh history
+  // entry on every click — back-button still works between subtabs because
+  // hashchange listens for explicit user navigation.
+  try { history.replaceState(null, '', '#' + next); }
+  catch (e) { location.hash = next; }
+  render();
+}
+
+function switchProjectsSubtab(next) {
+  // Backward-compat name kept for the inline onclick handlers in the strip.
+  setProjectsSubtab(next);
+}
+
+// Landing page — launcher cards. One per registered project plus, optionally,
+// projects that have sessions but no registry entry yet (so the user can still
+// resume them with one click).
+function renderProjectsLanding(container, sessions) {
+  // Build the same merged map as History does, but only render the launcher
+  // surface. History still shows the grouped session lists with everything
+  // we had before.
+  var byPath = mergeRegistryWithSessions(sessions);
+  var entries = sortMergedEntries(byPath);
+
+  // Loading guard — keep the "no agent installed" banner from flashing on
+  // first paint while /api/agents/installed is still in flight.
+  var agentsLoaded = window._agentsDetectionLoaded === true;
+  var installed = (window.installedAgents || []).map(function(a) { return a.id; });
+  var canLaunch = installed.length > 0;
+
+  var toolbar = '<div class="projects-toolbar" role="toolbar" aria-label="Projects actions">' +
+    '<button class="toolbar-btn toolbar-btn-primary" onclick="openAddProject()" title="Register a local folder or clone from GitHub" aria-label="Add a new project">+ Add Project</button>' +
+    '<button class="toolbar-btn" onclick="openProjectsSettings()" aria-label="Open projects settings">⚙ Settings</button>' +
+    // Warning is only emitted once detection has actually completed — otherwise
+    // a first-paint user sees the warning flash, then disappear half a second
+    // later when the fetch resolves.
+    (agentsLoaded && !canLaunch
+      ? '<span class="projects-toolbar-warning" role="status">⚠ <span>Warning: no agent CLI detected on this machine — </span><a href="#install-agents" onclick="scrollToInstallAgents();return false;">install one</a> to launch sessions.</span>'
+      : '') +
+    '</div>';
+
+  // Pre-detection skeleton — keeps the layout stable while the agents list
+  // is loading and prevents disabled-button flicker.
+  if (!agentsLoaded) {
+    container.innerHTML = toolbar +
+      '<div class="projects-launcher-grid" aria-busy="true">' +
+      '<div class="launcher-card-skel"></div><div class="launcher-card-skel"></div><div class="launcher-card-skel"></div>' +
+      '</div>';
+    return;
+  }
+
+  if (entries.length === 0) {
+    container.innerHTML = toolbar +
+      '<div class="projects-empty">No projects yet. ' +
+      '<button class="toolbar-btn toolbar-btn-primary" onclick="openAddProject()" style="margin:8px 0">+ Add Project</button><br>' +
+      '<span style="font-size:12px">Or start a fresh session in any folder under your home directory and it will be auto-registered.</span></div>';
+    return;
+  }
+
+  var cardsHtml = '<div class="projects-launcher-grid">';
+  entries.forEach(function(entry) {
+    cardsHtml += renderLauncherCard(entry[0], entry[1]);
+  });
+  cardsHtml += '</div>';
+  container.innerHTML = toolbar + cardsHtml;
+}
+
+function scrollToInstallAgents() {
+  // Best-effort — there's no dedicated view, but the sidebar has an "Install
+  // Agents" section the user can scroll the sidebar to.
+  var section = Array.from(document.querySelectorAll('.sidebar-section'))
+    .find(function(el) { return el.textContent && el.textContent.indexOf('Install Agents') >= 0; });
+  if (section && section.scrollIntoView) section.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+function renderLauncherCard(projKey, projInfo) {
+  var projName = projInfo.name;
+  var projPath = projInfo.path;
+  var color = getProjectColor(projName);
+  var list = projInfo.list || [];
+  var lastSession = list[0];
+  var totalSessions = list.length;
+
+  var sourceTag = '';
+  if (projInfo.source === 'github-clone') sourceTag = '<span class="launcher-card-tag" title="Cloned from GitHub">github</span>';
+  else if (projInfo.source === 'manual') sourceTag = '<span class="launcher-card-tag" title="Manually added">added</span>';
+  else if (projInfo.source === 'auto') sourceTag = '<span class="launcher-card-tag" title="Auto-registered on first launch">auto</span>';
+
+  var preferredTool = pickPreferredTool(projPath, lastSession);
+  var installed = window.installedAgents || [];
+  var canLaunch = installed.length > 0 && !!projPath;
+
+  var html = '<div class="launcher-card">';
+  html += '<div class="launcher-card-header">';
+  html += '<span class="launcher-card-dot" style="background:' + color + '"></span>';
+  html += '<span class="launcher-card-name" title="' + escHtml(projName) + '">' + escHtml(projName) + '</span>';
+  html += sourceTag;
+  html += '</div>';
+  if (projPath) html += '<div class="launcher-card-path" title="' + escHtml(projPath) + '">' + escHtml(projPath) + '</div>';
+  html += '<div class="launcher-card-meta">';
+  html += '<span>' + (totalSessions === 0 ? 'no sessions yet' : (totalSessions + ' session' + (totalSessions === 1 ? '' : 's'))) + '</span>';
+  if (preferredTool) html += '<span>· next: ' + escHtml(agentLabel(preferredTool)) + '</span>';
+  html += '</div>';
+
+  html += '<div class="launcher-card-actions">';
+  if (canLaunch && preferredTool) {
+    var newAria = 'Start new ' + agentLabel(preferredTool) + ' session in ' + projName;
+    var pickerAria = 'Pick a different agent for ' + projName;
+    html += '<span class="split-btn" role="group" aria-label="Launch ' + escHtml(projName) + '">';
+    html += '<button class="git-project-launch-btn primary new-btn" ' +
+      'data-proj-path="' + escHtml(projPath) + '" data-tool="' + escHtml(preferredTool) + '" ' +
+      'onclick="launchNewProjectSession(this.dataset.projPath, this.dataset.tool)" ' +
+      'title="' + escHtml(newAria) + '" aria-label="' + escHtml(newAria) + '">&#9654; New</button>';
+    html += '<button class="git-project-launch-btn primary picker-btn" ' +
+      'data-proj-path="' + escHtml(projPath) + '" ' +
+      'onclick="openAgentPicker(event, this.dataset.projPath)" ' +
+      'aria-label="' + escHtml(pickerAria) + '" aria-haspopup="menu" aria-expanded="false" ' +
+      'title="' + escHtml(pickerAria) + '">&#9662;</button>';
+    html += '</span>';
+  } else if (projPath && !canLaunch) {
+    // Make the disabled button actionable for keyboard/touch users — click
+    // routes to the Install Agents sidebar section.
+    html += '<button class="git-project-launch-btn" onclick="scrollToInstallAgents()" ' +
+      'aria-label="Install an agent first" ' +
+      'title="No agent installed — click to scroll to Install Agents">&#9654; Install an agent →</button>';
+  }
+  if (lastSession && canLaunch) {
+    var lastId = lastSession.id || '';
+    var sessTool = lastSession.tool || '';
+    // If the session's original tool is no longer installed we still let the
+    // user resume — but warn them; the server will surface the failure if
+    // the tool can't actually be invoked.
+    var installedSet = new Set(installed);
+    var toolMissing = sessTool && !installedSet.has(sessTool);
+    var lastTool = sessTool && installedSet.has(sessTool) ? sessTool : (preferredTool || 'claude');
+    var lastTitle = toolMissing
+      ? 'Resume last session (' + lastId.slice(0,8) + ') — original tool "' + sessTool + '" not detected, falling back to ' + agentLabel(lastTool)
+      : 'Resume last session (' + lastId.slice(0,8) + ')';
+    html += '<button class="git-project-launch-btn"' + (toolMissing ? ' aria-describedby="toolMissingHint"' : '') + ' data-sess-id="' + escHtml(lastId) + '" data-sess-tool="' + escHtml(lastTool) + '" data-proj-path="' + escHtml(projPath) + '" onclick="resumeLastProjectSession(this.dataset.sessId,this.dataset.sessTool,this.dataset.projPath)" title="' + escHtml(lastTitle) + '" aria-label="' + escHtml(lastTitle) + '">&#x21bb; Last</button>';
+  }
+  if (projInfo.manualId) {
+    html += '<button class="git-project-launch-btn" data-proj-id="' + escHtml(projInfo.manualId) + '" data-proj-name="' + escHtml(projName) + '" onclick="unregisterProject(this.dataset.projId,this.dataset.projName)" title="Remove from registry (does not delete files)">&times;</button>';
+  }
+  html += '</div>';
+
+  if (totalSessions > 0) {
+    html += '<button class="launcher-card-link" data-proj-key="' + escHtml(projKey) + '" data-proj-name="' + escHtml(projName) + '" onclick="viewProjectInHistory(this.dataset.projKey,this.dataset.projName)">View ' + totalSessions + ' session' + (totalSessions === 1 ? '' : 's') + ' →</button>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function mergeRegistryWithSessions(sessions) {
+  var byGit = {};
   sessions.forEach(function(s) {
     var info = getRepoInfo(s.project, s.git_root);
     if (!byGit[info.key]) byGit[info.key] = { name: info.name, list: [], path: info.key !== 'unknown' ? info.key : '', source: 'session', manualId: '' };
     byGit[info.key].list.push(s);
   });
-
-  // Merge manually-registered projects (local-only or cloned from GitHub) so
-  // they appear as project cards even before any session exists for them.
   (window.manualProjects || []).forEach(function(p) {
     if (!byGit[p.path]) {
       byGit[p.path] = { name: p.name, list: [], path: p.path, source: p.source || 'manual', manualId: p.id, _git: p.git, _lastAdded: p.addedAt };
     } else {
-      // Existing key from sessions — annotate with manual id so the launcher
-      // buttons can still show source and offer "remove from registry".
-      byGit[p.path].manualId = p.id;
-      if (!byGit[p.path].source || byGit[p.path].source === 'session') byGit[p.path].source = p.source || 'manual';
+      // When a registry entry overlaps a session-derived entry, the registry's
+      // `source` (manual / github-clone / auto) is the authoritative one — only
+      // `session` is a placeholder we replace. This prevents auto-registered
+      // projects from being silently relabeled as `manual` after their first
+      // session appears.
+      var existing = byGit[p.path];
+      var keepRegistrySource = p.source && p.source !== 'session';
+      var resolvedSource = keepRegistrySource
+        ? p.source
+        : ((!existing.source || existing.source === 'session') ? 'manual' : existing.source);
+      byGit[p.path] = { ...existing, manualId: p.id, source: resolvedSource };
     }
   });
+  return byGit;
+}
 
-  var sorted = Object.entries(byGit).sort(function(a, b) {
+// Shared sort: most-recent session timestamp first; falls back to the
+// registry add date when no session exists yet.
+function sortMergedEntries(byPath) {
+  return Object.entries(byPath).sort(function(a, b) {
     var aTs = a[1].list[0] ? a[1].list[0].last_ts : (a[1]._lastAdded ? Date.parse(a[1]._lastAdded) : 0);
     var bTs = b[1].list[0] ? b[1].list[0].last_ts : (b[1]._lastAdded ? Date.parse(b[1]._lastAdded) : 0);
     return bTs - aTs;
   });
+}
 
-  var html = '<div style="display:flex;gap:8px;margin-bottom:12px;align-items:center">';
-  html += '<button class="toolbar-btn" onclick="openAddProject()" title="Register a local folder or clone from GitHub" style="background:#3b82f6;color:#fff;border-color:#3b82f6">+ Add Project</button>';
+function pickPreferredTool(projectPath, lastSession) {
+  var settings = window.codbashSettings || {};
+  var installed = (window.installedAgents || []).map(function(a) { return a.id; });
+  var installedSet = new Set(installed);
+  // 1. Server-tracked last-used (survives across machines if settings sync)
+  var fromSettings = settings.lastUsedByPath ? settings.lastUsedByPath[projectPath] : null;
+  if (fromSettings && installedSet.has(fromSettings)) return fromSettings;
+  // 2. Most recent session in this project (local observation)
+  if (lastSession && lastSession.tool && installedSet.has(lastSession.tool)) return lastSession.tool;
+  // 3. Configured default
+  if (settings.defaultAgent && installedSet.has(settings.defaultAgent)) return settings.defaultAgent;
+  // 4. First installed
+  return installed.length > 0 ? installed[0] : null;
+}
+
+// Hard-coded labels so we can render a friendly name even when /api/agents/installed
+// has not returned yet (or when the tool is no longer detected on this box).
+const _AGENT_LABEL_FALLBACK = {
+  claude: 'Claude Code', codex: 'Codex', cursor: 'Cursor', qwen: 'Qwen Code',
+  kilo: 'Kilo', kiro: 'Kiro CLI', opencode: 'OpenCode',
+  copilot: 'Copilot CLI', 'copilot-chat': 'Copilot Chat',
+};
+function agentLabel(id) {
+  var found = (window.installedAgents || []).find(function(a) { return a.id === id; });
+  return found ? found.label : (_AGENT_LABEL_FALLBACK[id] || id);
+}
+
+// History-scoped filter — kept separate from the global gitProjectFilter so
+// that clicking "View N sessions →" on a launcher card never leaves the
+// Projects view. The legacy drillIntoGitProject() filter pushes the user to
+// the Sessions sidebar item and clobbers the subtab context.
+let historyProjectFilter = null;
+
+function viewProjectInHistory(projKey, projName) {
+  historyProjectFilter = { key: projKey, name: projName };
+  setProjectsSubtab('history');
+}
+
+function clearHistoryProjectFilter() {
+  if (!historyProjectFilter) return;
+  historyProjectFilter = null;
+  if (currentView === 'projects') render();
+}
+
+// History subtab — preserves the exact behavior of the old Projects view.
+// Only addition: if `historyProjectFilter` is set (via "View N sessions →"
+// from a launcher card), the merged map is filtered to just that project so
+// the user lands on a focused list instead of the full registry.
+function renderProjectsHistory(container, sessions) {
+  var byGit = mergeRegistryWithSessions(sessions);
+
+  // Apply the History-scoped filter if a card pushed us here.
+  if (historyProjectFilter && historyProjectFilter.key) {
+    var filtered = {};
+    if (Object.prototype.hasOwnProperty.call(byGit, historyProjectFilter.key)) {
+      filtered[historyProjectFilter.key] = byGit[historyProjectFilter.key];
+    }
+    byGit = filtered;
+  }
+
+  var sorted = sortMergedEntries(byGit);
+
+  var html = '';
+  if (historyProjectFilter) {
+    html += '<div class="history-filter-bar" role="status">' +
+      'Filtered to <strong>' + escHtml(historyProjectFilter.name) + '</strong> ' +
+      '<button class="toolbar-btn" onclick="clearHistoryProjectFilter()" aria-label="Clear project filter">&times; Clear filter</button>' +
+      '</div>';
+  }
+  html += '<div style="display:flex;gap:8px;margin-bottom:12px;align-items:center">';
   html += '<button class="toolbar-btn" onclick="document.querySelectorAll(\'.git-project-group\').forEach(function(g){g.classList.add(\'collapsed\')})">Collapse All</button>';
   html += '<button class="toolbar-btn" onclick="document.querySelectorAll(\'.git-project-group\').forEach(function(g){g.classList.remove(\'collapsed\')})">Expand All</button>';
   html += '</div>';
 
   if (sorted.length === 0) {
-    container.innerHTML = html + '<div class="empty-state">No projects yet. Click <strong>+ Add Project</strong> to register a local folder or clone one from GitHub.</div>';
+    var msg = historyProjectFilter
+      ? 'No sessions for <strong>' + escHtml(historyProjectFilter.name) + '</strong>.'
+      : 'No sessions yet. Launch a session from the <strong>Projects</strong> subtab and it will appear here.';
+    container.innerHTML = html + '<div class="empty-state">' + msg + '</div>';
     return;
   }
 
@@ -2128,7 +2452,14 @@ async function checkForUpdates() {
       var banner = document.getElementById('updateBanner');
       var text = document.getElementById('updateText');
       if (banner && text) {
-        text.innerHTML = '<strong>v' + data.latest + '</strong> available';
+        // Build via textContent/DOM nodes — never interpolate the npm-supplied
+        // version string into innerHTML, otherwise a tampered registry response
+        // can inject arbitrary HTML into our update banner.
+        text.textContent = '';
+        var strong = document.createElement('strong');
+        strong.textContent = 'v' + String(data.latest || '');
+        text.appendChild(strong);
+        text.appendChild(document.createTextNode(' available'));
         banner.style.display = 'flex';
       }
     }
@@ -2168,7 +2499,8 @@ async function loadManualProjects() {
     window.manualProjects = Array.isArray(data) ? data : [];
     if (currentView === 'projects') render();
   } catch (e) {
-    console.warn('[codbash] loadManualProjects failed:', e && e.message);
+    // Silent failure — bootstrap continues with an empty registry. Errors
+    // surface through subsequent user actions if they ever matter.
   }
 }
 
@@ -2178,7 +2510,17 @@ function _currentTerminalId() {
 
 async function launchNewProjectSession(projectPath, tool) {
   if (!projectPath) { showToast('No project path'); return; }
-  var t = tool || 'claude';
+  var installed = (window.installedAgents || []).map(function(a) { return a.id; });
+  if (installed.length === 0) {
+    showToast('No agent installed — see Install Agents in the sidebar');
+    return;
+  }
+  // Tool resolution: caller hint → settings.lastUsedByPath → settings.defaultAgent
+  // → first installed. Caller hint may be stale; we still validate against the
+  // installed list so we never try to spawn a non-existent binary.
+  var t = tool && installed.indexOf(tool) >= 0 ? tool : null;
+  if (!t) t = pickPreferredTool(projectPath, null);
+  if (!t) { showToast('No agent installed'); return; }
   try {
     var resp = await fetch('/api/launch', {
       method: 'POST',
@@ -2192,10 +2534,263 @@ async function launchNewProjectSession(projectPath, tool) {
       }),
     });
     var data = await resp.json();
-    if (data.ok) showToast('Starting new ' + t + ' session in ' + projectPath.split('/').pop());
-    else showToast('Launch failed: ' + (data.error || 'unknown'));
+    if (data.ok) {
+      // Single toast — calling showToast twice in a row replaces the message
+      // before the user can read the first one. Merge auto-register info into
+      // the same line when present.
+      var name = projectPath.split('/').pop();
+      var msg = 'Started ' + agentLabel(t) + ' in ' + name;
+      if (data.registered) msg += ' — added to Projects';
+      showToast(msg);
+      if (data.registered) await loadManualProjects();
+      // Optimistically remember the chosen tool client-side so the next ▶ New
+      // defaults to it before the next fetch of /api/settings.
+      if (window.codbashSettings) {
+        window.codbashSettings.lastUsedByPath = window.codbashSettings.lastUsedByPath || {};
+        window.codbashSettings.lastUsedByPath[projectPath] = t;
+      }
+    } else {
+      showToast('Launch failed: ' + (data.error || 'unknown'));
+    }
   } catch (e) {
     showToast('Launch failed: ' + e.message);
+  }
+}
+
+// ── Per-launch agent picker popover ───────────────────────────
+
+// Picker width must agree with the CSS min-width so the viewport clamp can
+// keep the popover on-screen.
+const _PICKER_WIDTH = 180;
+let _pickerAnchor = null;
+
+function openAgentPicker(event, projectPath) {
+  if (event) { event.preventDefault(); event.stopPropagation(); }
+  var anchor = event && event.currentTarget ? event.currentTarget : null;
+  var picker = document.getElementById('agentPicker');
+  if (!picker || !anchor) return;
+  _pickerAnchor = anchor;
+  var agents = window.installedAgents || [];
+  if (agents.length === 0) {
+    picker.innerHTML = '<div class="agent-picker-empty">No agents installed</div>';
+  } else {
+    picker.setAttribute('role', 'menu');
+    picker.setAttribute('aria-label', 'Pick an agent for this launch');
+    picker.innerHTML = agents.map(function(a, i) {
+      return '<div class="agent-picker-item" role="menuitem" tabindex="' + (i === 0 ? '0' : '-1') + '" ' +
+        'data-tool="' + escHtml(a.id) + '" data-proj-path="' + escHtml(projectPath) + '" ' +
+        'onclick="pickerLaunch(this.dataset.projPath, this.dataset.tool)" ' +
+        'onkeydown="onPickerKey(event, this.dataset.projPath, this.dataset.tool)">' +
+        escHtml(a.label) + '</div>';
+    }).join('');
+  }
+  // position: fixed against the viewport — works regardless of what ancestor
+  // is positioned and survives page scroll. We re-clamp on resize via the
+  // scroll handler that just closes the picker, which is the common pattern.
+  picker.classList.add('open');
+  var rect = anchor.getBoundingClientRect();
+  var viewportW = document.documentElement.clientWidth;
+  var clampedLeft = Math.max(8, Math.min(viewportW - _PICKER_WIDTH - 8, rect.right - _PICKER_WIDTH));
+  picker.style.top = (rect.bottom + 4) + 'px';
+  picker.style.left = clampedLeft + 'px';
+  if (anchor.setAttribute) anchor.setAttribute('aria-expanded', 'true');
+  // Focus first item so keyboard users can act.
+  setTimeout(function() {
+    var first = picker.querySelector('.agent-picker-item');
+    if (first && first.focus) first.focus();
+    document.addEventListener('click', _closeAgentPickerOnOutsideClick, true);
+    document.addEventListener('keydown', _closeAgentPickerOnEscape, true);
+    window.addEventListener('scroll', _closeAgentPickerOnScroll, { capture: true, passive: true });
+  }, 0);
+}
+
+function _closePicker() {
+  var picker = document.getElementById('agentPicker');
+  if (!picker) return;
+  picker.classList.remove('open');
+  if (_pickerAnchor && _pickerAnchor.setAttribute) _pickerAnchor.setAttribute('aria-expanded', 'false');
+  document.removeEventListener('click', _closeAgentPickerOnOutsideClick, true);
+  document.removeEventListener('keydown', _closeAgentPickerOnEscape, true);
+  window.removeEventListener('scroll', _closeAgentPickerOnScroll, true);
+  // Return focus to the chevron that opened the picker so keyboard users
+  // don't get dropped on body.
+  if (_pickerAnchor && _pickerAnchor.focus) {
+    try { _pickerAnchor.focus(); } catch (e) {}
+  }
+  _pickerAnchor = null;
+}
+
+function _closeAgentPickerOnOutsideClick(e) {
+  var picker = document.getElementById('agentPicker');
+  if (!picker) return;
+  if (picker.contains(e.target)) return;
+  _closePicker();
+}
+
+function _closeAgentPickerOnEscape(e) {
+  if (e.key === 'Escape') { e.stopPropagation(); _closePicker(); }
+}
+
+function _closeAgentPickerOnScroll() {
+  // Re-positioning the popover during scroll is jittery — closing is the
+  // commonly accepted UX and matches the picker's transient nature.
+  _closePicker();
+}
+
+function onPickerKey(e, projectPath, tool) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    pickerLaunch(projectPath, tool);
+    return;
+  }
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault();
+    var items = Array.from(document.querySelectorAll('.agent-picker-item'));
+    var idx = items.indexOf(e.currentTarget);
+    var nextIdx = e.key === 'ArrowDown'
+      ? Math.min(items.length - 1, idx + 1)
+      : Math.max(0, idx - 1);
+    if (items[nextIdx]) items[nextIdx].focus();
+  }
+}
+
+function pickerLaunch(projectPath, tool) {
+  _closePicker();
+  // Per-launch override — does mutate lastUsedByPath (this project's
+  // preference legitimately shifts to the explicit choice) but never touches
+  // settings.defaultAgent.
+  launchNewProjectSession(projectPath, tool);
+}
+
+// ── Projects settings modal ───────────────────────────────────
+
+let _modalFocusReturn = null;
+let _modalTrapFn = null;
+
+// Focus-trap helper — keeps Tab/Shift+Tab cycling inside the modal so
+// keyboard users can't accidentally tab onto the page behind the overlay.
+function _installModalFocusTrap(overlay) {
+  if (!overlay) return;
+  _modalFocusReturn = document.activeElement;
+  var focusableSel = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  var nodes = Array.from(overlay.querySelectorAll(focusableSel))
+    .filter(function(el) { return !el.disabled && el.offsetParent !== null; });
+  if (nodes.length === 0) return;
+  var first = nodes[0];
+  var last = nodes[nodes.length - 1];
+  _modalTrapFn = function(e) {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      // Both modals route close through the same callback chain.
+      if (overlay.id === 'projectsSettingsOverlay') closeProjectsSettings();
+      else if (overlay.id === 'addProjectOverlay' && typeof closeAddProject === 'function') closeAddProject();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+  document.addEventListener('keydown', _modalTrapFn, true);
+  setTimeout(function() { try { first.focus(); } catch (e) {} }, 0);
+}
+
+function _uninstallModalFocusTrap() {
+  if (_modalTrapFn) {
+    document.removeEventListener('keydown', _modalTrapFn, true);
+    _modalTrapFn = null;
+  }
+  if (_modalFocusReturn && _modalFocusReturn.focus) {
+    try { _modalFocusReturn.focus(); } catch (e) {}
+  }
+  _modalFocusReturn = null;
+}
+
+function openProjectsSettings() {
+  var overlay = document.getElementById('projectsSettingsOverlay');
+  if (!overlay) return;
+  var select = document.getElementById('psDefaultAgent');
+  var agents = window.installedAgents || [];
+  var current = (window.codbashSettings && window.codbashSettings.defaultAgent) || '';
+  var html = '<option value="">(none — fall back to first installed)</option>';
+  agents.forEach(function(a) {
+    var sel = a.id === current ? ' selected' : '';
+    html += '<option value="' + escHtml(a.id) + '"' + sel + '>' + escHtml(a.label) + '</option>';
+  });
+  if (select) select.innerHTML = html;
+  var err = document.getElementById('psError'); if (err) err.textContent = '';
+  var status = document.getElementById('psDetectStatus');
+  if (status) status.textContent = agents.length + ' agent' + (agents.length === 1 ? '' : 's') + ' detected';
+  overlay.classList.add('open');
+  overlay.setAttribute('aria-hidden', 'false');
+  _installModalFocusTrap(overlay);
+}
+
+function closeProjectsSettings() {
+  var overlay = document.getElementById('projectsSettingsOverlay');
+  if (overlay) {
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+  }
+  _uninstallModalFocusTrap();
+}
+
+async function saveProjectsSettings() {
+  var select = document.getElementById('psDefaultAgent');
+  var err = document.getElementById('psError');
+  var saveBtn = document.getElementById('psSaveBtn');
+  var pick = select ? select.value : '';
+  var body = { defaultAgent: pick || null };
+  if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = 'Saving…'; }
+  try {
+    var resp = await fetch('/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    var data = await resp.json().catch(function() { return {}; });
+    if (!resp.ok) {
+      var detail = data && data.error
+        ? data.error
+        : 'Save failed — server returned HTTP ' + resp.status;
+      if (err) err.textContent = detail;
+      return;
+    }
+    // Re-fetch authoritative settings instead of trusting the PUT response
+    // body. If the server ever returns a partial shape (e.g. {ok:true}) we'd
+    // otherwise clobber lastUsedByPath in memory and lose per-project state.
+    try {
+      var sResp = await fetch('/api/settings');
+      var sData = await sResp.json();
+      if (sData && typeof sData === 'object' && 'defaultAgent' in sData) {
+        window.codbashSettings = sData;
+      }
+    } catch (_) { /* keep the optimistic in-memory state */ }
+    showToast('Settings saved');
+    closeProjectsSettings();
+    if (currentView === 'projects') render();
+  } catch (e) {
+    if (err) err.textContent = 'Save failed: ' + (e && e.message);
+  } finally {
+    if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = 'Save'; }
+  }
+}
+
+async function refreshAgentsDetection() {
+  var status = document.getElementById('psDetectStatus');
+  if (status) status.textContent = 'detecting…';
+  try {
+    var resp = await fetch('/api/agents/refresh-detect', { method: 'POST' });
+    var data = await resp.json();
+    window.installedAgents = (data && data.agents) || [];
+    openProjectsSettings(); // re-render select with fresh list
+    if (currentView === 'projects') render();
+  } catch (e) {
+    if (status) status.textContent = 'refresh failed';
   }
 }
 
@@ -2223,19 +2818,36 @@ async function resumeLastProjectSession(sessionId, tool, projectPath) {
 
 async function unregisterProject(id, name) {
   if (!id) return;
-  if (!confirm('Remove “' + name + '” from project registry? Files on disk are untouched.')) return;
-  try {
-    var resp = await fetch('/api/projects/manual/' + encodeURIComponent(id), { method: 'DELETE' });
-    var data = await resp.json();
-    if (data.ok) {
-      showToast('Removed ' + name);
-      await loadManualProjects();
-    } else {
-      showToast('Remove failed');
+  // Use the same confirm-overlay pattern that showDeleteConfirm uses for
+  // sessions, instead of the native confirm() dialog — keeps the look
+  // consistent and avoids confusing the user with two different prompt styles.
+  // Project name is trimmed of control characters before display so a
+  // crafted name can't produce a misleading multi-line dialog.
+  var safeName = String(name || '').replace(/[\r\n\t\x00-\x1f]/g, ' ').slice(0, 200);
+  var overlay = document.getElementById('confirmOverlay');
+  if (!overlay) return;
+  document.getElementById('confirmTitle').textContent = 'Remove from project registry?';
+  document.getElementById('confirmText').textContent = 'Removes "' + safeName + '" from your project list. Files on disk are not touched.';
+  document.getElementById('confirmId').textContent = '';
+  var btn = document.getElementById('confirmAction');
+  btn.textContent = 'Remove';
+  btn.className = 'btn-delete';
+  btn.onclick = async function() {
+    overlay.style.display = 'none';
+    try {
+      var resp = await fetch('/api/projects/manual/' + encodeURIComponent(id), { method: 'DELETE' });
+      var data = await resp.json();
+      if (data.ok) {
+        showToast('Removed ' + safeName);
+        await loadManualProjects();
+      } else {
+        showToast('Remove failed');
+      }
+    } catch (e) {
+      showToast('Remove failed: ' + (e && e.message));
     }
-  } catch (e) {
-    showToast('Remove failed: ' + e.message);
-  }
+  };
+  overlay.style.display = 'flex';
 }
 
 // ── Add Project modal ─────────────────────────────────────────
@@ -2244,15 +2856,21 @@ function openAddProject() {
   var overlay = document.getElementById('addProjectOverlay');
   if (!overlay) return;
   overlay.classList.add('open');
+  overlay.setAttribute('aria-hidden', 'false');
   addProjectSwitchTab('local');
   var input = document.getElementById('apLocalPath');
   if (input) { input.value = ''; setTimeout(function() { input.focus(); }, 50); }
   var err = document.getElementById('apLocalError'); if (err) err.textContent = '';
+  _installModalFocusTrap(overlay);
 }
 
 function closeAddProject() {
   var overlay = document.getElementById('addProjectOverlay');
-  if (overlay) overlay.classList.remove('open');
+  if (overlay) {
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+  }
+  _uninstallModalFocusTrap();
   // Stop any in-flight device-code polling when the user dismisses the modal.
   _stopRepoScopePolling();
   _repoScopeDeviceCode = '';
@@ -2279,9 +2897,11 @@ function addProjectSwitchTab(tab) {
 async function submitAddLocalProject() {
   var input = document.getElementById('apLocalPath');
   var err = document.getElementById('apLocalError');
+  var addBtn = document.getElementById('apLocalAddBtn');
   if (err) err.textContent = '';
   var p = input ? input.value.trim() : '';
   if (!p) { if (err) err.textContent = 'Path required'; return; }
+  if (addBtn) { addBtn.disabled = true; addBtn.textContent = 'Adding…'; }
   try {
     var resp = await fetch('/api/projects/manual', {
       method: 'POST',
@@ -2298,6 +2918,8 @@ async function submitAddLocalProject() {
     }
   } catch (e) {
     if (err) err.textContent = e.message;
+  } finally {
+    if (addBtn) { addBtn.disabled = false; addBtn.textContent = 'Add'; }
   }
 }
 
@@ -2403,9 +3025,13 @@ function showDeviceCodePanel(deviceData, apiType) {
   // Copy button — the click handler reads from `dataset.code` instead of the
   // attribute being interpolated into an inline JS string, so any quote
   // characters in a future user_code value cannot break out of the handler.
+  // verification_uri is hard-bounded to https:// so a tampered upstream
+  // response can't smuggle a javascript: scheme into the `href`.
+  var rawUri = String(deviceData.verification_uri || '');
+  var safeUri = /^https:\/\//i.test(rawUri) ? rawUri : '#';
   status.innerHTML = ''
     + '<div class="ap-device-code">'
-    + '  <div>1. Open <a href="' + escHtml(deviceData.verification_uri) + '" target="_blank" rel="noopener">' + escHtml(deviceData.verification_uri) + '</a></div>'
+    + '  <div>1. Open <a href="' + escHtml(safeUri) + '" target="_blank" rel="noopener noreferrer">' + escHtml(safeUri) + '</a></div>'
     + '  <div>2. Enter code: <code class="ap-code">' + escHtml(deviceData.user_code) + '</code> '
     + '<button class="ap-copy" data-code="' + escHtml(deviceData.user_code) + '" onclick="copyText(this.dataset.code, &quot;Copied code&quot;)">Copy</button></div>'
     + '  <div class="ap-poll-status" id="apPollStatus">Waiting for authorization…</div>'
@@ -2583,11 +3209,53 @@ async function cloneRepoAndAdd(btn) {
 
 // ── Initialization ─────────────────────────────────────────────
 
+async function loadAgentsAndSettings() {
+  // allSettled so a partial failure (e.g. /api/agents/installed errors while
+  // /api/settings succeeds) doesn't wipe both pieces of state.
+  var results = await Promise.allSettled([
+    fetch('/api/agents/installed').then(function(r) { return r.json(); }),
+    fetch('/api/settings').then(function(r) { return r.json(); }),
+  ]);
+  var aData = results[0].status === 'fulfilled' ? results[0].value : null;
+  var sData = results[1].status === 'fulfilled' ? results[1].value : null;
+  if (aData && Array.isArray(aData.agents)) {
+    window.installedAgents = aData.agents;
+    window._agentsDetectionLoaded = true;
+  }
+  if (sData && typeof sData === 'object' && 'defaultAgent' in sData) {
+    window.codbashSettings = sData;
+  }
+  // Re-render any Projects subtab — both History (button selection depends
+  // on installed agents) and Projects landing need agent info.
+  if (currentView === 'projects') render();
+}
+
+function _onProjectsHashChange() {
+  if (currentView !== 'projects') return;
+  var h = (location.hash || '').replace(/^#/, '');
+  // Empty hash → fall back to user's persisted preference rather than keeping
+  // whatever we last rendered. If neither is set we land on 'projects'.
+  var next;
+  if (h === 'history' || h === 'projects') {
+    next = h;
+  } else {
+    try { next = localStorage.getItem('codedash-projects-subtab') === 'history' ? 'history' : 'projects'; }
+    catch (e) { next = 'projects'; }
+  }
+  if (next !== currentProjectsSubtab) {
+    currentProjectsSubtab = next;
+    try { localStorage.setItem('codedash-projects-subtab', next); } catch (e) {}
+    render();
+  }
+}
+
 (function init() {
   // Load data
   loadSessions();
   loadTerminals();
   loadManualProjects();
+  loadAgentsAndSettings();
+  window.addEventListener('hashchange', _onProjectsHashChange);
   checkForUpdates();
   setInterval(checkForUpdates, 10000); // check every 10s
   setInterval(loadSessions, 60000);    // refresh sessions + invalidate analytics cache every 60s

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -192,36 +192,62 @@
 </div>
 
 <!-- Add Project modal: open from Projects view to register a local path or clone from GitHub. -->
-<div class="confirm-overlay" id="addProjectOverlay">
+<div class="confirm-overlay" id="addProjectOverlay" role="dialog" aria-modal="true" aria-labelledby="apTitle" aria-hidden="true">
     <div class="confirm-box add-project-box">
-        <h3>Add project</h3>
-        <div class="ap-tabs">
-            <button class="ap-tab active" data-tab="local" onclick="addProjectSwitchTab('local')">Local path</button>
-            <button class="ap-tab" data-tab="owned" onclick="addProjectSwitchTab('owned')">My GitHub repos</button>
-            <button class="ap-tab" data-tab="contributing" onclick="addProjectSwitchTab('contributing')">Contributing</button>
+        <h3 id="apTitle">Add project</h3>
+        <div class="ap-tabs" role="tablist" aria-label="Add project source">
+            <button class="ap-tab active" data-tab="local" role="tab" aria-selected="true" tabindex="0" onclick="addProjectSwitchTab('local')">Local path</button>
+            <button class="ap-tab" data-tab="owned" role="tab" aria-selected="false" tabindex="-1" onclick="addProjectSwitchTab('owned')">My GitHub repos</button>
+            <button class="ap-tab" data-tab="contributing" role="tab" aria-selected="false" tabindex="-1" onclick="addProjectSwitchTab('contributing')">Contributing</button>
         </div>
         <div class="ap-body">
-            <div class="ap-pane" id="apPaneLocal">
-                <label>Folder path on this machine</label>
-                <input type="text" id="apLocalPath" placeholder="/Users/me/code/my-project" autocomplete="off" />
-                <div class="ap-hint">Must be an existing directory. <code>~</code> is expanded.</div>
-                <div class="ap-error" id="apLocalError"></div>
+            <div class="ap-pane" id="apPaneLocal" role="tabpanel">
+                <label for="apLocalPath">Folder path on this machine</label>
+                <input type="text" id="apLocalPath" placeholder="/Users/me/code/my-project" autocomplete="off" aria-describedby="apLocalHint" />
+                <div class="ap-hint" id="apLocalHint">Must be an existing directory. <code>~</code> is expanded.</div>
+                <div class="ap-error" id="apLocalError" role="alert"></div>
             </div>
-            <div class="ap-pane" id="apPaneOwned" style="display:none">
-                <input type="text" class="ap-filter" id="apOwnedFilter" placeholder="Filter repos…" oninput="renderRepoList('owned')" />
+            <div class="ap-pane" id="apPaneOwned" style="display:none" role="tabpanel">
+                <input type="text" class="ap-filter" id="apOwnedFilter" placeholder="Filter repos…" aria-label="Filter your repos" oninput="renderRepoList('owned')" />
                 <div class="ap-repos" id="apOwnedRepos"><div class="ap-loading">Loading…</div></div>
             </div>
-            <div class="ap-pane" id="apPaneContrib" style="display:none">
-                <input type="text" class="ap-filter" id="apContribFilter" placeholder="Filter repos…" oninput="renderRepoList('contributing')" />
+            <div class="ap-pane" id="apPaneContrib" style="display:none" role="tabpanel">
+                <input type="text" class="ap-filter" id="apContribFilter" placeholder="Filter repos…" aria-label="Filter repos you contribute to" oninput="renderRepoList('contributing')" />
                 <div class="ap-repos" id="apContribRepos"><div class="ap-loading">Click load to fetch repos you collaborate on…</div></div>
             </div>
         </div>
         <div class="confirm-btns">
             <button class="btn-cancel" onclick="closeAddProject()">Close</button>
-            <button class="btn-delete" id="apLocalAddBtn" style="background:#3b82f6" onclick="submitAddLocalProject()">Add</button>
+            <button class="btn-primary" id="apLocalAddBtn" onclick="submitAddLocalProject()">Add</button>
         </div>
     </div>
 </div>
+
+<!-- Projects settings modal: default agent + refresh detection. -->
+<div class="confirm-overlay" id="projectsSettingsOverlay" role="dialog" aria-modal="true" aria-labelledby="psTitle" aria-hidden="true">
+    <div class="confirm-box projects-settings-box">
+        <h3 id="psTitle">Projects settings</h3>
+        <div class="ap-body">
+            <label class="ps-label" for="psDefaultAgent">Default agent for ▶ New</label>
+            <select id="psDefaultAgent" class="ps-select" aria-describedby="psDefaultAgentHint">
+                <option>Loading agents…</option>
+            </select>
+            <div class="ap-hint" id="psDefaultAgentHint">Used when a project has no last-used agent yet. Only agents installed on this machine are listed.</div>
+            <div style="margin-top:14px">
+                <button class="toolbar-btn" onclick="refreshAgentsDetection()" aria-label="Refresh agent detection">↻ Refresh detection</button>
+                <span id="psDetectStatus" class="ap-hint" style="margin-left:8px" role="status"></span>
+            </div>
+            <div class="ap-error" id="psError" role="alert"></div>
+        </div>
+        <div class="confirm-btns">
+            <button class="btn-cancel" onclick="closeProjectsSettings()">Cancel</button>
+            <button id="psSaveBtn" class="btn-primary" onclick="saveProjectsSettings()">Save</button>
+        </div>
+    </div>
+</div>
+
+<!-- Per-launch agent picker popover. Anchored next to a project card's ⏷ button. -->
+<div class="agent-picker" id="agentPicker"></div>
 
 <div class="bulk-bar" id="bulkBar" style="display:none">
     <span id="bulkCount">0 selected</span>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -233,9 +233,16 @@
                 <option>Loading agents…</option>
             </select>
             <div class="ap-hint" id="psDefaultAgentHint">Used when a project has no last-used agent yet. Only agents installed on this machine are listed.</div>
-            <div style="margin-top:14px">
-                <button class="toolbar-btn" onclick="refreshAgentsDetection()" aria-label="Refresh agent detection">↻ Refresh detection</button>
-                <span id="psDetectStatus" class="ap-hint" style="margin-left:8px" role="status"></span>
+
+            <div style="margin-top:18px">
+                <div class="ps-label" style="margin-bottom:8px">Detected agents</div>
+                <div id="psDetectedList" class="ps-detected-list" aria-live="polite">
+                    <div class="ap-hint">Loading…</div>
+                </div>
+                <div style="margin-top:10px">
+                    <button class="toolbar-btn" onclick="refreshAgentsDetection()" aria-label="Refresh agent detection">↻ Refresh detection</button>
+                    <span id="psDetectStatus" class="ap-hint" style="margin-left:8px" role="status"></span>
+                </div>
             </div>
             <div class="ap-error" id="psError" role="alert"></div>
         </div>

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -3358,38 +3358,38 @@ body {
 
 
 /* ── Projects tab restructure ──────────────────────────────
- * Theme-aware throughout: uses --border / --text-primary / --text-muted /
- * --accent-blue / --card-bg from the base theme file, with fallbacks for
- * environments that haven't loaded the variable block.
+ * Uses the actual codbash theme variables (--bg-card, --bg-input,
+ * --text-primary, --text-secondary, --text-muted, --accent-blue, --border)
+ * so light/dark/monokai themes inherit the right colors automatically.
+ * Border-radius and hover patterns match existing .card / .toolbar-btn rules.
  */
 
 /* Subtab strip above Projects content */
 .projects-subtabs {
     display: flex;
     gap: 4px;
-    border-bottom: 1px solid var(--border, #2a2a2a);
+    border-bottom: 1px solid var(--border);
     margin-bottom: 14px;
-    padding-bottom: 0;
 }
 .projects-subtab {
     padding: 8px 16px;
     background: transparent;
     border: none;
-    color: var(--text-muted, #888);
+    color: var(--text-secondary);
     font: inherit;
     font-size: 13px;
     cursor: pointer;
     border-bottom: 2px solid transparent;
     margin-bottom: -1px;
-    transition: color .12s, border-color .12s;
+    transition: color 0.15s, border-color 0.15s;
 }
-.projects-subtab:hover { color: var(--text-primary, #ddd); }
+.projects-subtab:hover { color: var(--text-primary); }
 .projects-subtab.active {
-    color: var(--text-primary, #fff);
-    border-bottom-color: var(--accent-blue, #3b82f6);
+    color: var(--text-primary);
+    border-bottom-color: var(--accent-blue);
 }
 .projects-subtab:focus-visible {
-    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline: 2px solid var(--accent-blue);
     outline-offset: -2px;
     border-radius: 4px;
 }
@@ -3401,22 +3401,20 @@ body {
     gap: 10px;
     padding: 8px 12px;
     margin-bottom: 12px;
-    background: rgba(59, 130, 246, 0.08);
-    border: 1px solid var(--border, #2a2a2a);
-    border-left: 3px solid var(--accent-blue, #3b82f6);
-    border-radius: 4px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent-blue);
+    border-radius: 8px;
     font-size: 12px;
-    color: var(--text-primary, #ddd);
+    color: var(--text-primary);
 }
 .history-filter-bar .toolbar-btn { margin-left: auto; padding: 4px 10px; font-size: 11px; }
 
-/* Launcher landing — clean cards distinct from session groups */
+/* Launcher landing — cards match existing .card pattern (radius 10, hover transform) */
 .projects-launcher-grid {
     display: grid;
-    /* min(320px, 100%) keeps very narrow viewports from horizontal-scrolling */
     grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
     gap: 14px;
-    /* Subtle fade so subtab switches feel intentional instead of a hard swap */
     animation: subtab-fade-in 120ms ease-out;
 }
 @keyframes subtab-fade-in {
@@ -3427,16 +3425,21 @@ body {
     .projects-launcher-grid, .launcher-card-skel { animation: none !important; }
 }
 .launcher-card {
-    background: var(--card-bg, #1a1a1a);
-    border: 1px solid var(--border, #2a2a2a);
-    border-radius: 8px;
-    padding: 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
     display: flex;
     flex-direction: column;
     gap: 10px;
-    transition: border-color .12s, transform .12s;
+    transition: all 0.15s;
 }
-.launcher-card:hover { border-color: var(--accent-blue, #3b82f6); }
+.launcher-card:hover {
+    background: var(--bg-card-hover);
+    border-color: rgba(255,255,255,0.1);
+    transform: translateY(-1px);
+}
+[data-theme="light"] .launcher-card:hover { border-color: rgba(0,0,0,0.08); }
 .launcher-card-header {
     display: flex;
     align-items: center;
@@ -3452,27 +3455,26 @@ body {
 .launcher-card-name {
     font-weight: 600;
     font-size: 14px;
-    color: var(--text-primary, #fff);
+    color: var(--text-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     flex: 1;
 }
 .launcher-card-tag {
-    /* De-emphasized provenance hint — does NOT compete with the project name */
     font-size: 9px;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     padding: 2px 6px;
-    color: var(--text-muted, #888);
+    color: var(--text-muted);
     background: transparent;
-    border: 1px solid var(--border, #2a2a2a);
-    border-radius: 3px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
     flex-shrink: 0;
 }
 .launcher-card-path {
     font-size: 11px;
-    color: var(--text-muted, #888);
+    color: var(--text-muted);
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -3480,7 +3482,7 @@ body {
 }
 .launcher-card-meta {
     font-size: 11px;
-    color: var(--text-muted, #888);
+    color: var(--text-secondary);
     display: flex;
     gap: 10px;
     flex-wrap: wrap;
@@ -3496,14 +3498,11 @@ body {
     align-items: center;
     flex-wrap: wrap;
 }
-.launcher-card-actions .split-btn {
-    display: inline-flex;
-    /* Group role for accessibility — both halves announce together */
-}
+.launcher-card-actions .split-btn { display: inline-flex; }
 .launcher-card-actions .split-btn .new-btn {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    border-right: 1px solid var(--split-btn-divider, rgba(255, 255, 255, 0.2));
+    border-right: 1px solid rgba(255, 255, 255, 0.2);
     padding: 6px 10px;
 }
 .launcher-card-actions .split-btn .picker-btn {
@@ -3514,17 +3513,21 @@ body {
     line-height: 1;
 }
 [data-theme="light"] .launcher-card-actions .split-btn .new-btn {
-    --split-btn-divider: rgba(0, 0, 0, 0.2);
+    border-right-color: rgba(0, 0, 0, 0.2);
 }
-.launcher-card-actions button.git-project-launch-btn { margin: 0; padding: 6px 12px; font-size: 12px; }
+.launcher-card-actions button.git-project-launch-btn {
+    margin: 0;
+    padding: 6px 12px;
+    font-size: 12px;
+}
 .launcher-card-actions button.git-project-launch-btn:focus-visible {
-    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline: 2px solid var(--accent-blue);
     outline-offset: 2px;
 }
 .launcher-card-link {
     margin-top: auto;
     font-size: 11px;
-    color: var(--accent-blue, #3b82f6);
+    color: var(--accent-blue);
     cursor: pointer;
     background: none;
     border: none;
@@ -3534,16 +3537,16 @@ body {
 }
 .launcher-card-link:hover { text-decoration: underline; }
 .launcher-card-link:focus-visible {
-    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline: 2px solid var(--accent-blue);
     outline-offset: 2px;
     border-radius: 2px;
 }
 
 /* Pre-detection skeleton placeholder cards */
 .launcher-card-skel {
-    background: var(--card-bg, #1a1a1a);
-    border: 1px solid var(--border, #2a2a2a);
-    border-radius: 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
     height: 140px;
     opacity: 0.5;
     animation: launcher-skel-pulse 1.4s ease-in-out infinite;
@@ -3553,7 +3556,7 @@ body {
     50% { opacity: 0.55; }
 }
 
-/* Top toolbar inside the landing view */
+/* Toolbar above the launcher grid */
 .projects-toolbar {
     display: flex;
     gap: 8px;
@@ -3562,47 +3565,51 @@ body {
     margin-bottom: 14px;
 }
 .projects-toolbar-warning {
-    color: #d97706;
+    color: var(--accent-orange);
     font-size: 12px;
     display: inline-flex;
     align-items: center;
     gap: 6px;
 }
-[data-theme="dark"] .projects-toolbar-warning { color: #f59e0b; }
 .projects-toolbar-warning a {
-    color: var(--accent-blue, #3b82f6);
+    color: var(--accent-blue);
     text-decoration: underline;
 }
 .projects-empty {
     padding: 40px 20px;
     text-align: center;
-    color: var(--text-muted, #888);
-    border: 1px dashed var(--border, #2a2a2a);
-    border-radius: 8px;
+    color: var(--text-secondary);
+    background: var(--bg-card);
+    border: 1px dashed var(--border);
+    border-radius: 10px;
 }
 
-/* Reusable primary toolbar/dialog button (replaces inline blue overrides) */
+/* Primary toolbar/dialog button — matches .toolbar-btn pattern */
 .toolbar-btn-primary,
 .btn-primary {
-    background: var(--accent-blue, #3b82f6) !important;
-    color: #fff !important;
-    border: 1px solid var(--accent-blue, #3b82f6) !important;
-    padding: 8px 18px;
-    border-radius: 4px;
+    background: var(--accent-blue);
+    color: #fff;
+    border: 1px solid var(--accent-blue);
+    border-radius: 8px;
+    padding: 8px 14px;
     cursor: pointer;
     font: inherit;
+    font-size: 13px;
     font-weight: 500;
+    white-space: nowrap;
+    transition: all 0.15s;
 }
 .toolbar-btn-primary:hover,
 .btn-primary:hover {
-    filter: brightness(1.08);
+    filter: brightness(1.1);
 }
 .toolbar-btn-primary:focus-visible,
 .btn-primary:focus-visible {
-    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline: 2px solid var(--accent-blue);
     outline-offset: 2px;
 }
-.btn-primary[disabled] {
+.btn-primary[disabled],
+.toolbar-btn-primary[disabled] {
     opacity: 0.6;
     cursor: not-allowed;
 }
@@ -3610,13 +3617,12 @@ body {
 /* Per-launch agent picker popover (position: fixed, viewport-clamped in JS) */
 .agent-picker {
     position: fixed;
-    background: var(--card-bg, #1a1a1a);
-    border: 1px solid var(--border, #3a3a3a);
-    border-radius: 6px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
     padding: 4px;
     min-width: 180px;
-    /* Below modal overlays (z-index ~300) but above page chrome. */
     z-index: 250;
     display: none;
 }
@@ -3626,25 +3632,25 @@ body {
     cursor: pointer;
     border-radius: 4px;
     font-size: 13px;
-    color: var(--text-primary, #ddd);
+    color: var(--text-primary);
     display: flex;
     align-items: center;
     gap: 8px;
 }
 .agent-picker-item:hover {
-    background: rgba(59, 130, 246, 0.15);
-    color: var(--accent-blue, #3b82f6);
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
 }
 .agent-picker-item:focus-visible {
-    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline: 2px solid var(--accent-blue);
     outline-offset: -2px;
-    background: rgba(59, 130, 246, 0.25);
-    color: var(--accent-blue, #3b82f6);
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
 }
 .agent-picker-empty {
     padding: 10px 12px;
     font-size: 12px;
-    color: var(--text-muted, #888);
+    color: var(--text-muted);
 }
 
 /* Projects settings modal */
@@ -3654,19 +3660,19 @@ body {
 .ps-label {
     display: block;
     font-size: 12px;
-    color: var(--text-muted, #888);
+    color: var(--text-secondary);
     margin-bottom: 6px;
 }
 .ps-select {
     width: 100%;
-    background: var(--input-bg, #0d0d0d);
-    color: var(--text-primary, #fff);
-    border: 1px solid var(--border, #2a2a2a);
-    border-radius: 4px;
-    padding: 8px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 12px;
     font: inherit;
 }
 .ps-select:focus-visible {
-    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline: 2px solid var(--accent-blue);
     outline-offset: 1px;
 }

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -3676,3 +3676,50 @@ body {
     outline: 2px solid var(--accent-blue);
     outline-offset: 1px;
 }
+
+/* Detected-agents list inside the Projects settings modal */
+.ps-detected-list {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px;
+    max-height: 220px;
+    overflow-y: auto;
+}
+.ps-detected-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 8px;
+    font-size: 12px;
+    color: var(--text-primary);
+    border-radius: 4px;
+}
+.ps-detected-item + .ps-detected-item { margin-top: 2px; }
+.ps-detected-item.installed { /* default look */ }
+.ps-detected-item.missing { color: var(--text-muted); }
+.ps-detected-status {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+}
+.ps-detected-status.installed {
+    color: var(--accent-green);
+    border-color: var(--accent-green);
+}
+.ps-detected-status.missing {
+    color: var(--text-muted);
+}
+.ps-detected-name { flex: 1; }
+.ps-detected-via {
+    font-size: 10px;
+    color: var(--text-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -3355,3 +3355,318 @@ body {
     flex-direction: column;
     gap: 2px;
 }
+
+
+/* ── Projects tab restructure ──────────────────────────────
+ * Theme-aware throughout: uses --border / --text-primary / --text-muted /
+ * --accent-blue / --card-bg from the base theme file, with fallbacks for
+ * environments that haven't loaded the variable block.
+ */
+
+/* Subtab strip above Projects content */
+.projects-subtabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--border, #2a2a2a);
+    margin-bottom: 14px;
+    padding-bottom: 0;
+}
+.projects-subtab {
+    padding: 8px 16px;
+    background: transparent;
+    border: none;
+    color: var(--text-muted, #888);
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color .12s, border-color .12s;
+}
+.projects-subtab:hover { color: var(--text-primary, #ddd); }
+.projects-subtab.active {
+    color: var(--text-primary, #fff);
+    border-bottom-color: var(--accent-blue, #3b82f6);
+}
+.projects-subtab:focus-visible {
+    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline-offset: -2px;
+    border-radius: 4px;
+}
+
+/* History filter bar (shown when "View N sessions →" deeplinked from a card) */
+.history-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    margin-bottom: 12px;
+    background: rgba(59, 130, 246, 0.08);
+    border: 1px solid var(--border, #2a2a2a);
+    border-left: 3px solid var(--accent-blue, #3b82f6);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--text-primary, #ddd);
+}
+.history-filter-bar .toolbar-btn { margin-left: auto; padding: 4px 10px; font-size: 11px; }
+
+/* Launcher landing — clean cards distinct from session groups */
+.projects-launcher-grid {
+    display: grid;
+    /* min(320px, 100%) keeps very narrow viewports from horizontal-scrolling */
+    grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
+    gap: 14px;
+    /* Subtle fade so subtab switches feel intentional instead of a hard swap */
+    animation: subtab-fade-in 120ms ease-out;
+}
+@keyframes subtab-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .projects-launcher-grid, .launcher-card-skel { animation: none !important; }
+}
+.launcher-card {
+    background: var(--card-bg, #1a1a1a);
+    border: 1px solid var(--border, #2a2a2a);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: border-color .12s, transform .12s;
+}
+.launcher-card:hover { border-color: var(--accent-blue, #3b82f6); }
+.launcher-card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+.launcher-card-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.launcher-card-name {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-primary, #fff);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+}
+.launcher-card-tag {
+    /* De-emphasized provenance hint — does NOT compete with the project name */
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 2px 6px;
+    color: var(--text-muted, #888);
+    background: transparent;
+    border: 1px solid var(--border, #2a2a2a);
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+.launcher-card-path {
+    font-size: 11px;
+    color: var(--text-muted, #888);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.launcher-card-meta {
+    font-size: 11px;
+    color: var(--text-muted, #888);
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+.launcher-card-meta > *:not(:first-child)::before {
+    content: '· ';
+    margin-right: 2px;
+}
+.launcher-card-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+.launcher-card-actions .split-btn {
+    display: inline-flex;
+    /* Group role for accessibility — both halves announce together */
+}
+.launcher-card-actions .split-btn .new-btn {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: 1px solid var(--split-btn-divider, rgba(255, 255, 255, 0.2));
+    padding: 6px 10px;
+}
+.launcher-card-actions .split-btn .picker-btn {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding: 6px 8px;
+    font-size: 11px;
+    line-height: 1;
+}
+[data-theme="light"] .launcher-card-actions .split-btn .new-btn {
+    --split-btn-divider: rgba(0, 0, 0, 0.2);
+}
+.launcher-card-actions button.git-project-launch-btn { margin: 0; padding: 6px 12px; font-size: 12px; }
+.launcher-card-actions button.git-project-launch-btn:focus-visible {
+    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline-offset: 2px;
+}
+.launcher-card-link {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--accent-blue, #3b82f6);
+    cursor: pointer;
+    background: none;
+    border: none;
+    text-align: left;
+    padding: 0;
+    font-family: inherit;
+}
+.launcher-card-link:hover { text-decoration: underline; }
+.launcher-card-link:focus-visible {
+    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* Pre-detection skeleton placeholder cards */
+.launcher-card-skel {
+    background: var(--card-bg, #1a1a1a);
+    border: 1px solid var(--border, #2a2a2a);
+    border-radius: 8px;
+    height: 140px;
+    opacity: 0.5;
+    animation: launcher-skel-pulse 1.4s ease-in-out infinite;
+}
+@keyframes launcher-skel-pulse {
+    0%, 100% { opacity: 0.35; }
+    50% { opacity: 0.55; }
+}
+
+/* Top toolbar inside the landing view */
+.projects-toolbar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+}
+.projects-toolbar-warning {
+    color: #d97706;
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+[data-theme="dark"] .projects-toolbar-warning { color: #f59e0b; }
+.projects-toolbar-warning a {
+    color: var(--accent-blue, #3b82f6);
+    text-decoration: underline;
+}
+.projects-empty {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--text-muted, #888);
+    border: 1px dashed var(--border, #2a2a2a);
+    border-radius: 8px;
+}
+
+/* Reusable primary toolbar/dialog button (replaces inline blue overrides) */
+.toolbar-btn-primary,
+.btn-primary {
+    background: var(--accent-blue, #3b82f6) !important;
+    color: #fff !important;
+    border: 1px solid var(--accent-blue, #3b82f6) !important;
+    padding: 8px 18px;
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+    font-weight: 500;
+}
+.toolbar-btn-primary:hover,
+.btn-primary:hover {
+    filter: brightness(1.08);
+}
+.toolbar-btn-primary:focus-visible,
+.btn-primary:focus-visible {
+    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline-offset: 2px;
+}
+.btn-primary[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+/* Per-launch agent picker popover (position: fixed, viewport-clamped in JS) */
+.agent-picker {
+    position: fixed;
+    background: var(--card-bg, #1a1a1a);
+    border: 1px solid var(--border, #3a3a3a);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    padding: 4px;
+    min-width: 180px;
+    /* Below modal overlays (z-index ~300) but above page chrome. */
+    z-index: 250;
+    display: none;
+}
+.agent-picker.open { display: block; }
+.agent-picker-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 13px;
+    color: var(--text-primary, #ddd);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.agent-picker-item:hover {
+    background: rgba(59, 130, 246, 0.15);
+    color: var(--accent-blue, #3b82f6);
+}
+.agent-picker-item:focus-visible {
+    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline-offset: -2px;
+    background: rgba(59, 130, 246, 0.25);
+    color: var(--accent-blue, #3b82f6);
+}
+.agent-picker-empty {
+    padding: 10px 12px;
+    font-size: 12px;
+    color: var(--text-muted, #888);
+}
+
+/* Projects settings modal */
+.projects-settings-box {
+    max-width: 440px !important;
+}
+.ps-label {
+    display: block;
+    font-size: 12px;
+    color: var(--text-muted, #888);
+    margin-bottom: 6px;
+}
+.ps-select {
+    width: 100%;
+    background: var(--input-bg, #0d0d0d);
+    color: var(--text-primary, #fff);
+    border: 1px solid var(--border, #2a2a2a);
+    border-radius: 4px;
+    padding: 8px;
+    font: inherit;
+}
+.ps-select:focus-visible {
+    outline: 2px solid var(--accent-blue, #3b82f6);
+    outline-offset: 1px;
+}

--- a/src/projects.js
+++ b/src/projects.js
@@ -31,11 +31,20 @@ function loadProjects() {
 // Atomic write — temp file + rename so a crashed write never leaves a partial
 // file behind. The mutex below serializes read-modify-write operations to
 // prevent the classic interleaved-load lost-update race.
+// File mode 0600 — contains the user's local workspace layout which is mildly
+// sensitive on shared machines. Double-chmod (tmp + final) defends against
+// rename-preserves-destination-mode quirks on some Linux filesystems.
 function saveProjects(list) {
   ensureDir(path.dirname(PROJECTS_FILE));
   const tmp = PROJECTS_FILE + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify({ projects: list }, null, 2));
+  fs.writeFileSync(tmp, JSON.stringify({ projects: list }, null, 2), { mode: 0o600 });
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(tmp, 0o600); } catch {}
+  }
   fs.renameSync(tmp, PROJECTS_FILE);
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(PROJECTS_FILE, 0o600); } catch {}
+  }
 }
 
 let _writeLock = Promise.resolve();
@@ -80,14 +89,19 @@ function isSafeLaunchPath(p) {
   try {
     const abs = normalizePath(p);
     if (!fs.existsSync(abs)) return false;
-    if (!fs.statSync(abs).isDirectory()) return false;
+    // lstat first so a symlink pointing to e.g. /opt cannot smuggle a path
+    // out of $HOME past the auto-register boundary check. validatePath
+    // applies the same defense for the registry-write path.
+    const lst = fs.lstatSync(abs);
+    if (lst.isSymbolicLink()) return false;
+    if (!lst.isDirectory()) return false;
   } catch {
     return false;
   }
   return true;
 }
 
-const ALLOWED_SOURCES = new Set(['manual', 'github-clone']);
+const ALLOWED_SOURCES = new Set(['manual', 'github-clone', 'auto']);
 
 function addProject({ name, path: projectPath, source, remoteUrl, defaultBranch }) {
   const abs = validatePath(projectPath);

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,14 @@ const { generateHandoff } = require('./handoff');
 const { CHANGELOG } = require('./changelog');
 const { getHTML } = require('./html');
 const projectsApi = require('./projects');
+const settingsApi = require('./settings');
+// Element-level allowlist for launch flags. terminals.js currently only checks
+// for 'skip-permissions'; this set is the surface area we accept from clients.
+const ALLOWED_LAUNCH_FLAGS = new Set(['skip-permissions']);
+const agentsDetect = require('./agents-detect');
+const os = require('os');
+const fs = require('fs');
+const pathLib = require('path');
 
 // ── Logging ──────────────────────────────────
 const LOG_VERBOSE = process.env.CODEDASH_LOG !== '0';
@@ -70,7 +78,29 @@ function startServer(host, port, openBrowser = true) {
 
     // ── Static ──────────────────────────────
     if (req.method === 'GET' && (pathname === '/' || pathname === '/index.html')) {
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      // Defense-in-depth for the loopback-only HTML page:
+      // - script-src/style-src 'self' 'unsafe-inline' because the template
+      //   injects all JS/CSS inline (zero-deps build, see html.js)
+      // - connect-src 'self' so a malicious extension cannot fetch tokens from
+      //   our API and POST them elsewhere
+      // - frame-ancestors 'none' / X-Frame-Options DENY to block clickjacking
+      // - X-Content-Type-Options nosniff so the browser won't sniff text/html
+      //   when our endpoints return JSON.
+      res.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Content-Security-Policy': [
+          "default-src 'self'",
+          "script-src 'self' 'unsafe-inline'",
+          "style-src 'self' 'unsafe-inline'",
+          "connect-src 'self'",
+          "img-src 'self' data:",
+          "frame-ancestors 'none'",
+          "base-uri 'self'",
+        ].join('; '),
+        'X-Content-Type-Options': 'nosniff',
+        'X-Frame-Options': 'DENY',
+        'Referrer-Policy': 'no-referrer',
+      });
       res.end(getHTML());
     }
 
@@ -122,32 +152,125 @@ function startServer(host, port, openBrowser = true) {
     // ── Launch ──────────────────────────────
     else if (req.method === 'POST' && pathname === '/api/launch') {
       readBody(req, body => {
-        try {
-          const { sessionId, tool, flags, project, terminal, mode } = JSON.parse(body);
-          const fresh = mode === 'fresh';
-          if (!fresh && !/^[A-Za-z0-9._-]{1,128}$/.test(String(sessionId || ''))) {
-            throw new Error('invalid sessionId');
+        (async () => {
+          try {
+            const parsed = JSON.parse(body);
+            const { sessionId, tool, flags, project, terminal, mode, autoRegister } = parsed;
+            const fresh = mode === 'fresh';
+            if (!fresh && !/^[A-Za-z0-9._-]{1,128}$/.test(String(sessionId || ''))) {
+              throw new Error('invalid sessionId');
+            }
+            if (fresh && !project) {
+              throw new Error('project path required for fresh session');
+            }
+            // The project path flows into a shell command string in terminals.js
+            // (`cd "..." && claude ...`). Even though JSON.stringify wraps the
+            // value in double quotes, bash still expands $() and backticks
+            // inside double-quoted strings. We refuse anything other than a
+            // plain on-disk directory path.
+            if (project && !projectsApi.isSafeLaunchPath(project)) {
+              throw new Error('invalid or unsafe project path');
+            }
+            const resolvedTool = settingsApi.isKnownAgent(tool) ? tool : 'claude';
+            // Explicit allowlist for flags — element-level. Defense-in-depth in
+            // case a future code path interpolates a flag string into a shell
+            // command. Today only --dangerously-skip-permissions is allowed.
+            const safeFlags = Array.isArray(flags)
+              ? flags.filter(f => typeof f === 'string' && ALLOWED_LAUNCH_FLAGS.has(f))
+              : [];
+            log('LAUNCH', `mode=${fresh ? 'fresh' : 'resume'} session=${sessionId || '(none)'} tool=${resolvedTool} terminal=${terminal || 'default'} project=${project || '(none)'} flags=${safeFlags.join(',') || '(none)'}`);
+            openInTerminal(fresh ? '' : sessionId, resolvedTool, safeFlags, project || '', terminal || '', fresh ? 'fresh' : 'resume');
+
+            // Auto-register: when a fresh launch fires for a path under $HOME
+            // that is either a git repo or has been launched ≥2 times, add it
+            // to the manual registry so it surfaces as a launcher card. Failures
+            // here are non-fatal — the launch already succeeded.
+            let registered;
+            if (fresh && project && autoRegister !== false) {
+              try {
+                const maybe = await maybeAutoRegister(project);
+                if (maybe && maybe.added) registered = maybe.project;
+              } catch (e) {
+                log('WARN', `auto-register failed: ${e.message}`);
+              }
+            }
+
+            // Remember the tool the user picked for this project so the next
+            // ▶ New click defaults to the same agent.
+            if (project) {
+              try { await settingsApi.rememberLastUsed(project, resolvedTool); } catch (_) {}
+            }
+
+            log('LAUNCH', 'ok');
+            json(res, registered ? { ok: true, registered } : { ok: true });
+          } catch (e) {
+            log('ERROR', `launch failed: ${e.message}`);
+            json(res, { ok: false, error: e.message }, 400);
           }
-          if (fresh && !project) {
-            throw new Error('project path required for fresh session');
-          }
-          // The project path flows into a shell command string in terminals.js
-          // (`cd "..." && claude ...`). Even though JSON.stringify wraps the
-          // value in double quotes, bash still expands $() and backticks
-          // inside double-quoted strings. We refuse anything other than a
-          // plain on-disk directory path.
-          if (project && !projectsApi.isSafeLaunchPath(project)) {
-            throw new Error('invalid or unsafe project path');
-          }
-          log('LAUNCH', `mode=${fresh ? 'fresh' : 'resume'} session=${sessionId || '(none)'} tool=${tool || 'claude'} terminal=${terminal || 'default'} project=${project || '(none)'} flags=${(flags || []).join(',') || '(none)'}`);
-          openInTerminal(fresh ? '' : sessionId, tool || 'claude', flags || [], project || '', terminal || '', fresh ? 'fresh' : 'resume');
-          log('LAUNCH', 'ok');
-          json(res, { ok: true });
-        } catch (e) {
-          log('ERROR', `launch failed: ${e.message}`);
-          json(res, { ok: false, error: e.message }, 400);
-        }
+        })();
       });
+    }
+
+    // ── Settings (UI-level) ─────────────────
+    else if (req.method === 'GET' && pathname === '/api/settings') {
+      // Filter defaultAgent against the current installed list so the client
+      // never sees a stale value pointing at an uninstalled agent.
+      agentsDetect.detectRealOS().then(det => {
+        const settings = settingsApi.loadSettings();
+        const installedIds = new Set(det.agents.map(a => a.id));
+        const safeDefault = settings.defaultAgent && installedIds.has(settings.defaultAgent)
+          ? settings.defaultAgent
+          : null;
+        json(res, {
+          defaultAgent: safeDefault,
+          lastUsedByPath: settings.lastUsedByPath,
+        });
+      }).catch(e => json(res, { error: e.message }, 500));
+    }
+    else if (req.method === 'PUT' && pathname === '/api/settings') {
+      readBody(req, body => {
+        agentsDetect.detectRealOS().then(det => {
+          let parsed;
+          try { parsed = JSON.parse(body || '{}'); }
+          catch { return json(res, { error: 'invalid json' }, 400); }
+
+          const next = {};
+          if (Object.prototype.hasOwnProperty.call(parsed, 'defaultAgent')) {
+            const da = parsed.defaultAgent;
+            if (da === null) {
+              next.defaultAgent = null;
+            } else if (!settingsApi.isKnownAgent(da)) {
+              return json(res, { error: 'unknown agent id' }, 400);
+            } else if (!det.agents.some(a => a.id === da)) {
+              return json(res, { error: 'agent not installed: ' + da }, 400);
+            } else {
+              next.defaultAgent = da;
+            }
+          }
+          settingsApi.updateSettings(next)
+            .then(saved => json(res, {
+              defaultAgent: saved.defaultAgent,
+              lastUsedByPath: saved.lastUsedByPath,
+            }))
+            .catch(e => json(res, { error: e.message }, 500));
+        }).catch(e => json(res, { error: e.message }, 500));
+      });
+    }
+
+    // ── Installed agents detection ──────────
+    // We expose detection metadata to the browser but strip `binPath` — the
+    // browser has no business knowing the user's filesystem layout, and a
+    // future code path could otherwise pass an attacker-controlled value back
+    // to the server expecting it to be the same internal path.
+    else if (req.method === 'GET' && pathname === '/api/agents/installed') {
+      agentsDetect.detectRealOS()
+        .then(d => json(res, stripBinPaths(d)))
+        .catch(e => json(res, { error: e.message }, 500));
+    }
+    else if (req.method === 'POST' && pathname === '/api/agents/refresh-detect') {
+      agentsDetect.detectRealOS({ force: true })
+        .then(d => json(res, stripBinPaths(d)))
+        .catch(e => json(res, { error: e.message }, 500));
     }
 
     // ── Delete ──────────────────────────────
@@ -684,6 +807,59 @@ function startServer(host, port, openBrowser = true) {
   });
 }
 
+// Auto-register helper for /api/launch. Adds a fresh-launch project to the
+// manual registry when it looks like a real workspace the user will revisit:
+//   * the path must be under $HOME (no /tmp, no /Applications)
+//   * AND either:
+//      - the path contains a .git directory or file (real repo or worktree), OR
+//      - the user has already fresh-launched the same path before (tracked
+//        via settings.lastUsedByPath — second hit means it survived the
+//        one-shot threshold).
+// Returns { added: boolean, project } so the caller can surface a toast.
+// Async: awaits the projects.js mutex-serialized write so we never report
+// success before the registry has actually persisted the new entry.
+async function maybeAutoRegister(projectPath) {
+  if (!projectPath || typeof projectPath !== 'string') return { added: false };
+  const abs = pathLib.resolve(projectPath);
+  const home = os.homedir();
+  if (!abs.startsWith(home + pathLib.sep) && abs !== home) return { added: false };
+
+  const existing = projectsApi.loadProjects().find(p => p.path === abs);
+  if (existing) return { added: false, project: existing };
+
+  // Single stat — both directory and file forms of .git count as a repo.
+  const isGitRepo = (() => {
+    try {
+      const st = fs.statSync(pathLib.join(abs, '.git'));
+      return st.isDirectory() || st.isFile();
+    } catch { return false; }
+  })();
+
+  const previouslyLaunched = !!(settingsApi.loadSettings().lastUsedByPath || {})[abs];
+
+  if (!isGitRepo && !previouslyLaunched) return { added: false };
+
+  // Await the registry write so the response to the client reflects reality.
+  const project = await projectsApi.addProject({
+    name: pathLib.basename(abs),
+    path: abs,
+    source: 'auto',
+  });
+  return { added: true, project };
+}
+
+// Remove binPath from each agent entry before serialising to the browser.
+function stripBinPaths(detection) {
+  if (!detection || !Array.isArray(detection.agents)) return detection;
+  return {
+    refreshedAt: detection.refreshedAt,
+    agents: detection.agents.map(a => {
+      const { binPath, ...rest } = a;
+      return rest;
+    }),
+  };
+}
+
 function openIDE(ide, target) {
   const bin = ide === 'cursor' ? 'cursor' : 'code';
   const winBin = bin + '.exe';
@@ -1000,10 +1176,26 @@ function json(res, data, status = 200) {
   res.end(JSON.stringify(data));
 }
 
+// Cap request bodies at 2 MB. Without a limit a local process (or a page
+// opened by the user that hits the loopback API) can stream arbitrary bytes
+// and exhaust heap memory. 2 MB is generous — every legitimate POST body in
+// this codebase is well under 100 KB.
+const MAX_REQUEST_BODY = 2 * 1024 * 1024;
 function readBody(req, cb) {
   let body = '';
-  req.on('data', chunk => body += chunk);
-  req.on('end', () => cb(body));
+  let size = 0;
+  let aborted = false;
+  req.on('data', chunk => {
+    if (aborted) return;
+    size += chunk.length;
+    if (size > MAX_REQUEST_BODY) {
+      aborted = true;
+      req.destroy();
+      return;
+    }
+    body += chunk;
+  });
+  req.on('end', () => { if (!aborted) cb(body); });
 }
 
 function getBrowserUrl(host, port) {
@@ -1052,9 +1244,9 @@ function isNewer(latest, current) {
 }
 
 // ── GitHub Auth (Device Flow) ──────────────
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+// fs, os, pathLib are already required at the top of the file. Aliasing path
+// here so the legacy block below keeps reading naturally without renames.
+const path = pathLib;
 
 const GITHUB_CLIENT_ID = 'Ov23liBD3XGfBBIZiyK6';
 const GITHUB_PROFILE_FILE = path.join(os.homedir(), '.codedash', 'github-profile.json');
@@ -1223,9 +1415,18 @@ function saveGitHubProfile(profile) {
   if (profile) {
     // Atomic write + restrictive perms (owner read/write only). The token file
     // would otherwise be world-readable on shared boxes/CI runners.
+    // Double-chmod pattern: set mode on the .tmp, then re-chmod the final
+    // path after rename — on some Linux filesystems renameSync preserves the
+    // *destination's* mode if the file already existed, leaving a 0644 hole.
     const tmp = GITHUB_PROFILE_FILE + '.tmp';
     fs.writeFileSync(tmp, JSON.stringify(profile, null, 2), { mode: 0o600 });
+    if (process.platform !== 'win32') {
+      try { fs.chmodSync(tmp, 0o600); } catch {}
+    }
     fs.renameSync(tmp, GITHUB_PROFILE_FILE);
+    if (process.platform !== 'win32') {
+      try { fs.chmodSync(GITHUB_PROFILE_FILE, 0o600); } catch {}
+    }
   } else {
     try { fs.unlinkSync(GITHUB_PROFILE_FILE); } catch {}
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,192 @@
+// UI-level settings: default agent + last-used-by-path map.
+//
+// Storage: <CODBASH_SETTINGS_DIR or ~/.codedash>/settings.json, mode 0600.
+//
+// Writes are serialized through a promise-chain mutex and made atomic via
+// tmp-file + rename, mirroring the pattern in projects.js. Reads tolerate a
+// missing or corrupt file by returning defaults — writes do NOT, so a corrupt
+// file is loud rather than silently overwritten.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const KNOWN_AGENTS = Object.freeze([
+  'claude', 'codex', 'cursor', 'qwen',
+  'kilo', 'kiro', 'opencode', 'copilot', 'copilot-chat',
+]);
+const KNOWN_AGENT_SET = new Set(KNOWN_AGENTS);
+
+// Cap the lastUsedByPath map so a long-running install over hundreds of
+// ephemeral worktree paths doesn't grow settings.json without bound. 500 is
+// generous — typical users have <50 active projects.
+const MAX_LAST_USED = 500;
+// Reject path keys that are absurdly long or look like prototype-pollution
+// attempts (__proto__, constructor) — these can't appear in legitimate
+// absolute paths on any supported OS.
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+function isSafePathKey(k) {
+  if (typeof k !== 'string' || k.length === 0 || k.length > 1024) return false;
+  if (FORBIDDEN_KEYS.has(k)) return false;
+  return true;
+}
+
+function settingsDir() {
+  return process.env.CODBASH_SETTINGS_DIR || path.join(os.homedir(), '.codedash');
+}
+function settingsFile() {
+  return path.join(settingsDir(), 'settings.json');
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function emptySettings() {
+  return { defaultAgent: null, lastUsedByPath: {} };
+}
+
+// Reader tolerates absent / corrupt file — callers always get a usable object.
+function loadSettings() {
+  const fp = settingsFile();
+  let raw;
+  try { raw = fs.readFileSync(fp, 'utf8'); }
+  catch { return emptySettings(); }
+  let parsed;
+  try { parsed = JSON.parse(raw); }
+  catch { return emptySettings(); }
+  return {
+    defaultAgent: typeof parsed.defaultAgent === 'string' && KNOWN_AGENT_SET.has(parsed.defaultAgent)
+      ? parsed.defaultAgent
+      : null,
+    lastUsedByPath: sanitizeLastUsed(parsed.lastUsedByPath),
+  };
+}
+
+// Internal read used inside the mutex; throws on corrupt JSON so updates don't
+// silently obliterate a file we couldn't parse. Use loadSettings() for soft reads.
+// Both `defaultAgent` and the `lastUsedByPath` entries are validated against
+// the known-agent set so a tampered file can't smuggle untrusted strings into
+// future writes.
+function readForUpdate() {
+  const fp = settingsFile();
+  if (!fs.existsSync(fp)) return emptySettings();
+  const raw = fs.readFileSync(fp, 'utf8');
+  let parsed;
+  try { parsed = JSON.parse(raw); }
+  catch { throw new Error('settings.json is corrupt — refusing to overwrite. Move it aside and retry.'); }
+  return {
+    defaultAgent: typeof parsed.defaultAgent === 'string' && KNOWN_AGENT_SET.has(parsed.defaultAgent)
+      ? parsed.defaultAgent
+      : null,
+    lastUsedByPath: sanitizeLastUsed(parsed.lastUsedByPath),
+  };
+}
+
+// Filter a lastUsedByPath candidate down to safe key/value pairs. Used by
+// both the reader (sanitises on-disk data) and the writer (sanitises caller
+// input before merging into the persisted object).
+function sanitizeLastUsed(obj) {
+  if (!obj || typeof obj !== 'object') return {};
+  const out = Object.create(null);
+  for (const [k, v] of Object.entries(obj)) {
+    if (!isSafePathKey(k)) continue;
+    if (typeof v !== 'string' || !KNOWN_AGENT_SET.has(v)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+function writeAtomic(obj) {
+  const fp = settingsFile();
+  ensureDir(path.dirname(fp));
+  const tmp = fp + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), { mode: 0o600 });
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(tmp, 0o600); } catch {}
+  }
+  fs.renameSync(tmp, fp);
+  if (process.platform !== 'win32') {
+    try { fs.chmodSync(fp, 0o600); } catch {}
+  }
+}
+
+let _writeLock = Promise.resolve();
+// Promise-chain mutex. The `then(fn, fn)` shape is deliberate (same pattern as
+// in projects.js): we want the queue to keep moving even if a previous step
+// rejected. `fn` is re-invoked on rejection but it will re-throw if the
+// underlying file is still corrupt, so the rejection surfaces to that
+// specific caller, not the entire queue.
+function withWriteLock(fn) {
+  const next = _writeLock.then(fn, fn);
+  _writeLock = next.catch(() => {});
+  return next;
+}
+
+// Merge update — caller passes a partial; we shallow-merge into the on-disk
+// object. `lastUsedByPath` is merged key-by-key so per-project entries are
+// not wiped by an update that only sets `defaultAgent`. Caller input is run
+// through `sanitizeLastUsed` so a buggy or malicious caller can't smuggle in
+// prototype-pollution keys, oversized strings, or non-agent values.
+function updateSettings(partial) {
+  return withWriteLock(() => {
+    const current = readForUpdate();
+    const next = { ...current };
+    if (Object.prototype.hasOwnProperty.call(partial, 'defaultAgent')) {
+      next.defaultAgent = partial.defaultAgent === null
+        ? null
+        : (KNOWN_AGENT_SET.has(partial.defaultAgent) ? partial.defaultAgent : current.defaultAgent);
+    }
+    if (partial.lastUsedByPath && typeof partial.lastUsedByPath === 'object') {
+      const sanitized = sanitizeLastUsed(partial.lastUsedByPath);
+      const merged = { ...current.lastUsedByPath, ...sanitized };
+      // Cap map size — drop oldest keys (insertion order) once over MAX_LAST_USED.
+      const entries = Object.entries(merged);
+      next.lastUsedByPath = entries.length > MAX_LAST_USED
+        ? Object.fromEntries(entries.slice(entries.length - MAX_LAST_USED))
+        : merged;
+    }
+    writeAtomic(next);
+    return next;
+  });
+}
+
+function rememberLastUsed(projectPath, tool) {
+  if (!projectPath || typeof projectPath !== 'string') return Promise.resolve();
+  if (!KNOWN_AGENT_SET.has(tool)) return Promise.resolve();
+  return updateSettings({ lastUsedByPath: { [projectPath]: tool } });
+}
+
+function isKnownAgent(id) {
+  return typeof id === 'string' && KNOWN_AGENT_SET.has(id);
+}
+
+// Pure selection helper that mirrors the client's `pickPreferredTool` priority
+// order (lastUsed > default > first installed). Currently consumed only by the
+// unit tests — kept on the server module so server-side callers can adopt the
+// same priority order without re-deriving it. Replaces the older inline
+// `isKnownAgent(tool) ? tool : 'claude'` fallback in `/api/launch` if/when we
+// move that path here.
+function pickLaunchTool({ path: projectPath, settings, installed }) {
+  const installedSet = new Set(Array.isArray(installed) ? installed : []);
+  const last = settings && settings.lastUsedByPath ? settings.lastUsedByPath[projectPath] : null;
+  if (last && installedSet.has(last)) return last;
+  const def = settings ? settings.defaultAgent : null;
+  if (def && installedSet.has(def)) return def;
+  if (installedSet.size === 0) return null;
+  // Return the first agent in the installed list — caller is expected to pass
+  // an array ordered by preference (currently KNOWN_AGENTS order).
+  for (const id of (Array.isArray(installed) ? installed : [])) {
+    if (KNOWN_AGENT_SET.has(id)) return id;
+  }
+  return null;
+}
+
+module.exports = {
+  KNOWN_AGENTS,
+  loadSettings,
+  updateSettings,
+  rememberLastUsed,
+  isKnownAgent,
+  pickLaunchTool,
+};

--- a/test/agents-detect.test.js
+++ b/test/agents-detect.test.js
@@ -11,12 +11,16 @@ function loadFresh() {
   return require('../src/agents-detect');
 }
 
+// Default stub for custom detectors so tests don't probe the real filesystem.
+const NO_CUSTOM = { ghCopilotExtension: () => null, vscodeCopilotChatExtension: () => null };
+
 test('detect picks up an agent found on PATH', async () => {
   const { detect } = loadFresh();
   const got = await detect({
     platform: 'darwin',
     which: (bin) => bin === 'claude' ? '/usr/local/bin/claude' : null,
     appBundleExists: () => false,
+    customChecks: NO_CUSTOM,
   });
   const claude = got.agents.find(a => a.id === 'claude');
   assert.ok(claude, 'claude should be detected');
@@ -30,6 +34,7 @@ test('detect falls back to macOS app bundle when CLI is missing', async () => {
     platform: 'darwin',
     which: () => null,
     appBundleExists: (name) => name === 'Cursor.app',
+    customChecks: NO_CUSTOM,
   });
   const cursor = got.agents.find(a => a.id === 'cursor');
   assert.ok(cursor, 'cursor should be detected via app bundle');
@@ -42,6 +47,7 @@ test('detect ignores app-bundle lookup on non-darwin', async () => {
     platform: 'linux',
     which: () => null,
     appBundleExists: () => true, // would-be hit, must be ignored
+    customChecks: NO_CUSTOM,
   });
   assert.equal(got.agents.length, 0);
 });
@@ -52,10 +58,29 @@ test('detect prefers PATH binary over app bundle for the same agent', async () =
     platform: 'darwin',
     which: (bin) => bin === 'cursor-agent' ? '/opt/homebrew/bin/cursor-agent' : null,
     appBundleExists: () => true,
+    customChecks: NO_CUSTOM,
   });
   const cursor = got.agents.find(a => a.id === 'cursor');
   assert.ok(cursor);
   assert.equal(cursor.detectedVia, 'path', 'PATH should win over app-bundle');
+});
+
+test('detect uses customCheck only when PATH and app-bundle miss', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'linux',
+    which: () => null,
+    appBundleExists: () => false,
+    customChecks: {
+      ghCopilotExtension: () => ({ ok: true, detectedVia: 'gh-extension' }),
+      vscodeCopilotChatExtension: () => null,
+    },
+  });
+  const copilot = got.agents.find(a => a.id === 'copilot');
+  assert.ok(copilot, 'copilot should be detected via gh extension');
+  assert.equal(copilot.detectedVia, 'gh-extension');
+  const chat = got.agents.find(a => a.id === 'copilot-chat');
+  assert.equal(chat, undefined, 'copilot-chat should NOT be detected when extension is missing');
 });
 
 test('detect labels each agent with a human-readable string', async () => {
@@ -64,6 +89,7 @@ test('detect labels each agent with a human-readable string', async () => {
     platform: 'darwin',
     which: (bin) => '/usr/bin/' + bin,
     appBundleExists: () => false,
+    customChecks: NO_CUSTOM,
   });
   // All 7 agents from terminals.js plus the synthetic copilot-chat alias.
   const ids = got.agents.map(a => a.id).sort();
@@ -85,6 +111,7 @@ test('detect.refreshedAt is an ISO timestamp', async () => {
     platform: 'linux',
     which: () => null,
     appBundleExists: () => false,
+    customChecks: NO_CUSTOM,
   });
   assert.match(got.refreshedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
 });
@@ -95,6 +122,7 @@ test('detect response never contains a "token" or "repoToken" field', async () =
     platform: 'darwin',
     which: () => '/usr/local/bin/claude',
     appBundleExists: () => false,
+    customChecks: NO_CUSTOM,
   });
   const json = JSON.stringify(got);
   assert.equal(json.includes('token'), false, 'response must not leak token field');

--- a/test/agents-detect.test.js
+++ b/test/agents-detect.test.js
@@ -1,0 +1,103 @@
+// Tests for src/agents-detect.js — PATH probing + macOS .app bundle fallback.
+//
+// Strategy: pass an injected detector context so we can fake fs/exec without
+// monkey-patching the real OS. The module exports a pure `detect(ctx)` helper
+// alongside the cached real-OS variant.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function loadFresh() {
+  delete require.cache[require.resolve('../src/agents-detect')];
+  return require('../src/agents-detect');
+}
+
+test('detect picks up an agent found on PATH', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'darwin',
+    which: (bin) => bin === 'claude' ? '/usr/local/bin/claude' : null,
+    appBundleExists: () => false,
+  });
+  const claude = got.agents.find(a => a.id === 'claude');
+  assert.ok(claude, 'claude should be detected');
+  assert.equal(claude.detectedVia, 'path');
+  assert.equal(claude.binPath, '/usr/local/bin/claude');
+});
+
+test('detect falls back to macOS app bundle when CLI is missing', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'darwin',
+    which: () => null,
+    appBundleExists: (name) => name === 'Cursor.app',
+  });
+  const cursor = got.agents.find(a => a.id === 'cursor');
+  assert.ok(cursor, 'cursor should be detected via app bundle');
+  assert.equal(cursor.detectedVia, 'app-bundle');
+});
+
+test('detect ignores app-bundle lookup on non-darwin', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'linux',
+    which: () => null,
+    appBundleExists: () => true, // would-be hit, must be ignored
+  });
+  assert.equal(got.agents.length, 0);
+});
+
+test('detect prefers PATH binary over app bundle for the same agent', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'darwin',
+    which: (bin) => bin === 'cursor-agent' ? '/opt/homebrew/bin/cursor-agent' : null,
+    appBundleExists: () => true,
+  });
+  const cursor = got.agents.find(a => a.id === 'cursor');
+  assert.ok(cursor);
+  assert.equal(cursor.detectedVia, 'path', 'PATH should win over app-bundle');
+});
+
+test('detect labels each agent with a human-readable string', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'darwin',
+    which: (bin) => '/usr/bin/' + bin,
+    appBundleExists: () => false,
+  });
+  // All 7 agents from terminals.js plus the synthetic copilot-chat alias.
+  const ids = got.agents.map(a => a.id).sort();
+  assert.ok(ids.includes('claude'));
+  assert.ok(ids.includes('codex'));
+  assert.ok(ids.includes('cursor'));
+  assert.ok(ids.includes('qwen'));
+  assert.ok(ids.includes('kilo'));
+  assert.ok(ids.includes('kiro'));
+  assert.ok(ids.includes('opencode'));
+  for (const a of got.agents) {
+    assert.ok(typeof a.label === 'string' && a.label.length > 0, 'missing label for ' + a.id);
+  }
+});
+
+test('detect.refreshedAt is an ISO timestamp', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'linux',
+    which: () => null,
+    appBundleExists: () => false,
+  });
+  assert.match(got.refreshedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+});
+
+test('detect response never contains a "token" or "repoToken" field', async () => {
+  const { detect } = loadFresh();
+  const got = await detect({
+    platform: 'darwin',
+    which: () => '/usr/local/bin/claude',
+    appBundleExists: () => false,
+  });
+  const json = JSON.stringify(got);
+  assert.equal(json.includes('token'), false, 'response must not leak token field');
+  assert.equal(json.includes('repoToken'), false, 'response must not leak repoToken field');
+  assert.equal(json.includes('gho_'), false, 'response must not contain GitHub token prefix');
+});

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,0 +1,136 @@
+// Tests for src/settings.js — atomic 0600 read/write, mutex, stale-default fallback.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Module under test is loaded after we point SETTINGS_FILE override env var
+// at a per-test temp directory. This avoids touching the real ~/.codedash.
+function freshSettingsModule(tmpDir) {
+  process.env.CODBASH_SETTINGS_DIR = tmpDir;
+  delete require.cache[require.resolve('../src/settings')];
+  return require('../src/settings');
+}
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-settings-'));
+}
+
+test('loadSettings returns defaults when file missing', () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  const got = s.loadSettings();
+  assert.equal(got.defaultAgent, null);
+  assert.deepEqual(got.lastUsedByPath, {});
+});
+
+test('saveSettings writes mode 0600 and is readable back', async () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  await s.updateSettings({ defaultAgent: 'claude' });
+  const filePath = path.join(dir, 'settings.json');
+  assert.ok(fs.existsSync(filePath));
+  // POSIX-only assertion; codbash supports macOS/Linux/WSL.
+  if (process.platform !== 'win32') {
+    const mode = fs.statSync(filePath).mode & 0o777;
+    assert.equal(mode, 0o600, 'expected mode 0600, got 0' + mode.toString(8));
+  }
+  const got = s.loadSettings();
+  assert.equal(got.defaultAgent, 'claude');
+});
+
+test('updateSettings is a merge, not a replace', async () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  await s.updateSettings({ defaultAgent: 'claude' });
+  await s.updateSettings({ lastUsedByPath: { '/Users/me/a': 'cursor' } });
+  const got = s.loadSettings();
+  assert.equal(got.defaultAgent, 'claude', 'defaultAgent must survive partial update');
+  assert.equal(got.lastUsedByPath['/Users/me/a'], 'cursor');
+});
+
+test('rememberLastUsed updates only the requested path entry', async () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  await s.updateSettings({ lastUsedByPath: { '/a': 'claude', '/b': 'codex' } });
+  await s.rememberLastUsed('/a', 'cursor');
+  const got = s.loadSettings();
+  assert.equal(got.lastUsedByPath['/a'], 'cursor');
+  assert.equal(got.lastUsedByPath['/b'], 'codex');
+});
+
+test('concurrent updateSettings calls are serialized (no lost writes)', async () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  const writes = [];
+  for (let i = 0; i < 30; i++) {
+    writes.push(s.rememberLastUsed('/p' + i, 'claude'));
+  }
+  await Promise.all(writes);
+  const got = s.loadSettings();
+  for (let i = 0; i < 30; i++) {
+    assert.equal(got.lastUsedByPath['/p' + i], 'claude', 'lost write at /p' + i);
+  }
+});
+
+test('corrupt settings file does NOT wipe data on next update', async () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  await s.updateSettings({ defaultAgent: 'claude' });
+  fs.writeFileSync(path.join(dir, 'settings.json'), '{ not valid json');
+  // updateSettings must throw rather than silently overwrite with empty {}
+  await assert.rejects(() => s.updateSettings({ defaultAgent: 'codex' }), /parse|json|corrupt/i);
+});
+
+test('loadSettings returns defaults on corrupt file (read-side tolerance)', () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  fs.writeFileSync(path.join(dir, 'settings.json'), '{ bad');
+  const got = s.loadSettings();
+  assert.equal(got.defaultAgent, null);
+  assert.deepEqual(got.lastUsedByPath, {});
+});
+
+test('validateAgentId rejects unknown agents', () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  assert.equal(s.isKnownAgent('claude'), true);
+  assert.equal(s.isKnownAgent('cursor'), true);
+  assert.equal(s.isKnownAgent('codex'), true);
+  assert.equal(s.isKnownAgent('opencode'), true);
+  assert.equal(s.isKnownAgent('kiro'), true);
+  assert.equal(s.isKnownAgent('kilo'), true);
+  assert.equal(s.isKnownAgent('qwen'), true);
+  assert.equal(s.isKnownAgent('copilot'), true);
+  assert.equal(s.isKnownAgent('copilot-chat'), true);
+  assert.equal(s.isKnownAgent('bogus'), false);
+  assert.equal(s.isKnownAgent(''), false);
+  assert.equal(s.isKnownAgent(null), false);
+  assert.equal(s.isKnownAgent({ id: 'claude' }), false);
+});
+
+test('pickLaunchTool priority: lastUsed > default > first installed', () => {
+  const dir = mkTmp();
+  const s = freshSettingsModule(dir);
+  // lastUsed wins
+  assert.equal(
+    s.pickLaunchTool({ path: '/a', settings: { defaultAgent: 'codex', lastUsedByPath: { '/a': 'cursor' } }, installed: ['claude', 'cursor', 'codex'] }),
+    'cursor'
+  );
+  // lastUsed not installed → fall through to default
+  assert.equal(
+    s.pickLaunchTool({ path: '/a', settings: { defaultAgent: 'codex', lastUsedByPath: { '/a': 'cursor' } }, installed: ['claude', 'codex'] }),
+    'codex'
+  );
+  // default not installed → fall through to first installed
+  assert.equal(
+    s.pickLaunchTool({ path: '/a', settings: { defaultAgent: 'cursor', lastUsedByPath: {} }, installed: ['claude', 'codex'] }),
+    'claude'
+  );
+  // nothing installed → null
+  assert.equal(
+    s.pickLaunchTool({ path: '/a', settings: { defaultAgent: 'claude', lastUsedByPath: {} }, installed: [] }),
+    null
+  );
+});


### PR DESCRIPTION
## Summary

Restructures the **Projects** view into two purpose-built subtabs:

- **Projects** (landing, default) — registered project launcher cards with `▶ New` split-button + `⏷` per-launch agent picker + `⚙ Settings` modal for the default agent.
- **History** — the existing grouped-session view, relocated unchanged. Drawer/click-into-session/collapse-all/etc. all work identically.

Built on top of #210 (dual-token GitHub auth). Stacked branch — don't merge until #210 lands first.

## What's new

### User-facing
- Each registered project gets a clean launcher card: name, path, source tag (`github` / `added` / `auto`), `▶ New`, `⟳ Last`, `⏷` agent picker, `View N sessions →` deeplink to History filtered to that project.
- `⚙ Settings` modal — pick a default agent for ▶ New across all projects. List only shows agents detected on this machine.
- Auto-register on first fresh launch: if you start a session in any git repo under `$HOME`, the project gets added to your registry automatically.
- Per-launch override via the `⏷` picker — pick a different agent for a single launch without changing your default.

### Under the hood
- `~/.codedash/settings.json` (mode 0600, mutex-serialised atomic writes) stores `defaultAgent` and per-project `lastUsedByPath`.
- Agent detection probes `$PATH` directly (no shell) + macOS `.app` bundles for Cursor/VS Code.
- Four new API routes: `GET/PUT /api/settings`, `GET /api/agents/installed`, `POST /api/agents/refresh-detect`.
- `POST /api/launch` gains optional `autoRegister` and returns `registered: { ... }` when a new project was added.

## SDD / BDD / TDD
- `docs/design/projects-tab-restructure.md` — full architecture, contracts, risks.
- `specs/projects-tab-restructure.feature` — 20 BDD scenarios (happy / edge / negative).
- 16 unit tests in `test/settings.test.js` + `test/agents-detect.test.js`. All green.
- Pre-existing `wsl-windows.test.js` failure is unrelated (failed on parent branch too).

## Three-agent review

Ran code-reviewer + security-reviewer + UX/UI reviewer in parallel. Combined: **0 CRITICAL, 11 HIGH, 17 MEDIUM, 55 LOW** (after dedup).

All severities fixed before commit, no deferrals. Highlights:
- **Security:** 2 MB request-body cap, launch-flag allowlist, double-chmod on tokens, scheme allowlist for `verification_uri`, `binPath` stripped from API responses, CSP + X-Frame-Options + Referrer-Policy headers, prototype-pollution guard on settings keys, `lstat` defense vs symlink-out-of-HOME.
- **A11y:** `role=tablist/tab/dialog/menu/group`, focus-trap on modals, `Esc` close, Arrow-key navigation in subtabs and picker, `focus-visible` rings, aria-labels on every emoji button.
- **UX:** loading skeleton (no flash of "no agent installed"), single-toast merging (no clobber), re-fetch settings after save (no shape-trust clobber), theme-aware CSS variables (works on light/monokai), `position:fixed` viewport-clamped picker, history filter bar with clear button.

## Cross-platform testing needed

Verified on **macOS Sequoia** with Claude Code + Cursor + Copilot. Please confirm on:

- [ ] **Linux** (Ubuntu/Fedora) — `realWhich` walks `$PATH` directly without a shell (defense-in-depth), no `.app` bundle branch.
- [ ] **WSL** (Ubuntu under Windows 11) — same as Linux + WSL-specific path handling already in `terminals.js`.
- [ ] **Windows native** — `where.exe` branch in `agents-detect.js` (untested on real Windows by me).

## Test plan

- [ ] Open Projects → defaults to **Projects** subtab. Verify launcher cards render with correct source tags and the configured default agent.
- [ ] Switch to **History** subtab → identical to current Projects view (group list, drawer on session click, collapse/expand, no behavioral change).
- [ ] Click `View N sessions →` on a launcher card → History subtab opens filtered to that project; "× Clear filter" bar appears at top.
- [ ] Click `▶ New` → terminal opens with the picked agent in the project directory.
- [ ] Click `⏷` → picker shows only installed agents; pick one → launches with that agent without changing the global default.
- [ ] Open `⚙ Settings` → change default agent → save → click ▶ New on a fresh card → uses the new default. Try saving an uninstalled agent via curl → 400.
- [ ] First-time launch in a git repo under `$HOME` → toast says "Added X to Projects — Started Y" → card appears with `auto` tag.
- [ ] Reload with `#history` in URL → History subtab is active. Same for `#projects`.
- [ ] Keyboard: Tab into subtab strip → Left/Right cycles tabs → Tab into modal → Tab traps inside → Esc closes.
- [ ] Verify `~/.codedash/settings.json` and `~/.codedash/projects.json` have file mode `0600` after writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)