### PR TITLE
fix: collapse worktrees to main repo, ignore $HOME-as-git-root

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -105,8 +105,11 @@ function detectHomes() {
   const homes = [];
   const seen = new Set();
   const addHome = (home) => {
-    const normalized = normalizeProjectPath(home);
+    let normalized = normalizeProjectPath(home);
     if (!normalized) return;
+    // Resolve symlinks so the HOME-as-gitRoot guard later compares apples to
+    // apples — on macOS /var → /private/var, on Docker $HOME is often a symlink.
+    try { normalized = fs.realpathSync(normalized); } catch {}
     const key = process.platform === 'win32' ? normalized.toLowerCase() : normalized;
     if (seen.has(key)) return;
     seen.add(key);
@@ -2404,13 +2407,19 @@ function _saveGitRootDiskCache() {
 
 // Parse first `worktree <path>` entry from `git worktree list --porcelain`.
 // The first record is always the main worktree, so a session living inside any
-// linked worktree collapses to the main repo's identity.
+// linked worktree collapses to the main repo's identity. Returns '' for bare
+// repos (a `bare` line inside the first record) since they have no working tree.
 function _parseMainWorktree(porcelain) {
   if (!porcelain) return '';
+  let candidate = '';
   for (const line of porcelain.split('\n')) {
-    if (line.startsWith('worktree ')) return line.slice('worktree '.length).trim();
+    if (candidate && line === 'bare') return '';
+    if (candidate && line === '') return candidate;
+    if (!candidate && line.startsWith('worktree ')) {
+      candidate = line.slice('worktree '.length).trim();
+    }
   }
-  return '';
+  return candidate;
 }
 
 function resolveGitRoot(projectPath) {
@@ -2443,7 +2452,12 @@ function resolveGitRoot(projectPath) {
   }
   // An accidental .git at $HOME (e.g. a dotfiles repo) would otherwise leak its
   // remote onto every session whose only crime was being launched from home.
-  if (root && ALL_HOMES.some(h => h === root)) root = '';
+  // On Windows, normalize separators + case so C:\Users\foo == C:/users/FOO.
+  if (root) {
+    const norm = (p) => process.platform === 'win32' ? p.replace(/\\/g, '/').toLowerCase() : p;
+    const rootKey = norm(root);
+    if (ALL_HOMES.some(h => norm(h) === rootKey)) root = '';
+  }
   _gitRootCache[projectPath] = root;
   return root;
 }

--- a/src/data.js
+++ b/src/data.js
@@ -2380,7 +2380,8 @@ function scanCodexSessions() {
 //      from the session cwd string. Works without git for standard worktree layouts.
 
 const _gitRootCache = {};
-const GIT_ROOT_CACHE_FILE = path.join(os.tmpdir(), 'codedash-gitroot-cache.json');
+// v2: collapses worktrees to main repo + ignores $HOME-as-git-root.
+const GIT_ROOT_CACHE_FILE = path.join(os.tmpdir(), 'codedash-gitroot-cache-v2.json');
 let _gitRootDiskCache = null;
 
 function _loadGitRootDiskCache() {
@@ -2401,6 +2402,17 @@ function _saveGitRootDiskCache() {
   } catch {}
 }
 
+// Parse first `worktree <path>` entry from `git worktree list --porcelain`.
+// The first record is always the main worktree, so a session living inside any
+// linked worktree collapses to the main repo's identity.
+function _parseMainWorktree(porcelain) {
+  if (!porcelain) return '';
+  for (const line of porcelain.split('\n')) {
+    if (line.startsWith('worktree ')) return line.slice('worktree '.length).trim();
+  }
+  return '';
+}
+
 function resolveGitRoot(projectPath) {
   if (!projectPath) return '';
   _loadGitRootDiskCache();
@@ -2410,16 +2422,30 @@ function resolveGitRoot(projectPath) {
     _gitRootCache[projectPath] = '';
     return '';
   }
+  const opts = { encoding: 'utf8', timeout: 2000, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'] };
+  let root = '';
   try {
-    const root = execFileSync('git', ['-C', projectPath, 'rev-parse', '--show-toplevel'], {
-      encoding: 'utf8', timeout: 2000, windowsHide: true, stdio: ['pipe', 'pipe', 'pipe']
-    }).trim();
-    _gitRootCache[projectPath] = root;
-    return root;
-  } catch {
-    _gitRootCache[projectPath] = '';
-    return '';
+    const porcelain = execFileSync('git', ['-C', projectPath, 'worktree', 'list', '--porcelain'], opts);
+    root = _parseMainWorktree(porcelain);
+  } catch {}
+  if (!root) {
+    try {
+      root = execFileSync('git', ['-C', projectPath, 'rev-parse', '--show-toplevel'], opts).trim();
+    } catch {}
   }
+  // Bare repos report the .git dir itself; treat them as "no working tree" so
+  // downstream code doesn't try to read files from a bare path.
+  if (root && /\.git\/?$/.test(root)) root = '';
+  // Normalize symlinks so /var and /private/var on macOS produce one cache key
+  // for the same physical directory — otherwise the same project shows twice.
+  if (root) {
+    try { root = fs.realpathSync(root); } catch {}
+  }
+  // An accidental .git at $HOME (e.g. a dotfiles repo) would otherwise leak its
+  // remote onto every session whose only crime was being launched from home.
+  if (root && ALL_HOMES.some(h => h === root)) root = '';
+  _gitRootCache[projectPath] = root;
+  return root;
 }
 
 const _gitInfoCache = {};
@@ -5386,5 +5412,8 @@ module.exports = {
     parseClaudeStructuredMessage,
     parseStructuredMessage,
     isFilteredClaudeStructuredMessage,
+    _parseMainWorktree,
+    resolveGitRoot,
+    ALL_HOMES,
   },
 };

--- a/test/git-root-resolve.test.js
+++ b/test/git-root-resolve.test.js
@@ -26,9 +26,14 @@ test('_parseMainWorktree handles empty input', () => {
   assert.equal(_parseMainWorktree(null), '');
 });
 
-test('_parseMainWorktree ignores lines that look like worktree but are not records', () => {
+test('_parseMainWorktree returns first worktree line regardless of preceding content', () => {
   const porcelain = 'HEAD abc\nworktree /a\n';
   assert.equal(_parseMainWorktree(porcelain), '/a');
+});
+
+test('_parseMainWorktree returns empty for bare main worktree', () => {
+  const porcelain = ['worktree /repos/origin.git', 'bare', ''].join('\n');
+  assert.equal(_parseMainWorktree(porcelain), '');
 });
 
 test('resolveGitRoot collapses linked worktree to main repo', () => {
@@ -38,7 +43,8 @@ test('resolveGitRoot collapses linked worktree to main repo', () => {
     const main = path.join(tmp, 'main');
     fs.mkdirSync(main, { recursive: true });
     const gitOpts = { cwd: main, stdio: 'ignore', timeout: 5000 };
-    execFileSync('git', ['init', '-q', '-b', 'main'], gitOpts);
+    // Plain `git init` (no -b flag) keeps compatibility with git < 2.28.
+    execFileSync('git', ['init', '-q'], gitOpts);
     execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], gitOpts);
     const wt = path.join(tmp, 'wt-feature');
     execFileSync('git', ['worktree', 'add', '-q', wt, '-b', 'feature'], gitOpts);
@@ -64,7 +70,7 @@ test('resolveGitRoot returns empty for bare repos', () => {
   const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-bare-')));
   try {
     const bare = path.join(tmp, 'origin.git');
-    execFileSync('git', ['init', '-q', '--bare', '-b', 'main', bare], { stdio: 'ignore', timeout: 5000 });
+    execFileSync('git', ['init', '-q', '--bare', bare], { stdio: 'ignore', timeout: 5000 });
     assert.equal(resolveGitRoot(bare), '');
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
@@ -81,7 +87,7 @@ test('resolveGitRoot normalizes symlinked paths to a single key', () => {
     const link = path.join(tmp, 'link');
     fs.symlinkSync(real, link);
     const gitOpts = { cwd: real, stdio: 'ignore', timeout: 5000 };
-    execFileSync('git', ['init', '-q', '-b', 'main'], gitOpts);
+    execFileSync('git', ['init', '-q'], gitOpts);
     execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], gitOpts);
     assert.equal(resolveGitRoot(real), real);
     assert.equal(resolveGitRoot(link), real);

--- a/test/git-root-resolve.test.js
+++ b/test/git-root-resolve.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const { _parseMainWorktree, resolveGitRoot, ALL_HOMES } = require('../src/data').__test;
+
+test('_parseMainWorktree returns first worktree path', () => {
+  const porcelain = [
+    'worktree /repos/myproj',
+    'HEAD abc123',
+    'branch refs/heads/main',
+    '',
+    'worktree /repos/myproj-feature',
+    'HEAD def456',
+    'branch refs/heads/feature',
+    '',
+  ].join('\n');
+  assert.equal(_parseMainWorktree(porcelain), '/repos/myproj');
+});
+
+test('_parseMainWorktree handles empty input', () => {
+  assert.equal(_parseMainWorktree(''), '');
+  assert.equal(_parseMainWorktree(null), '');
+});
+
+test('_parseMainWorktree ignores lines that look like worktree but are not records', () => {
+  const porcelain = 'HEAD abc\nworktree /a\n';
+  assert.equal(_parseMainWorktree(porcelain), '/a');
+});
+
+test('resolveGitRoot collapses linked worktree to main repo', () => {
+  // git resolves symlinks (macOS /var → /private/var), so use realpath upfront.
+  const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-wt-')));
+  try {
+    const main = path.join(tmp, 'main');
+    fs.mkdirSync(main, { recursive: true });
+    const gitOpts = { cwd: main, stdio: 'ignore', timeout: 5000 };
+    execFileSync('git', ['init', '-q', '-b', 'main'], gitOpts);
+    execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], gitOpts);
+    const wt = path.join(tmp, 'wt-feature');
+    execFileSync('git', ['worktree', 'add', '-q', wt, '-b', 'feature'], gitOpts);
+
+    // Both the main checkout and the linked worktree must resolve to the main path.
+    assert.equal(resolveGitRoot(main), main);
+    assert.equal(resolveGitRoot(wt), main);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolveGitRoot ignores $HOME-as-git-root', (t) => {
+  const home = ALL_HOMES[0];
+  if (!home || !fs.existsSync(path.join(home, '.git'))) {
+    t.skip('home is not a git repo on this machine');
+    return;
+  }
+  assert.equal(resolveGitRoot(home), '');
+});
+
+test('resolveGitRoot returns empty for bare repos', () => {
+  const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-bare-')));
+  try {
+    const bare = path.join(tmp, 'origin.git');
+    execFileSync('git', ['init', '-q', '--bare', '-b', 'main', bare], { stdio: 'ignore', timeout: 5000 });
+    assert.equal(resolveGitRoot(bare), '');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolveGitRoot normalizes symlinked paths to a single key', () => {
+  // Simulates macOS /var -> /private/var: two input paths for the same dir
+  // must produce the same git root, not two cache entries.
+  const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-sym-')));
+  try {
+    const real = path.join(tmp, 'real');
+    fs.mkdirSync(real);
+    const link = path.join(tmp, 'link');
+    fs.symlinkSync(real, link);
+    const gitOpts = { cwd: real, stdio: 'ignore', timeout: 5000 };
+    execFileSync('git', ['init', '-q', '-b', 'main'], gitOpts);
+    execFileSync('git', ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'init'], gitOpts);
+    assert.equal(resolveGitRoot(real), real);
+    assert.equal(resolveGitRoot(link), real);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Sessions whose `cwd` lives inside a linked git worktree, or sessions launched from `\$HOME` when home itself happens to be a git repo, were being mismapped to the wrong project / wrong GitHub remote in the dashboard.

This PR fixes `resolveGitRoot()` in `src/data.js` so the project identity (and downstream remote inference) is stable for those cases.

## Changes

- **Linked worktrees collapse to the main repo.** `git worktree list --porcelain` is parsed for its first record (the main worktree) before falling back to `rev-parse --show-toplevel`. Previously every linked worktree appeared as its own "project".
- **Bare repos are skipped.** Paths ending in `.git` (what `--porcelain` reports for bare repos) are dropped — downstream code assumes a working tree.
- **Symlinked paths are normalized via `fs.realpathSync`** so macOS `/var` vs `/private/var` doesn't duplicate the same physical project.
- **`\$HOME`-as-git-root is rejected.** When the home directory itself is a git repo (e.g. a dotfiles repo), sessions launched from home no longer inherit that remote.
- **Disk cache filename bumped to `-v2.json`** to invalidate stale entries from before the fix.

## Tests

`test/git-root-resolve.test.js` — 7 cases:
- 3 unit tests for `_parseMainWorktree` (happy path, empty input, lines that look like records but aren't).
- 4 integration tests using real `git` in `os.tmpdir()`: linked worktree → main, bare repo → empty, symlink → normalized to real path, `\$HOME`-as-git-root → empty (skipped if home isn't a repo on the machine).

All 7 pass locally. Pre-existing `test/wsl-windows.test.js` failure on macOS is unrelated to this change.

## Deferred (out of scope)

- Atomic disk-cache writes (`writeFileSync` → tmp + rename). Project-wide pattern in the existing cache helpers; addressing it here would balloon the diff.
- Debug-log on the silent porcelain → `rev-parse` fallback. Zero-dependency project has no logger; left as a comment-level TODO.

## Test plan

- [ ] Run `node --test test/git-root-resolve.test.js` — all 7 pass.
- [ ] In the dashboard, sessions whose `cwd` was a linked worktree now group under the main repo's project card.
- [ ] Sessions whose `cwd` is `\$HOME` (when home is a git repo) no longer carry that repo's remote.