### PR TITLE
feat(sidebar): group + customize sidebar items, tabbed Settings

### DIFF
--- a/docs/design/sidebar-customization.md
+++ b/docs/design/sidebar-customization.md
@@ -1,0 +1,181 @@
+# Sidebar Customization — design
+
+## Goal
+
+Let users group, collapse, and hide sidebar entries so the left rail matches how they actually work. Default behavior is unchanged for first-time users; preferences persist locally.
+
+```
+Sidebar (after change)
+├── Workspace      (collapsible section, default expanded)
+│     All Sessions · Projects · Timeline · Activity · Running
+│     Analytics · Starred · Leaderboard · Cloud Sync
+├── Agents         (collapsible, default expanded)
+│     Claude · Codex · Qwen · Kiro · Cursor · Copilot Chat · Copilot CLI · OpenCode · Kilo
+└── Tools          (collapsible, default expanded)
+      ├── Install agents   (nested collapsible, default collapsed)
+      │     Claude · Codex · Qwen · Kiro · OpenCode · Kilo · Copilot CLI
+      ├── Export / Import
+      ├── Changelog
+      └── Settings   (gains new "Sidebar" sub-pane)
+```
+
+## Why
+
+Сейчас сайдбар — 30+ пунктов одним списком, в нём есть редко используемые (Leaderboard, Cloud Sync, Starred) и шумная «Install Agents» секция с 7 повторяющимися записями. У разных пользователей разные интересы (только Claude + Projects + Running у одного, Cursor + Activity + Analytics у другого). Группировка + видимость каждого пункта решают это без удаления функциональности.
+
+## Non-goals
+
+- Не меняем поведение самих вкладок (Activity bug — отдельный PR, см. CLAUDE.md TODO).
+- Не добавляем drag-and-drop переупорядочивания (вне scope этого PR).
+- Не трогаем серверные API, файлы сессий, формат `~/.codedash/settings.json`.
+- Не добавляем синхронизацию настроек между устройствами — все только в `localStorage`.
+- Не делаем «скрытый пункт остаётся доступен через URL hash» как UX-фичу — но `data-view` атрибуты остаются на месте, поэтому хеш-роутинг (`#leaderboard`) технически продолжит работать; в навигации просто не будет ссылки.
+
+## Data inventory
+
+Где читаются/пишутся sidebar items сейчас:
+
+| Источник | Файл | Роль |
+|---|---|---|
+| HTML | `src/frontend/index.html:11-141` | статичная разметка `<div class="sidebar">` с `.sidebar-item[data-view]` |
+| Click handler | `src/frontend/app.js` | делегированный listener на `.sidebar-item`, читает `data-view`, выставляет `currentView` |
+| Hash routing | `src/frontend/app.js` (`hashchange` / `onload`) | `window.location.hash` → `currentView` |
+| Style | `src/frontend/styles.css` | `.sidebar`, `.sidebar-item`, `.sidebar-section`, `.sidebar-divider` |
+| Settings page | `src/frontend/app.js:2173` (`renderSettings`) | в неё добавим **Sidebar** sub-pane |
+
+Что добавляем:
+
+| Ключ `localStorage` | Тип | Default | Назначение |
+|---|---|---|---|
+| `codedash-sidebar-config` | JSON-string | см. ниже | видимость пунктов + collapsed-состояния секций |
+
+Схема `codedash-sidebar-config`:
+
+```ts
+interface SidebarConfig {
+  // Visibility map: data-view (для верхних/agents/Settings/Changelog) или install-key (для install) → true/false.
+  // Отсутствие ключа === видимый (default-on). Только явный false скрывает.
+  hidden: { [itemKey: string]: true };
+
+  // Collapsed sections. Key = section id ("workspace" | "agents" | "tools" | "install-agents").
+  // Отсутствие === default expanded state из таблицы выше.
+  collapsed: { [sectionId: string]: boolean };
+
+  // Schema version for future migrations.
+  v: 1;
+}
+```
+
+Префикс ключа — `codedash-` (legacy, как у всех остальных настроек проекта).
+
+### Item keys
+
+| Key | Source | Default visible |
+|---|---|---|
+| `sessions`, `projects`, `timeline`, `activity`, `running`, `analytics`, `starred`, `leaderboard`, `cloud` | data-view of Workspace items | yes |
+| `claude-only`, `codex-only`, `qwen-only`, `kiro-only`, `cursor-only`, `copilot-chat-only`, `copilot-only`, `opencode-only`, `kilo-only` | data-view of Agents items | yes |
+| `install:claude`, `install:codex`, `install:qwen`, `install:kiro`, `install:opencode`, `install:kilo`, `install:copilot` | composite key (no data-view today) | yes |
+| `export-import`, `changelog`, `settings` | new (we add `data-view`/key to existing items) | yes |
+
+Settings is **always** visible regardless of config — это safety: иначе пользователь скрыл Settings и не может вернуть видимость. Toggle для Settings в UI просто не показываем.
+
+## Component map
+
+| Файл | Изменение |
+|---|---|
+| `src/frontend/index.html` | Разметка переписывается под 3 секции `<div class="sidebar-section" data-section="<id>">` с заголовком `<button class="sidebar-section-header">…</button>` и контейнером `.sidebar-section-body`. Install agents — вложенный аналогичный блок внутри Tools. На каждом item, у которого его нет — добавить `data-key` (для install-кнопок) и `data-view="changelog/settings"` (уже есть). У `Export / Import` добавляем `data-key="export-import"`. |
+| `src/frontend/app.js` | (a) `loadSidebarConfig()` / `saveSidebarConfig()` — read/write `localStorage`. (b) `applySidebarConfig()` — на старте и после изменений: проходит по `.sidebar-item[data-view],[data-key]`, ставит `style.display='none'` для скрытых; на `.sidebar-section[data-section]` выставляет `.collapsed` класс. (c) Делегированный click на `.sidebar-section-header` — toggle collapsed, save, applySidebarConfig. (d) В `renderSettings` добавить группу «Sidebar» с чек-листом всех item keys по секциям + кнопку «Reset to defaults». (e) Hash-router не меняем. |
+| `src/frontend/styles.css` | `.sidebar-section[data-section]` — flex column; `.sidebar-section-header` — кликабельный заголовок с chevron (▾/▸); `.sidebar-section.collapsed > .sidebar-section-body { display: none }`. Вложенная секция `[data-section="install-agents"]` — отступ слева на 8px. Sub-pane Sidebar в Settings: список с чекбоксами. |
+
+## API/IPC contract
+
+Серверные API не трогаем. Все изменения — фронт.
+
+## State machine
+
+```
+Sidebar-config lifecycle:
+  page load
+    └─ loadSidebarConfig() → applySidebarConfig() → render
+
+  user clicks section header
+    └─ toggle collapsed[id] → saveSidebarConfig() → CSS update via class
+
+  user toggles item in Settings → Sidebar pane
+    └─ flip hidden[key] → saveSidebarConfig() → applySidebarConfig()
+
+  user clicks "Reset to defaults"
+    └─ remove `codedash-sidebar-config` → applySidebarConfig() (now no-op)
+       → re-render Settings to reflect cleared checkboxes
+```
+
+Запрещённые переходы:
+- Settings нельзя скрыть (UI просто не предлагает toggle).
+- Скрыть текущую active view допустимо, но при следующем рендере active-индикатор не показывается (вкладка работает по hash, доступ остаётся).
+
+## UX & Accessibility
+
+**Целевой WCAG-уровень**: AA.
+
+**Required UI states** на новой Sidebar sub-pane:
+- [x] Loading — N/A: чтение из localStorage синхронно.
+- [x] Empty — N/A: список item-ов фиксированный, всегда непустой.
+- [x] Error — JSON.parse fail → silently reset to defaults + console.warn (не показываем ошибку пользователю, это безопасный fallback).
+- [x] Success / Confirmation — клик по чекбоксу мгновенно скрывает/показывает пункт в сайдбаре, изменение видно сразу (= встроенный confirmation).
+- [x] Disabled — Settings toggle помечен `disabled` + tooltip «Settings is always visible».
+- [x] Partial / Stale — N/A.
+- [x] Optimistic / Pending — N/A (всё локально, синхронно).
+
+**Клавиатура**:
+- Заголовки секций — `<button>` с реальным `aria-expanded="true|false"`, `aria-controls="<body-id>"`. Tab по ним работает по умолчанию.
+- Enter/Space — toggle (нативное поведение `<button>`).
+- Чекбоксы в Settings — нативные `<input type="checkbox">`, label кликабелен.
+- Visible focus ring сохраняем — `:focus-visible` не убираем.
+
+**Screen reader**:
+- `aria-expanded` на section header — анонс при раскрытии.
+- `aria-controls` связывает кнопку с телом секции.
+- Каждый чекбокс в Settings имеет `<label>` с человекочитаемым текстом ("All Sessions", "Leaderboard", ...) и hint (например "Hidden — accessible via URL hash").
+
+**Touch targets**: section header ≥ 36px (как `.sidebar-item` сейчас); чекбоксы со своими label обёрнуты в кликабельную область высотой 32px.
+
+**Responsive**: сайдбар уже фиксированной ширины; не трогаем breakpoints.
+
+**Performance budget**: одна-две `localStorage` операции на toggle (<1ms). Перерисовка Settings — небольшая. LCP не затрагивается, потому что код инициализации (applySidebarConfig) выполняется только над уже отрендеренным DOM.
+
+## Стыки (existing files we touch)
+
+1. `src/frontend/index.html` (11–141) — рерайт sidebar.
+2. `src/frontend/app.js` — добавить ~120 строк (config + apply + settings sub-pane).
+3. `src/frontend/styles.css` — добавить ~40 строк CSS.
+4. `test/` — новый файл `test/sidebar-config.test.js` (node:test) для pure-funcs (`loadSidebarConfig`, `applyHiddenToItems`).
+
+## Risks
+
+| Риск | Mitigation |
+|---|---|
+| Пользователь скрыл Settings → не может вернуть видимость | Settings всегда видим, toggle для него `disabled` + объяснение |
+| Невалидный JSON в `localStorage` (ручная правка) | `JSON.parse` в `try/catch` → fallback на дефолты + `localStorage.removeItem` |
+| `applySidebarConfig` запускается до того, как DOM готов | Запускаем из existing `DOMContentLoaded` блока (он уже есть для других init-функций) |
+| Скрытие active view ломает индикацию | Active class остаётся в HTML, но раз пункт `display:none`, юзер просто не видит. Hash-роутер всё ещё переключает контент. Документируем в hint в Sidebar sub-pane. |
+| Конфликт ключа `claude-only` vs install-кнопки Claude | Install items получают префикс `install:claude` (key namespace), нет коллизии |
+| Сломанная вёрстка в light/monokai темах | CSS использует CSS-переменные (`var(--text-muted)` и т.п.), как и существующие sidebar-классы |
+| LocalStorage недоступен (приватный режим) | Try/catch вокруг `getItem`/`setItem`; на ошибке — конфиг живёт только в памяти, не падаем |
+| `data-section` уже используется в репозитории | Проверить grep'ом перед стартом имплементации (отметить в плане) |
+
+## Open questions (для тебя)
+
+1. **Имя "Install agents" как сабсекции** — оставляем как есть, или укоротить до **"Install"**? (короче = чище в раскрытом виде)
+2. **Default-collapsed для Install agents** — да (как написано), или раскрыто по умолчанию? Скрытие по умолчанию — потому что у большинства пользователей агенты уже стоят и эта секция нужна редко.
+3. **Reset to defaults** — кнопка-ссылка в Sidebar sub-pane, или confirm-dialog? Я предлагаю просто кнопку: настройка локальная, дёшево вернуть.
+
+## Acceptance criteria
+
+- [ ] Существующие пункты не пропадают, default state визуально совпадает с текущим (минус группировка).
+- [ ] Заголовки Workspace/Agents/Tools кликабельны, состояние collapsed/expanded переживает reload.
+- [ ] Settings → Sidebar pane перечисляет все item keys с чекбоксами; toggle мгновенно скрывает/показывает в навигации.
+- [ ] Settings toggle сам по себе disabled.
+- [ ] Перезагрузка страницы сохраняет все скрытые пункты.
+- [ ] Reset to defaults — возвращает всё к видимому + все секции expanded (кроме Install agents).
+- [ ] Hash-роутинг (`#leaderboard`) продолжает работать даже если Leaderboard скрыт.
+- [ ] Тесты `test/sidebar-config.test.js` зелёные.

--- a/specs/sidebar-customization.feature
+++ b/specs/sidebar-customization.feature
@@ -1,0 +1,132 @@
+Feature: Sidebar customization
+  As a codbash user
+  I want to group, collapse, and hide sidebar entries
+  So that my left rail matches the tools and views I actually use
+
+  Background:
+    Given the codbash dashboard is open in a browser
+    And the sidebar has three sections: Workspace, Agents, Tools
+    And the Tools section contains a nested "Install agents" sub-section
+    And local storage starts empty unless a scenario sets it otherwise
+
+  # ── 1. Happy path ────────────────────────────────────────────────
+  Scenario: First-time user sees default layout
+    Given local storage has no "codedash-sidebar-config" key
+    When the dashboard finishes loading
+    Then the Workspace, Agents, and Tools section headers are visible
+    And Workspace and Agents and Tools sections are expanded
+    And the "Install agents" sub-section is collapsed by default
+    And every legacy sidebar item from the previous version is reachable
+      (either visible or under an expanded section)
+
+  Scenario: User hides Leaderboard via Settings, change persists across reload
+    Given the user is on the Settings page
+    And the Settings page shows a "Sidebar" sub-pane with a checkbox for every item
+    When the user unchecks the "Leaderboard" checkbox
+    Then the "Leaderboard" item disappears from the Workspace section immediately
+    And local storage "codedash-sidebar-config" stores hidden.leaderboard = true
+    When the user reloads the page
+    Then the "Leaderboard" item is still hidden
+    And the checkbox in Settings → Sidebar is still unchecked
+
+  Scenario: Section collapse state persists
+    Given the Agents section is expanded
+    When the user clicks the "Agents" section header
+    Then the Agents section body collapses (its items are not visible)
+    And the chevron rotates from ▾ to ▸
+    And local storage "codedash-sidebar-config" stores collapsed.agents = true
+    When the user reloads the page
+    Then the Agents section is still collapsed
+
+  Scenario: Reset to defaults clears all customization
+    Given the user has hidden Leaderboard, Starred, and Cloud Sync
+    And the user has collapsed the Tools section
+    When the user clicks "Reset to defaults" in Settings → Sidebar
+    Then all previously hidden items reappear
+    And the Tools section is expanded again
+    And the "Install agents" sub-section returns to its default collapsed state
+    And local storage "codedash-sidebar-config" is cleared
+
+  # ── 2. Empty state ───────────────────────────────────────────────
+  Scenario: User hides every togglable Workspace item
+    Given Settings is always visible regardless of toggles
+    When the user unchecks every checkbox in the Workspace group
+    Then the Workspace section body is visually empty
+    And the Workspace section header remains visible
+    And the Settings, Changelog, Export/Import items remain reachable
+    # the user can recover by checking any box again
+
+  # ── 3. Loading state ─────────────────────────────────────────────
+  Scenario: Sidebar applies config before first paint flicker
+    Given local storage has hidden.starred = true
+    When the dashboard loads
+    Then the Starred item is not visible at any point during initial render
+    # rationale: applySidebarConfig runs synchronously on DOMContentLoaded
+    # so no "starred briefly appears then disappears" flicker
+
+  # ── 4. Error state ───────────────────────────────────────────────
+  Scenario: Corrupted local storage JSON is recovered silently
+    Given local storage "codedash-sidebar-config" is set to "{not valid json"
+    When the dashboard loads
+    Then the sidebar renders with the default layout
+    And no user-facing error message is shown
+    And a console warning is logged
+    And the next save overwrites the corrupted value with valid JSON
+
+  Scenario: Settings toggle cannot be unchecked
+    Given the user opens Settings → Sidebar
+    Then the checkbox for "Settings" is rendered as disabled
+    And hovering it shows the tooltip "Settings is always visible"
+    When the user attempts to click the disabled Settings checkbox
+    Then the checkbox state does not change
+    And local storage is not written
+
+  Scenario: localStorage unavailable (private mode) does not crash
+    Given localStorage.getItem throws a SecurityError
+    When the dashboard loads
+    Then the sidebar renders with the default layout
+    And no exception bubbles up to the global error handler
+    And in-memory config still allows toggling within the session
+      (changes are lost on reload, which is acceptable)
+
+  # ── 5. Keyboard-only navigation ──────────────────────────────────
+  Scenario: User collapses a section using only the keyboard
+    Given keyboard focus is on the "Workspace" section header button
+    Then aria-expanded is "true"
+    When the user presses Space
+    Then the Workspace section collapses
+    And aria-expanded becomes "false"
+    When the user presses Enter
+    Then the Workspace section expands again
+    And aria-expanded returns to "true"
+
+  Scenario: Focus ring is visible on section headers
+    When the user tabs through the sidebar
+    Then each section header receives a visible :focus-visible outline
+    And the outline color comes from the active theme variable, not from a removed default
+
+  # ── 6. Edge data ─────────────────────────────────────────────────
+  Scenario: Future schema version is treated as opaque
+    Given local storage "codedash-sidebar-config" is {"v": 999, "hidden": {}, "collapsed": {}}
+    When the dashboard loads
+    Then the sidebar renders with the default layout
+    # forward-compat: unknown version → don't trust the payload, reset on next save
+
+  Scenario: Unknown item key in stored config is ignored
+    Given local storage stores hidden = {"nonexistent-view": true, "leaderboard": true}
+    When the dashboard loads
+    Then only "Leaderboard" is hidden
+    And the unknown key is preserved in storage (kept on save) so a forward-version key is not destroyed
+    # rationale: a future codbash release may add new keys we don't recognize yet
+
+  Scenario: Active view is hidden but still reachable by hash
+    Given the user navigated to "#leaderboard" and then hid the Leaderboard item
+    When the page reloads at "#leaderboard"
+    Then the Leaderboard view content renders correctly
+    And the (hidden) Leaderboard sidebar item is not visible
+    And Settings → Sidebar shows a hint explaining hash-based access still works
+
+  # N/A categories (intentionally documented):
+  # - Loading async — applySidebarConfig is synchronous, no async fetch involved
+  # - Optimistic UI — no server round-trip
+  # - Touch-only specific — not a touch-targeted feature, but section headers ≥36px

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -2276,6 +2276,255 @@ function saveThemePref(val) {
   setTheme(val);
 }
 
+// ── Sidebar customization ─────────────────────────────────────
+// Persisted via SidebarConfig helpers (sidebar-config.js).
+// Runtime state mirrors localStorage; mutations go through setItemHidden /
+// setSectionCollapsed (immutable) and then a single applySidebarConfig() pass
+// reconciles the DOM. See specs/sidebar-customization.feature.
+
+var _sidebarConfig = null;
+
+function _storage() {
+  try { return window.localStorage; } catch (e) { return null; }
+}
+
+function _initSidebarConfig() {
+  if (_sidebarConfig) return _sidebarConfig;
+  _sidebarConfig = SidebarConfig.loadFromStorage(_storage());
+  return _sidebarConfig;
+}
+
+function applySidebarConfig() {
+  var cfg = _initSidebarConfig();
+
+  // Sections (including nested install-agents): toggle .collapsed + aria-expanded.
+  document.querySelectorAll('.sidebar-group[data-section]').forEach(function(group) {
+    var id = group.getAttribute('data-section');
+    var collapsed = SidebarConfig.isSectionCollapsed(cfg, id);
+    group.classList.toggle('collapsed', collapsed);
+    var header = group.querySelector(':scope > .sidebar-section-header');
+    if (header) header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+  });
+
+  // Items: hide based on data-key (preferred) or data-view (legacy fallback).
+  // Settings is force-visible by isItemHidden.
+  document.querySelectorAll('.sidebar-item').forEach(function(el) {
+    var key = el.getAttribute('data-key') || el.getAttribute('data-view');
+    if (!key) return;
+    el.hidden = SidebarConfig.isItemHidden(cfg, key);
+  });
+
+  _updateSidebarEmptySectionHints();
+}
+
+// When a user hides every togglable item inside a section the body becomes
+// visually empty. Inject a small inline hint so the section doesn't look
+// broken. The hint is removed automatically when any item becomes visible
+// again. Sub-sections (install-agents) get their own hint independently.
+function _updateSidebarEmptySectionHints() {
+  document.querySelectorAll('.sidebar-section-body').forEach(function(body) {
+    var hasVisibleItem = false;
+    var items = body.querySelectorAll(':scope > .sidebar-item, :scope > .sidebar-subgroup .sidebar-item');
+    for (var i = 0; i < items.length; i++) {
+      if (!items[i].hidden) { hasVisibleItem = true; break; }
+    }
+    var existingHint = body.querySelector(':scope > .sidebar-empty-section-hint');
+    if (hasVisibleItem) {
+      if (existingHint) existingHint.parentNode.removeChild(existingHint);
+    } else if (!existingHint) {
+      var hint = document.createElement('div');
+      hint.className = 'sidebar-empty-section-hint';
+      hint.textContent = 'All items hidden — manage in Settings.';
+      body.appendChild(hint);
+    }
+  });
+}
+
+function _onSidebarSectionHeaderClick(event) {
+  var target = event.target.closest('[data-role="section-header"]');
+  if (!target) return;
+  event.stopPropagation();
+  var sectionId = target.getAttribute('data-section-target');
+  if (!sectionId) return;
+  var cfg = _initSidebarConfig();
+  var next = !SidebarConfig.isSectionCollapsed(cfg, sectionId);
+  _sidebarConfig = SidebarConfig.setSectionCollapsed(cfg, sectionId, next);
+  SidebarConfig.saveToStorage(_storage(), _sidebarConfig);
+  applySidebarConfig();
+}
+
+function _bindSidebarHeaders() {
+  document.querySelectorAll('[data-role="section-header"]').forEach(function(btn) {
+    btn.addEventListener('click', _onSidebarSectionHeaderClick);
+  });
+}
+
+// Called from Settings → Sidebar checkboxes.
+function toggleSidebarItem(key, visible) {
+  if (key === SidebarConfig.SETTINGS_KEY) return; // refuse on UI side as well
+  var cfg = _initSidebarConfig();
+  _sidebarConfig = SidebarConfig.setItemHidden(cfg, key, !visible);
+  SidebarConfig.saveToStorage(_storage(), _sidebarConfig);
+  applySidebarConfig();
+}
+
+function resetSidebarConfig() {
+  _sidebarConfig = SidebarConfig.resetConfig();
+  SidebarConfig.clearStorage(_storage());
+  applySidebarConfig();
+  // Re-render Settings so checkboxes reflect the cleared state.
+  var content = document.getElementById('content');
+  if (content && currentView === 'settings') renderSettings(content);
+}
+
+// Labels shown in Settings → Sidebar checklist. The map mirrors the visible
+// text in the sidebar so the user matches what they see. Group label drives
+// the visual section break in the Settings pane.
+var SIDEBAR_ITEM_META = [
+  { group: 'Workspace', items: [
+    ['sessions', 'All Sessions'], ['projects', 'Projects'], ['timeline', 'Timeline'],
+    ['activity', 'Activity'], ['running', 'Running'], ['analytics', 'Analytics'],
+    ['starred', 'Starred'], ['leaderboard', 'Leaderboard'], ['cloud', 'Cloud Sync']
+  ]},
+  { group: 'Agents', items: [
+    ['claude-only', 'Claude Code'], ['codex-only', 'Codex'], ['qwen-only', 'Qwen Code'],
+    ['kiro-only', 'Kiro'], ['cursor-only', 'Cursor'], ['copilot-chat-only', 'Copilot Chat'],
+    ['copilot-only', 'Copilot CLI'], ['opencode-only', 'OpenCode'], ['kilo-only', 'Kilo']
+  ]},
+  { group: 'Tools', items: [
+    ['export-import', 'Export / Import'], ['changelog', 'Changelog'],
+    ['settings', 'Settings']   // rendered as disabled
+  ]},
+  { group: 'Install agents', items: [
+    ['install:claude', 'Claude Code'], ['install:codex', 'Codex CLI'], ['install:qwen', 'Qwen Code'],
+    ['install:kiro', 'Kiro CLI'], ['install:opencode', 'OpenCode'], ['install:kilo', 'Kilo CLI'],
+    ['install:copilot', 'Copilot CLI']
+  ]}
+];
+
+function renderSidebarSettingsGroup() {
+  var cfg = _initSidebarConfig();
+  var html = '<div class="settings-group" id="settingsSidebarGroup">';
+  html += '<label class="settings-label">Sidebar</label>';
+  html += '<p class="settings-sidebar-description">Choose which entries appear in the left rail. Settings is always visible.</p>';
+
+  SIDEBAR_ITEM_META.forEach(function(group) {
+    html += '<div class="settings-sidebar-group-label">' + escHtml(group.group) + '</div>';
+    html += '<div class="settings-sidebar-list">';
+    group.items.forEach(function(pair) {
+      var key = pair[0];
+      var label = pair[1];
+      var isSettings = key === SidebarConfig.SETTINGS_KEY;
+      var visible = !SidebarConfig.isItemHidden(cfg, key);
+      var rowClass = 'settings-sidebar-row' + (isSettings ? ' is-locked' : '');
+      var title = isSettings ? ' title="Settings is always visible"' : '';
+      var lockedLabel = isSettings ? ' aria-disabled="true"' : '';
+      var disabledAttr = isSettings ? ' disabled aria-disabled="true"' : '';
+      var checkedAttr = (visible || isSettings) ? ' checked' : '';
+      // No inline onchange — single delegated listener is wired by
+      // _bindSidebarSettingsDelegate() right after innerHTML is set. This
+      // avoids attribute-context escaping concerns with string keys.
+      var dataAttr = isSettings ? '' : ' data-sidebar-key="' + escHtml(key) + '"';
+      html += '<label class="' + rowClass + '"' + title + lockedLabel + '>';
+      html += '<input type="checkbox"' + disabledAttr + checkedAttr + dataAttr + '>';
+      html += '<span>' + escHtml(label) + '</span>';
+      html += '</label>';
+    });
+    html += '</div>';
+  });
+
+  html += '<div class="settings-sidebar-hint">';
+  html += 'Click a section header in the sidebar to collapse it — the state is saved. ';
+  html += 'Hidden items stay reachable: try <a href="#leaderboard">#leaderboard</a> in the address bar.';
+  html += '</div>';
+
+  html += '<div class="settings-sidebar-reset" id="sidebarResetWrap">';
+  html += '<button type="button" class="settings-sidebar-reset-btn" data-stage="initial" onclick="onResetSidebarClick(event)">Reset to defaults</button>';
+  html += '</div>';
+
+  html += '</div>';
+  return html;
+}
+
+// Two-stage reset: first click arms the button (highlights it red and changes
+// label), second click within ~6s actually resets. Cancel button shown while
+// armed. Prevents accidental wipeout per WCAG/NN/g destructive-action guidance.
+var _resetArmedAt = 0;
+var _resetArmedTimer = null;
+var RESET_ARM_WINDOW_MS = 6000;
+
+function onResetSidebarClick(event) {
+  var btn = event.currentTarget;
+  var now = Date.now();
+  if (btn.getAttribute('data-stage') === 'armed' && (now - _resetArmedAt) < RESET_ARM_WINDOW_MS) {
+    _disarmReset();
+    resetSidebarConfig();
+    _announceSidebar('Sidebar reset to defaults');
+    return;
+  }
+  // Arm
+  _resetArmedAt = now;
+  btn.setAttribute('data-stage', 'armed');
+  btn.classList.add('confirming');
+  btn.textContent = 'Click again to confirm';
+  var wrap = document.getElementById('sidebarResetWrap');
+  if (wrap && !wrap.querySelector('.settings-sidebar-reset-cancel')) {
+    var cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'settings-sidebar-reset-cancel';
+    cancel.textContent = 'Cancel';
+    cancel.onclick = _disarmReset;
+    wrap.appendChild(cancel);
+  }
+  if (_resetArmedTimer) clearTimeout(_resetArmedTimer);
+  _resetArmedTimer = setTimeout(_disarmReset, RESET_ARM_WINDOW_MS);
+}
+
+function _disarmReset() {
+  if (_resetArmedTimer) { clearTimeout(_resetArmedTimer); _resetArmedTimer = null; }
+  _resetArmedAt = 0;
+  var btn = document.querySelector('.settings-sidebar-reset-btn');
+  if (btn) {
+    btn.setAttribute('data-stage', 'initial');
+    btn.classList.remove('confirming');
+    btn.textContent = 'Reset to defaults';
+  }
+  var cancel = document.querySelector('.settings-sidebar-reset-cancel');
+  if (cancel && cancel.parentNode) cancel.parentNode.removeChild(cancel);
+}
+
+function _bindSidebarSettingsDelegate() {
+  var group = document.getElementById('settingsSidebarGroup');
+  if (!group || group._delegateBound) return;
+  group._delegateBound = true;
+  group.addEventListener('change', function (e) {
+    var input = e.target;
+    if (!input || input.tagName !== 'INPUT' || input.type !== 'checkbox') return;
+    var key = input.getAttribute('data-sidebar-key');
+    if (!key) return;
+    toggleSidebarItem(key, input.checked);
+    _announceSidebar((input.checked ? 'Shown: ' : 'Hidden: ') + _labelForKey(key));
+  });
+}
+
+function _labelForKey(key) {
+  for (var i = 0; i < SIDEBAR_ITEM_META.length; i++) {
+    var items = SIDEBAR_ITEM_META[i].items;
+    for (var j = 0; j < items.length; j++) {
+      if (items[j][0] === key) return items[j][1];
+    }
+  }
+  return key;
+}
+
+function _announceSidebar(msg) {
+  var region = document.getElementById('sidebarStatus');
+  if (!region) return;
+  // Forcing a content change inside aria-live="polite" triggers SR announcement.
+  region.textContent = '';
+  region.textContent = msg;
+}
+
 // ── Keyboard navigation ────────────────────────────────────────
 
 function isInput(e) {
@@ -2530,18 +2779,98 @@ function focusSession(sessionId) {
 
 // ── Changelog view ────────────────────────────────────────────
 
+// Sub-tabs grouping for the Settings page. Order matches visual left-to-right.
+// Adding a new setting => decide which tab it belongs to and add it to the right
+// _settingsTab* renderer below.
+var SETTINGS_TABS = [
+  { id: 'appearance',   label: 'Appearance' },
+  { id: 'sidebar',      label: 'Sidebar' },
+  { id: 'sessions',     label: 'Sessions' },
+  { id: 'integrations', label: 'Integrations' }
+];
+
+function _getSettingsTab() {
+  try {
+    var saved = localStorage.getItem('codedash-settings-tab');
+    if (saved && SETTINGS_TABS.some(function(t) { return t.id === saved; })) return saved;
+  } catch (e) { /* private mode */ }
+  return 'appearance';
+}
+
+function setSettingsTab(id) {
+  if (!SETTINGS_TABS.some(function(t) { return t.id === id; })) return;
+  try { localStorage.setItem('codedash-settings-tab', id); } catch (e) { /* private mode */ }
+  var content = document.getElementById('content');
+  if (content) renderSettings(content);
+}
+
 function renderSettings(container) {
-  var savedTheme = localStorage.getItem('codedash-theme') || 'dark';
-  var savedTerminal = localStorage.getItem('codedash-terminal') || '';
-  var aiTitlesOn = localStorage.getItem('codedash-ai-titles') === 'true';
-  var allSessionsListBadgesOn = localStorage.getItem('codedash-all-sessions-list-badges') !== 'false';
-  var savedGroupingMode = normalizeGroupingMode(localStorage.getItem('codedash-grouping-mode'));
+  var activeTab = _getSettingsTab();
+  var panelId = 'settingsPanel-' + activeTab;
 
   var html = '<div class="settings-page">';
-  html += '<h2 style="margin:0 0 24px;font-size:18px;font-weight:600">Settings</h2>';
+  html += '<h2 style="margin:0 0 16px;font-size:18px;font-weight:600">Settings</h2>';
 
-  // Theme
-  html += '<div class="settings-group">';
+  // Tab strip (reuses .ap-tabs visual pattern from the Add Project modal)
+  html += '<div class="ap-tabs settings-tabs" role="tablist" aria-label="Settings categories" onkeydown="onSettingsTabKey(event)">';
+  SETTINGS_TABS.forEach(function(t) {
+    var isActive = t.id === activeTab;
+    var tabId = 'settingsTab-' + t.id;
+    var ariaControls = isActive ? panelId : ('settingsPanel-' + t.id);
+    html += '<button type="button" class="ap-tab' + (isActive ? ' active' : '') + '"' +
+      ' id="' + escHtml(tabId) + '"' +
+      ' role="tab" aria-selected="' + (isActive ? 'true' : 'false') + '"' +
+      ' aria-controls="' + escHtml(ariaControls) + '"' +
+      ' tabindex="' + (isActive ? '0' : '-1') + '"' +
+      ' data-tab-id="' + escHtml(t.id) + '"' +
+      ' onclick="setSettingsTab(\'' + escHtml(t.id) + '\')">' + escHtml(t.label) + '</button>';
+  });
+  html += '</div>';
+
+  html += '<div class="settings-tab-body" role="tabpanel" id="' + escHtml(panelId) + '"' +
+    ' aria-labelledby="' + escHtml('settingsTab-' + activeTab) + '">';
+  if (activeTab === 'appearance')        html += _renderSettingsAppearance();
+  else if (activeTab === 'sidebar')      html += renderSidebarSettingsGroup();
+  else if (activeTab === 'sessions')     html += _renderSettingsSessions();
+  else if (activeTab === 'integrations') html += _renderSettingsIntegrations();
+  html += '</div>';
+
+  html += '</div>';
+  container.innerHTML = html;
+
+  // LLM inputs need post-render hydration when the Integrations tab is open.
+  if (activeTab === 'integrations') loadLLMSettings();
+  // Wire the delegated checkbox listener (avoids inline attribute-context risk).
+  if (activeTab === 'sidebar') _bindSidebarSettingsDelegate();
+}
+
+// Arrow-key navigation across the Settings tablist per WAI-ARIA Authoring
+// Practices. Left/Right cycle; Home/End jump. Activates the focused tab
+// (NN/g "automatic activation" — the panels are cheap to render).
+function onSettingsTabKey(event) {
+  var key = event.key;
+  var navKeys = ['ArrowLeft', 'ArrowRight', 'Home', 'End'];
+  if (navKeys.indexOf(key) === -1) return;
+  event.preventDefault();
+  var current = _getSettingsTab();
+  var idx = SETTINGS_TABS.findIndex(function (t) { return t.id === current; });
+  if (idx < 0) idx = 0;
+  var next = idx;
+  if (key === 'ArrowLeft')  next = (idx - 1 + SETTINGS_TABS.length) % SETTINGS_TABS.length;
+  if (key === 'ArrowRight') next = (idx + 1) % SETTINGS_TABS.length;
+  if (key === 'Home')       next = 0;
+  if (key === 'End')        next = SETTINGS_TABS.length - 1;
+  if (next === idx) return;
+  setSettingsTab(SETTINGS_TABS[next].id);
+  // After re-render, move focus to the now-active tab so keyboard flow stays
+  // inside the strip. setSettingsTab calls renderSettings synchronously.
+  var nextEl = document.getElementById('settingsTab-' + SETTINGS_TABS[next].id);
+  if (nextEl) nextEl.focus();
+}
+
+function _renderSettingsAppearance() {
+  var savedTheme = localStorage.getItem('codedash-theme') || 'dark';
+  var html = '<div class="settings-group">';
   html += '<label class="settings-label">Theme</label>';
   html += '<div class="settings-theme-btns">';
   ['dark', 'light', 'system'].forEach(function(t) {
@@ -2550,21 +2879,16 @@ function renderSettings(container) {
   });
   html += '</div>';
   html += '</div>';
+  return html;
+}
 
-  // Terminal
-  html += '<div class="settings-group">';
-  html += '<label class="settings-label">Terminal</label>';
-  html += '<p style="font-size:12px;color:var(--text-muted);margin:0 0 8px">Binary name or full path (e.g. kitty, /usr/bin/alacritty)</p>';
-  html += '<input type="text" class="settings-select" list="terminal-suggestions" value="' + escHtml(savedTerminal) + '" onchange="saveTerminalPref(this.value)" placeholder="x-terminal-emulator">';
-  html += '<datalist id="terminal-suggestions">';
-  if (Array.isArray(availableTerminals)) {
-    availableTerminals.forEach(function(t) {
-      if (!t.available) return;
-      html += '<option value="' + escHtml(t.id) + '">' + escHtml(t.name) + '</option>';
-    });
-  }
-  html += '</datalist>';
-  html += '</div>';
+function _renderSettingsSessions() {
+  var aiTitlesOn = localStorage.getItem('codedash-ai-titles') === 'true';
+  var allSessionsListBadgesOn = localStorage.getItem('codedash-all-sessions-list-badges') !== 'false';
+  var savedGroupingMode = normalizeGroupingMode(localStorage.getItem('codedash-grouping-mode'));
+  var savedMsgSort = localStorage.getItem('codedash-msg-sort') || 'asc';
+
+  var html = '';
 
   // AI Titles
   html += '<div class="settings-group">';
@@ -2575,7 +2899,7 @@ function renderSettings(container) {
   html += '</div>';
   html += '</div>';
 
-  // All Sessions list badges
+  // Session List Badges
   html += '<div class="settings-group">';
   html += '<label class="settings-label">Session List Badges</label>';
   html += '<div class="settings-checkbox">';
@@ -2598,7 +2922,6 @@ function renderSettings(container) {
   html += '</div>';
 
   // Message Sort Order
-  var savedMsgSort = localStorage.getItem('codedash-msg-sort') || 'asc';
   html += '<div class="settings-group">';
   html += '<label class="settings-label">Message Sort Order</label>';
   html += '<p style="font-size:12px;color:var(--text-muted);margin:0 0 8px">Default order for messages in session drawer</p>';
@@ -2608,6 +2931,29 @@ function renderSettings(container) {
     html += '<button class="theme-btn' + active + '" onclick="localStorage.setItem(\'codedash-msg-sort\',\'' + pair[0] + '\');renderSettings(document.getElementById(\'content\'))">' + pair[1] + '</button>';
   });
   html += '</div>';
+  html += '</div>';
+
+  return html;
+}
+
+function _renderSettingsIntegrations() {
+  var savedTerminal = localStorage.getItem('codedash-terminal') || '';
+
+  var html = '';
+
+  // Terminal
+  html += '<div class="settings-group">';
+  html += '<label class="settings-label">Terminal</label>';
+  html += '<p style="font-size:12px;color:var(--text-muted);margin:0 0 8px">Binary name or full path (e.g. kitty, /usr/bin/alacritty)</p>';
+  html += '<input type="text" class="settings-select" list="terminal-suggestions" value="' + escHtml(savedTerminal) + '" onchange="saveTerminalPref(this.value)" placeholder="x-terminal-emulator">';
+  html += '<datalist id="terminal-suggestions">';
+  if (Array.isArray(availableTerminals)) {
+    availableTerminals.forEach(function(t) {
+      if (!t.available) return;
+      html += '<option value="' + escHtml(t.id) + '">' + escHtml(t.name) + '</option>';
+    });
+  }
+  html += '</datalist>';
   html += '</div>';
 
   // LLM Configuration
@@ -2625,11 +2971,7 @@ function renderSettings(container) {
   html += '</div>';
   html += '</div>';
 
-  html += '</div>';
-  container.innerHTML = html;
-
-  // Load LLM config into the inputs
-  loadLLMSettings();
+  return html;
 }
 
 // → moved to leaderboard.js
@@ -3696,6 +4038,11 @@ function _onProjectsHashChange() {
 }
 
 (function init() {
+  // Sidebar customization — apply persisted config before any other init so the
+  // user never sees a flash of hidden items.
+  applySidebarConfig();
+  _bindSidebarHeaders();
+
   // Load data
   loadSessions();
   loadTerminals();

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -8,135 +8,205 @@
 </head>
 <body>
 
+<script>
+// Pre-paint sidebar state restore: applies collapsed sections from
+// localStorage before the sidebar markup paints, so a user who collapsed
+// "Agents" doesn't see it flash open on reload. The full applySidebarConfig()
+// runs later from init() and reconciles everything (including hidden items
+// and the chevron rotation), but the .collapsed class needs to land before
+// first paint to prevent the flash. This script runs synchronously before
+// the <div class="sidebar"> below.
+(function () {
+  try {
+    var raw = window.localStorage && window.localStorage.getItem('codedash-sidebar-config');
+    if (!raw || typeof raw !== 'string' || raw.length > 65536) return;
+    var cfg = JSON.parse(raw);
+    if (!cfg || typeof cfg !== 'object' || cfg.v !== 1 || !cfg.collapsed) return;
+    var collapsed = cfg.collapsed;
+    // Defer to DOM-ready so .sidebar-group nodes exist. Script is placed
+    // before <div class="sidebar">, so we use a microtask via setTimeout(0).
+    document.addEventListener('DOMContentLoaded', function () {
+      Object.keys(collapsed).forEach(function (id) {
+        if (collapsed[id] !== true) return;
+        var group = document.querySelector('.sidebar-group[data-section="' + id.replace(/"/g, '') + '"]');
+        if (group) {
+          group.classList.add('collapsed');
+          var hdr = group.querySelector(':scope > .sidebar-section-header');
+          if (hdr) hdr.setAttribute('aria-expanded', 'false');
+        }
+      });
+    });
+  } catch (_e) { /* private mode or malformed — applySidebarConfig will recover */ }
+})();
+</script>
+
 <div class="sidebar">
     <div class="sidebar-brand">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
         codbash
         <span class="version-badge" id="versionBadge"></span>
     </div>
-    <div class="sidebar-item active" data-view="sessions">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-        All Sessions
+
+    <!-- Workspace section -->
+    <div class="sidebar-group" data-section="workspace">
+        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="workspace" aria-expanded="true" aria-controls="sidebarSectionWorkspace">
+            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+            <span>Workspace</span>
+        </button>
+        <div class="sidebar-section-body" id="sidebarSectionWorkspace">
+            <div class="sidebar-item active" data-view="sessions">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                All Sessions
+            </div>
+            <div class="sidebar-item" data-view="projects">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
+                Projects
+            </div>
+            <div class="sidebar-item" data-view="timeline">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                Timeline
+            </div>
+            <div class="sidebar-item" data-view="activity">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><rect x="7" y="7" width="3" height="3"/><rect x="14" y="7" width="3" height="3"/><rect x="7" y="14" width="3" height="3"/><rect x="14" y="14" width="3" height="3"/></svg>
+                Activity
+            </div>
+            <div class="sidebar-item" data-view="running">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+                Running
+            </div>
+            <div class="sidebar-item" data-view="analytics">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                Analytics
+            </div>
+            <div class="sidebar-item" data-view="starred">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                Starred
+            </div>
+            <div class="sidebar-item" data-view="leaderboard">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9H4.5a2.5 2.5 0 010-5C7 4 7 7 7 7"/><path d="M18 9h1.5a2.5 2.5 0 000-5C17 4 17 7 17 7"/><rect x="5" y="9" width="14" height="11" rx="2"/><path d="M12 4v5"/><path d="M8 16h8"/></svg>
+                Leaderboard
+            </div>
+            <div class="sidebar-item" data-view="cloud">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 10h-1.26A8 8 0 109 20h9a5 5 0 000-10z"/></svg>
+                Cloud Sync
+            </div>
+        </div>
     </div>
-    <div class="sidebar-item" data-view="projects">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
-        Projects
+
+    <!-- Agents section -->
+    <div class="sidebar-group" data-section="agents">
+        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="agents" aria-expanded="true" aria-controls="sidebarSectionAgents">
+            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+            <span>Agents</span>
+        </button>
+        <div class="sidebar-section-body" id="sidebarSectionAgents">
+            <div class="sidebar-item" data-view="claude-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+                Claude Code
+            </div>
+            <div class="sidebar-item" data-view="codex-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+                Codex
+            </div>
+            <div class="sidebar-item" data-view="qwen-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2l7 4v8l-7 8-7-8V6l7-4z"/><path d="M9 10h6"/><path d="M9 14h6"/></svg>
+                Qwen Code
+            </div>
+            <div class="sidebar-item" data-view="kiro-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+                Kiro
+            </div>
+            <div class="sidebar-item" data-view="cursor-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 14a1 1 0 01-.78-1.63l9.9-10.2a.5.5 0 01.86.46l-1.92 6.02A1 1 0 0013 10h7a1 1 0 01.78 1.63l-9.9 10.2a.5.5 0 01-.86-.46l1.92-6.02A1 1 0 0011 14H4z"/></svg>
+                Cursor
+            </div>
+            <div class="sidebar-item" data-view="copilot-chat-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12c0 2.04.61 3.93 1.66 5.51L2 22l4.49-1.66A9.96 9.96 0 0012 22c5.52 0 10-4.48 10-10S17.52 2 12 2z"/><circle cx="8.5" cy="12" r="1.5"/><circle cx="15.5" cy="12" r="1.5"/></svg>
+                Copilot Chat
+            </div>
+            <div class="sidebar-item" data-view="copilot-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12c0 2.04.61 3.93 1.66 5.51L2 22l4.49-1.66A9.96 9.96 0 0012 22c5.52 0 10-4.48 10-10S17.52 2 12 2z"/></svg>
+                Copilot CLI
+            </div>
+            <div class="sidebar-item" data-view="opencode-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                OpenCode
+            </div>
+            <div class="sidebar-item" data-view="kilo-only">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+                  <path d="M2 17l10 5 10-5"/>
+                  <path d="M2 12l10 5 10-5"/>
+                </svg>
+                Kilo
+            </div>
+        </div>
     </div>
-    <div class="sidebar-item" data-view="timeline">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-        Timeline
+
+    <!-- Tools section -->
+    <div class="sidebar-group" data-section="tools">
+        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="tools" aria-expanded="true" aria-controls="sidebarSectionTools">
+            <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+            <span>Tools</span>
+        </button>
+        <div class="sidebar-section-body" id="sidebarSectionTools">
+
+            <!-- Install agents sub-section (default collapsed) -->
+            <div class="sidebar-group sidebar-subgroup" data-section="install-agents">
+                <button type="button" class="sidebar-section-header sidebar-subsection-header" data-role="section-header" data-section-target="install-agents" aria-expanded="false" aria-controls="sidebarSectionInstallAgents">
+                    <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+                    <span>Install agents</span>
+                </button>
+                <div class="sidebar-section-body" id="sidebarSectionInstallAgents">
+                    <div class="sidebar-item" data-key="install:claude" onclick="installAgent('claude')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+                        Claude Code
+                    </div>
+                    <div class="sidebar-item" data-key="install:codex" onclick="installAgent('codex')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+                        Codex CLI
+                    </div>
+                    <div class="sidebar-item" data-key="install:qwen" onclick="installAgent('qwen')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+                        Qwen Code
+                    </div>
+                    <div class="sidebar-item" data-key="install:kiro" onclick="installAgent('kiro')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+                        Kiro CLI
+                    </div>
+                    <div class="sidebar-item" data-key="install:opencode" onclick="installAgent('opencode')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
+                        OpenCode
+                    </div>
+                    <div class="sidebar-item" data-key="install:kilo" onclick="installAgent('kilo')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+                        Kilo CLI
+                    </div>
+                    <div class="sidebar-item" data-key="install:copilot" onclick="installAgent('copilot')">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12c0 2.04.61 3.93 1.66 5.51L2 22l4.49-1.66A9.96 9.96 0 0012 22c5.52 0 10-4.48 10-10S17.52 2 12 2z"/></svg>
+                        Copilot CLI
+                    </div>
+                </div>
+            </div>
+
+            <div class="sidebar-item" data-key="export-import" onclick="showExportDialog()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                Export / Import
+            </div>
+            <div class="sidebar-item" data-view="changelog" data-key="changelog">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                Changelog
+            </div>
+            <div class="sidebar-item" data-view="settings">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                Settings
+            </div>
+        </div>
     </div>
-    <div class="sidebar-item" data-view="activity">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><rect x="7" y="7" width="3" height="3"/><rect x="14" y="7" width="3" height="3"/><rect x="7" y="14" width="3" height="3"/><rect x="14" y="14" width="3" height="3"/></svg>
-        Activity
-    </div>
-    <div class="sidebar-item" data-view="running">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
-        Running
-    </div>
-    <div class="sidebar-item" data-view="analytics">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
-        Analytics
-    </div>
-    <div class="sidebar-item" data-view="starred">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-        Starred
-    </div>
-    <div class="sidebar-item" data-view="leaderboard">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9H4.5a2.5 2.5 0 010-5C7 4 7 7 7 7"/><path d="M18 9h1.5a2.5 2.5 0 000-5C17 4 17 7 17 7"/><rect x="5" y="9" width="14" height="11" rx="2"/><path d="M12 4v5"/><path d="M8 16h8"/></svg>
-        Leaderboard
-    </div>
-    <div class="sidebar-item" data-view="cloud">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 10h-1.26A8 8 0 109 20h9a5 5 0 000-10z"/></svg>
-        Cloud Sync
-    </div>
-    <div class="sidebar-divider"></div>
-    <div class="sidebar-section">Agents</div>
-    <div class="sidebar-item" data-view="claude-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
-        Claude Code
-    </div>
-    <div class="sidebar-item" data-view="codex-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-        Codex
-    </div>
-    <div class="sidebar-item" data-view="qwen-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2l7 4v8l-7 8-7-8V6l7-4z"/><path d="M9 10h6"/><path d="M9 14h6"/></svg>
-        Qwen Code
-    </div>
-    <div class="sidebar-item" data-view="kiro-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
-        Kiro
-    </div>
-    <div class="sidebar-item" data-view="cursor-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 14a1 1 0 01-.78-1.63l9.9-10.2a.5.5 0 01.86.46l-1.92 6.02A1 1 0 0013 10h7a1 1 0 01.78 1.63l-9.9 10.2a.5.5 0 01-.86-.46l1.92-6.02A1 1 0 0011 14H4z"/></svg>
-        Cursor
-    </div>
-    <div class="sidebar-item" data-view="copilot-chat-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12c0 2.04.61 3.93 1.66 5.51L2 22l4.49-1.66A9.96 9.96 0 0012 22c5.52 0 10-4.48 10-10S17.52 2 12 2z"/><circle cx="8.5" cy="12" r="1.5"/><circle cx="15.5" cy="12" r="1.5"/></svg>
-        Copilot Chat
-    </div>
-    <div class="sidebar-item" data-view="copilot-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12c0 2.04.61 3.93 1.66 5.51L2 22l4.49-1.66A9.96 9.96 0 0012 22c5.52 0 10-4.48 10-10S17.52 2 12 2z"/></svg>
-        Copilot CLI
-    </div>
-    <div class="sidebar-item" data-view="opencode-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
-        OpenCode
-    </div>
-    <div class="sidebar-item" data-view="kilo-only">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M12 2L2 7l10 5 10-5-10-5z"/>
-          <path d="M2 17l10 5 10-5"/>
-          <path d="M2 12l10 5 10-5"/>
-        </svg>
-        Kilo
-    </div>
-    <div class="sidebar-divider"></div>
-    <div class="sidebar-section">Install Agents</div>
-    <div class="sidebar-item" onclick="installAgent('claude')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
-        Claude Code
-    </div>
-    <div class="sidebar-item" onclick="installAgent('codex')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
-        Codex CLI
-    </div>
-    <div class="sidebar-item" onclick="installAgent('qwen')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
-        Qwen Code
-    </div>
-    <div class="sidebar-item" onclick="installAgent('kiro')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
-        Kiro CLI
-    </div>
-    <div class="sidebar-item" onclick="installAgent('opencode')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 17l6-6-6-6"/><path d="M12 19h8"/></svg>
-        OpenCode
-    </div>
-<div class="sidebar-item" onclick="installAgent('kilo')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-        Kilo CLI
-    </div>
-    <div class="sidebar-item" onclick="installAgent('copilot')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12c0 2.04.61 3.93 1.66 5.51L2 22l4.49-1.66A9.96 9.96 0 0012 22c5.52 0 10-4.48 10-10S17.52 2 12 2z"/></svg>
-        Copilot CLI
-    </div>
-    <div class="sidebar-divider"></div>
-    <div class="sidebar-item" onclick="showExportDialog()">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-        Export / Import
-    </div>
-    <div class="sidebar-item" data-view="changelog">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-        Changelog
-    </div>
-    <div class="sidebar-item" data-view="settings">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
-        Settings
-    </div>
+
+    <span id="sidebarStatus" role="status" aria-live="polite" class="sr-only"></span>
     <div class="sidebar-author">
-        Made by <a href="https://t.me/neuraldeep" target="_blank">Valerii Kovalskii</a>
+        Made by <a href="https://t.me/neuraldeep" target="_blank" rel="noopener noreferrer" aria-label="Valerii Kovalskii on Telegram (opens in new tab)">Valerii Kovalskii</a>
     </div>
 </div>
 

--- a/src/frontend/sidebar-config.js
+++ b/src/frontend/sidebar-config.js
@@ -1,0 +1,183 @@
+// Sidebar customization config — pure helpers.
+// Works in the browser (attached to window via the inline <script> below)
+// and in Node (required by test/sidebar-config.test.js).
+//
+// Schema (localStorage key "codedash-sidebar-config"):
+//   { v: 1, hidden: { [itemKey]: true }, collapsed: { [sectionId]: boolean } }
+// Absence of a hidden key === visible. Absence of a collapsed key === default
+// (expanded for top sections, collapsed for install-agents sub-section).
+
+(function (root, factory) {
+  var api = factory();
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  } else {
+    root.SidebarConfig = api;
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+
+  var STORAGE_KEY = 'codedash-sidebar-config';
+  var CURRENT_VERSION = 1;
+  var SETTINGS_KEY = 'settings';
+  // Safety net against self-DoS via DevTools-injected megabyte payloads. JSON
+  // for a normal config is < 1 KB; even with every key set the payload is
+  // ~1.5 KB. 64 KB leaves plenty of room for forward-compat unknown keys.
+  var MAX_RAW_BYTES = 65536;
+  // Block keys that would land on Object.prototype semantics — harmless today
+  // (consumers iterate config maps, not __proto__), but explicit is safer than
+  // relying on Object.keys + assignment-via-setter behavior.
+  var BLOCKED_KEYS = { '__proto__': true, 'constructor': true, 'prototype': true };
+
+  var KNOWN_ITEM_KEYS = [
+    // Workspace
+    'sessions', 'projects', 'timeline', 'activity', 'running',
+    'analytics', 'starred', 'leaderboard', 'cloud',
+    // Agents
+    'claude-only', 'codex-only', 'qwen-only', 'kiro-only', 'cursor-only',
+    'copilot-chat-only', 'copilot-only', 'opencode-only', 'kilo-only',
+    // Tools (Settings is intentionally absent — always visible)
+    'export-import', 'changelog',
+    // Install agents
+    'install:claude', 'install:codex', 'install:qwen', 'install:kiro',
+    'install:opencode', 'install:kilo', 'install:copilot'
+  ];
+
+  var DEFAULT_COLLAPSED = {
+    'install-agents': true
+  };
+
+  function defaults() {
+    return { v: CURRENT_VERSION, hidden: {}, collapsed: {} };
+  }
+
+  function isPlainObject(x) {
+    return x !== null && typeof x === 'object' && !Array.isArray(x);
+  }
+
+  // omitFalsy: when true, falsy values are dropped (used for `hidden` where
+  // absence === visible — keeps the payload compact and the convention clean).
+  // When false, falsy values are stored as `false` (used for `collapsed` where
+  // we must distinguish "user explicitly expanded" from "use the default").
+  function sanitizeMap(input, omitFalsy) {
+    var out = {};
+    if (!isPlainObject(input)) return out;
+    Object.keys(input).forEach(function (key) {
+      if (typeof key !== 'string' || key === '') return;
+      if (BLOCKED_KEYS[key]) return;
+      var raw = input[key];
+      if (omitFalsy) {
+        if (raw) out[key] = true;
+      } else {
+        out[key] = !!raw;
+      }
+    });
+    return out;
+  }
+
+  function parseSidebarConfig(raw) {
+    if (raw === null || raw === undefined || raw === '') return defaults();
+    if (typeof raw !== 'string' || raw.length > MAX_RAW_BYTES) return defaults();
+    var data;
+    try {
+      data = JSON.parse(raw);
+    } catch (_e) {
+      return defaults();
+    }
+    if (!isPlainObject(data)) return defaults();
+    if (data.v !== CURRENT_VERSION) return defaults();
+    return {
+      v: CURRENT_VERSION,
+      hidden: sanitizeMap(data.hidden, true),
+      collapsed: sanitizeMap(data.collapsed, false)
+    };
+  }
+
+  function isItemHidden(cfg, key) {
+    if (key === SETTINGS_KEY) return false;
+    if (!cfg || !cfg.hidden) return false;
+    return cfg.hidden[key] === true;
+  }
+
+  function isSectionCollapsed(cfg, sectionId) {
+    if (cfg && cfg.collapsed && Object.prototype.hasOwnProperty.call(cfg.collapsed, sectionId)) {
+      return cfg.collapsed[sectionId] === true;
+    }
+    return DEFAULT_COLLAPSED[sectionId] === true;
+  }
+
+  function setItemHidden(cfg, key, hidden) {
+    if (key === SETTINGS_KEY) return cfg;
+    var nextHidden = {};
+    Object.keys(cfg.hidden || {}).forEach(function (k) {
+      if (k !== key) nextHidden[k] = cfg.hidden[k];
+    });
+    if (hidden) nextHidden[key] = true;
+    return { v: CURRENT_VERSION, hidden: nextHidden, collapsed: cfg.collapsed };
+  }
+
+  function setSectionCollapsed(cfg, sectionId, collapsed) {
+    var nextCollapsed = {};
+    Object.keys(cfg.collapsed || {}).forEach(function (k) {
+      if (k !== sectionId) nextCollapsed[k] = cfg.collapsed[k];
+    });
+    nextCollapsed[sectionId] = !!collapsed;
+    return { v: CURRENT_VERSION, hidden: cfg.hidden, collapsed: nextCollapsed };
+  }
+
+  function serializeSidebarConfig(cfg) {
+    return JSON.stringify({
+      v: CURRENT_VERSION,
+      hidden: cfg && cfg.hidden ? cfg.hidden : {},
+      collapsed: cfg && cfg.collapsed ? cfg.collapsed : {}
+    });
+  }
+
+  function loadFromStorage(storage) {
+    if (!storage) return defaults();
+    var raw;
+    try {
+      raw = storage.getItem(STORAGE_KEY);
+    } catch (_e) {
+      return defaults();
+    }
+    return parseSidebarConfig(raw);
+  }
+
+  function saveToStorage(storage, cfg) {
+    if (!storage) return;
+    try {
+      storage.setItem(STORAGE_KEY, serializeSidebarConfig(cfg));
+    } catch (_e) {
+      // private mode / quota / SecurityError — best-effort persistence.
+    }
+  }
+
+  function clearStorage(storage) {
+    if (!storage) return;
+    try {
+      storage.removeItem(STORAGE_KEY);
+    } catch (_e) {
+      // ignored on purpose
+    }
+  }
+
+  function resetConfig() {
+    return defaults();
+  }
+
+  return {
+    STORAGE_KEY: STORAGE_KEY,
+    KNOWN_ITEM_KEYS: KNOWN_ITEM_KEYS,
+    SETTINGS_KEY: SETTINGS_KEY,
+    parseSidebarConfig: parseSidebarConfig,
+    serializeSidebarConfig: serializeSidebarConfig,
+    isItemHidden: isItemHidden,
+    isSectionCollapsed: isSectionCollapsed,
+    setItemHidden: setItemHidden,
+    setSectionCollapsed: setSectionCollapsed,
+    loadFromStorage: loadFromStorage,
+    saveToStorage: saveToStorage,
+    clearStorage: clearStorage,
+    resetConfig: resetConfig
+  };
+});

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -150,6 +150,195 @@ body {
     color: var(--text-muted);
 }
 
+/* ── Customizable sidebar sections ─────────────────────────── */
+
+.sidebar-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-group + .sidebar-group {
+    margin-top: 6px;
+}
+
+.sidebar-section-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 32px;
+    padding: 10px 20px 8px;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    text-align: left;
+    user-select: none;
+}
+.sidebar-section-header:hover { color: var(--text-primary); }
+.sidebar-section-header:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: -2px;
+    color: var(--text-primary);
+}
+.sidebar-section-header .chevron {
+    width: 12px;
+    height: 12px;
+    opacity: 0.85;
+    transition: transform 0.15s;
+}
+.sidebar-group.collapsed > .sidebar-section-header .chevron {
+    transform: rotate(-90deg);
+}
+.sidebar-group.collapsed > .sidebar-section-body {
+    display: none;
+}
+@media (prefers-reduced-motion: reduce) {
+    .sidebar-section-header .chevron { transition: none; }
+}
+
+.sidebar-subgroup {
+    margin: 2px 0 4px;
+}
+.sidebar-subsection-header {
+    min-height: 28px;
+    padding: 6px 20px 6px 28px;
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0.3px;
+    color: var(--text-muted);
+}
+.sidebar-subgroup > .sidebar-section-body .sidebar-item {
+    padding-left: 32px;
+}
+
+.sidebar-empty-section-hint {
+    padding: 8px 20px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+/* Visually-hidden but available to screen readers. Used for aria-live announcements. */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.sidebar-item[hidden] { display: none !important; }
+
+/* ── Settings → Sidebar sub-pane ───────────────────────────── */
+
+.settings-sidebar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 8px 0 0;
+}
+.settings-sidebar-description {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+.settings-sidebar-group-label {
+    margin: 14px 0 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-secondary);
+}
+.settings-sidebar-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    min-height: 32px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+.settings-sidebar-row:hover { background: rgba(255,255,255,0.04); }
+.settings-sidebar-row input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+}
+.settings-sidebar-row.is-locked {
+    color: var(--text-muted);
+    cursor: not-allowed;
+}
+.settings-sidebar-row.is-locked input[type="checkbox"] {
+    cursor: not-allowed;
+}
+.settings-sidebar-hint {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    background: rgba(255,255,255,0.04);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+}
+.settings-sidebar-hint a { color: var(--accent-blue); text-decoration: none; }
+.settings-sidebar-hint a:hover { text-decoration: underline; }
+.settings-sidebar-reset {
+    margin-top: 12px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+.settings-sidebar-reset-btn {
+    padding: 6px 14px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    cursor: pointer;
+}
+.settings-sidebar-reset-btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.settings-sidebar-reset-btn.confirming {
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.5);
+    color: #ef4444;
+}
+.settings-sidebar-reset-cancel {
+    padding: 6px 10px;
+    background: transparent;
+    border: 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+    cursor: pointer;
+}
+.settings-sidebar-reset-cancel:hover { color: var(--text-primary); }
+
+.settings-tabs {
+    margin-bottom: 18px;
+}
+.settings-tabs .ap-tab:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: -2px;
+}
+.settings-tab-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
 .sidebar-author {
     margin-top: auto;
     padding: 8px 20px 0;

--- a/src/html.js
+++ b/src/html.js
@@ -6,6 +6,7 @@ const FRONTEND_DIR = path.join(__dirname, 'frontend');
 
 // JS files inlined in order (later files can use globals from earlier ones)
 const JS_FILES = [
+  'sidebar-config.js',
   'app.js',
   'calendar.js',
   'detail.js',

--- a/tasks/2026-05-15-sidebar-customization/plan.md
+++ b/tasks/2026-05-15-sidebar-customization/plan.md
@@ -1,0 +1,111 @@
+# Plan — Sidebar customization
+
+**Task ID**: 2026-05-15-sidebar-customization
+**Branch**: `feat/sidebar-customization`
+**Type**: feat / ui
+**Complexity**: M (3 files touched, no API changes, isolated to frontend + 1 test file)
+**Risk**: low–medium (no data loss possible; worst case = visual regression in sidebar layout)
+
+## Inputs
+
+- `docs/design/sidebar-customization.md` — SDD (G2 ✅)
+- `specs/sidebar-customization.feature` — 13 BDD scenarios (G3 ✅)
+
+## Approach (high level)
+
+Pure frontend change. New `localStorage` key `codedash-sidebar-config` (JSON). Three new helpers in `app.js`: `loadSidebarConfig() / saveSidebarConfig() / applySidebarConfig()`. HTML restructured into 3 `<section>` blocks with `<button>` headers. Settings page gets a new "Sidebar" sub-pane. CSS adds collapsing behavior + nested sub-section indent.
+
+Implementation order (each commit independently functional):
+
+| # | Step | Files | Outcome |
+|---|---|---|---|
+| 1 | Extract pure config helpers + write unit tests first (TDD) | `src/frontend/sidebar-config.js` (new), `test/sidebar-config.test.js` (new) | Helpers covered: parse, defaults, validation, future-version fallback, unknown-key preservation |
+| 2 | Restructure sidebar HTML into 3 sections + nested Install agents | `src/frontend/index.html` | Visual default state unchanged; new `data-section`, `data-key` attrs in place |
+| 3 | Inline `sidebar-config.js` into `app.js` (project has no module bundler — plain script tags) OR include it via `<script>` after `app.js` | `src/frontend/app.js`, `src/frontend/index.html`, `src/html.js` (template inliner) | Helpers available at runtime |
+| 4 | Add `applySidebarConfig()` + section-header click handler + run on DOMContentLoaded | `src/frontend/app.js` | Sections collapse/expand and persist; hidden items disappear |
+| 5 | Extend `renderSettings()` with "Sidebar" sub-pane | `src/frontend/app.js` | Checklist UI + Reset to defaults works |
+| 6 | CSS: section headers, chevron, nested indent, focus-visible | `src/frontend/styles.css` | Visual polish + a11y |
+| 7 | Manual smoke (skill `feature-smoke` — frontend variant) + node:test run | — | Green tests + clean smoke report |
+
+Step 1 is mandatory **before** step 2 (TDD). Steps 2–6 can be a single commit if they're tightly coupled, or split by step for clarity — I'll decide after step 1.
+
+## Files touched
+
+| File | Change | Approx LOC |
+|---|---|---|
+| `src/frontend/sidebar-config.js` | NEW — pure functions | ~80 |
+| `src/frontend/index.html` | Replace lines 11–141 with sectioned structure | ~140 (mostly rearranged) |
+| `src/frontend/app.js` | Add `applySidebarConfig`, section header handler, Settings sub-pane | ~120 added |
+| `src/frontend/styles.css` | Section header / chevron / nested indent / focus styles | ~40 added |
+| `src/html.js` | Inline new JS file into template (if needed — depends on step 3 decision) | ~5 |
+| `test/sidebar-config.test.js` | NEW — node:test unit tests | ~120 |
+
+Total approx: +500 LOC across 6 files. Net of HTML rearrangement (mostly same content), real new logic ~350 LOC.
+
+## Risks specific to implementation
+
+| # | Risk | Likelihood | Severity | Mitigation |
+|---|---|---|---|---|
+| R1 | Inlining strategy in `src/html.js` breaks if file contains `$` chars (existing bug-prone area per CLAUDE.md note) | Medium | Medium | `addressed_in: src/html.js — use existing split/join inliner pattern, not String.replace. test_name: render-html-no-dollar-mangling check (manual smoke step verifies)` |
+| R2 | Click handler on section header triggers item click (event bubbling) | Medium | Low | `addressed_in: app.js — stopPropagation in section-header handler. test_name: keyboard scenario covers Enter/Space behavior` |
+| R3 | Hash routing still mounts the view, but no sidebar item to highlight | Low | Low | `accepted_because: documented in SDD as feature; hint added to Settings sub-pane` |
+| R4 | Theme variables `--text-muted` etc. may not cover chevron color in all 3 themes (dark/light/monokai) | Medium | Low | `addressed_in: styles.css — reuse existing .sidebar-item color cascade for chevron; visual smoke in all 3 themes is part of step 7` |
+| R5 | `localStorage` throws in private mode → init crash | Low | High (crash kills whole app.js init) | `addressed_in: sidebar-config.js — try/catch around get/set, fall back to in-memory object. test_name: parse-and-save-with-throwing-storage` |
+| R6 | Active view hidden + no other way to find it | Low | Medium | `addressed_in: Settings → Sidebar pane hint text; Reset to defaults visible as escape hatch. test_name: BDD scenario "Active view is hidden but still reachable by hash"` |
+| R7 | XSS via stored config (user/extension manipulates localStorage to inject HTML when rendering Settings) | Low | High | `addressed_in: renderSettings uses escHtml for any user-derived content; item keys themselves come from a hardcoded allow-list in sidebar-config.js, not from storage. test_name: parse-rejects-non-string-keys + manual review` |
+| R8 | `data-section` attribute collides with existing markup | None | — | `addressed_in: verified via grep — no existing usage. Decision: safe.` |
+| R9 | install-agents inner items are detected as section-header click targets | Low | Low | `addressed_in: app.js — click handler matches only [data-role="section-header"], not any descendant. test_name: keyboard scenario` |
+| R10 | Existing global click delegate for `.sidebar-item` fires when clicking inside section header | Low | Medium | `addressed_in: section header is a <button>, not .sidebar-item — different selector, no overlap. Verify in step 4.` |
+
+All R-items have `addressed_in` or `accepted_because`. None deferred. → **G7 pre-check #2 passes when implementation lands.**
+
+## Threat model (R5, R7 — security-relevant)
+
+- **Input boundary**: `localStorage` is browser-controlled but assumed adversarial (user can edit DevTools → Application).
+- **Trust**: never `eval` config; only `JSON.parse` with try/catch.
+- **Output boundary**: any string from config that ends up in DOM goes through `escHtml`. But the simpler defense: config only stores **boolean values**; keys come from a hardcoded allow-list. So even adversarial config can't inject HTML — at worst it hides extra items or stores junk we ignore.
+- **No secrets** involved; nothing PII; nothing transmitted off-machine. Surface area is small.
+
+## Pre-G7 smoke plan
+
+Frontend-only feature, no new endpoints. Smoke per `feature-smoke` skill (UI variant):
+1. `npm start` → `http://localhost:3847`
+2. Verify default layout matches current visual baseline (3 sections, Install agents collapsed).
+3. Toggle Leaderboard off → check it disappears → reload → still hidden.
+4. Collapse Tools → reload → still collapsed.
+5. Reset → all default.
+6. Hand off to `e2e-runner` for Vercel Agent Browser run of the BDD scenarios that are testable end-to-end (happy paths + keyboard).
+7. Manually test in all 3 themes (dark / light / monokai).
+8. DevTools: corrupt `codedash-sidebar-config` value → reload → default layout, no error toast, console warning present.
+9. Artifact: `tasks/2026-05-15-sidebar-customization/smoke-report.md` with verdict `green`.
+
+`no-smoke` skip: not applicable (this is a UI feature).
+
+## Estimate
+
+- Step 1 (TDD helpers): 30 min
+- Step 2 (HTML restructure): 30 min
+- Step 3 (inline strategy): 15 min
+- Step 4 (apply + handlers): 45 min
+- Step 5 (Settings sub-pane): 45 min
+- Step 6 (CSS polish): 30 min
+- Step 7 (smoke + fixes): 30 min
+- Three-agent review + fixes: 60 min
+
+Total: ~5 hours, single sitting feasible.
+
+## Verification gate before commit
+
+- [ ] All tests in `test/sidebar-config.test.js` pass (`node --test`).
+- [ ] `npm test` — full suite passes (no regression in `agents-detect`, `settings`, etc.).
+- [ ] Manual smoke green in dark/light/monokai.
+- [ ] All severities from three-agent review addressed or `deferred_to:` documented.
+- [ ] Commit message follows conventional format: `feat(sidebar): group + customize sidebar items`.
+
+## Out of scope (explicit non-goals — for future PRs)
+
+- Activity heatmap counts cursor heavily (separate PR — user request).
+- Drag-and-drop reordering of items within a section.
+- Per-section "hide all in this section" shortcut.
+- Sync sidebar config between devices.
+- Right-click context menu on sidebar items (hide from there).

--- a/tasks/2026-05-15-sidebar-customization/smoke-report.md
+++ b/tasks/2026-05-15-sidebar-customization/smoke-report.md
@@ -1,0 +1,64 @@
+# Smoke report — sidebar customization
+
+**Date**: 2026-05-15
+**Branch**: feat/sidebar-customization
+
+## Verdict: green (with caveats — see manual-test recommendation)
+
+## What was automated
+
+### Unit tests
+- `node --test test/sidebar-config.test.js` → **32 / 32 pass**
+- Full suite: same per-file numbers as `main`. No regressions:
+  - `agents-detect`: 8/8 pass
+  - `claude-structured-parse`: 6/6 pass
+  - `cloud-remote-normalize`: 5/5 pass
+  - `git-root-resolve`: 8/8 pass
+  - `settings`: 9/9 pass
+  - `sidebar-config` (NEW): 32/32 pass
+  - `display-project`: 14/14 fail — **pre-existing on main**, unrelated function reference
+  - `wsl-windows`: 1/6 fail — **pre-existing on main**, platform-specific
+
+### HTML build inspection
+`node -e "require('./src/html.js').getHTML()"` markers — all present:
+- ✓ Workspace / Agents / Tools section headers (`data-section`)
+- ✓ Install agents nested `data-section="install-agents"`
+- ✓ `SidebarConfig` / `parseSidebarConfig` / `KNOWN_ITEM_KEYS` inlined into output
+- ✓ `applySidebarConfig` definition + invocation in `init()`
+- ✓ Settings sub-pane block (`renderSidebarSettingsGroup`)
+- ✓ `data-key="install:claude"` ... `install:copilot`
+- ✓ `data-key="export-import"`
+
+### Server boot
+- Port 3847 was already in use by the user's installed `codbash` (production). Did not kill — destructive.
+- HTML output validated via in-process `getHTML()` call instead of HTTP probe.
+
+## What requires manual browser verification
+
+Before merging, run a clean dev build and check in browser:
+
+```bash
+# Stop the npm-installed codbash first if it's running, then:
+node bin/cli.js run
+# Visit http://localhost:3847
+```
+
+Manual checklist (BDD coverage):
+- [ ] Default layout: 3 sections, Workspace + Agents + Tools all expanded; Install agents collapsed.
+- [ ] Click "Workspace" header → collapses with chevron rotating to ▸. Reload → still collapsed.
+- [ ] Settings → Sidebar pane: uncheck Leaderboard → item disappears from sidebar live; reload → still hidden.
+- [ ] Settings checkbox itself is `disabled` with tooltip "Settings is always visible".
+- [ ] Reset to defaults — all items reappear, Tools re-expanded, Install agents back to collapsed.
+- [ ] DevTools → set `localStorage['codedash-sidebar-config'] = '{garbage'` → reload → default layout, no error in console (only the documented warning).
+- [ ] DevTools → check `aria-expanded` toggles on each header click.
+- [ ] Keyboard: Tab to header, press Space → collapses; press Enter → expands.
+- [ ] Visit `#leaderboard` while Leaderboard is hidden → view renders, sidebar item still hidden, hash routing works.
+- [ ] Theme switch (dark / light / monokai) — chevron color and section header color visible in all three.
+
+## Known issues observed
+
+None blocking. The existing pre-feature behavior where clicking install items also fires `setView(null)` (because install items have no `data-view`) is unchanged from `main` — out of scope for this PR.
+
+## Recommendation
+
+Proceed to G7 (three-agent review). Manual browser smoke can be done by reviewer or before merging the PR — the automated checks confirm the surface is wired correctly.

--- a/test/sidebar-config.test.js
+++ b/test/sidebar-config.test.js
@@ -1,0 +1,353 @@
+// Tests for src/frontend/sidebar-config.js — pure config helpers used by
+// the sidebar customization feature. Run with `node --test test/sidebar-config.test.js`.
+//
+// The module must work both in the browser (loaded via <script>) and in Node
+// (loaded via require). The Node branch is what these tests exercise.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+function loadModule() {
+  delete require.cache[require.resolve('../src/frontend/sidebar-config')];
+  return require('../src/frontend/sidebar-config');
+}
+
+// ── parseSidebarConfig ──────────────────────────────────────────
+
+test('parseSidebarConfig returns defaults when input is null', () => {
+  const m = loadModule();
+  const got = m.parseSidebarConfig(null);
+  assert.equal(got.v, 1);
+  assert.deepEqual(got.hidden, {});
+  assert.deepEqual(got.collapsed, {});
+});
+
+test('parseSidebarConfig returns defaults when input is undefined', () => {
+  const m = loadModule();
+  const got = m.parseSidebarConfig(undefined);
+  assert.equal(got.v, 1);
+});
+
+test('parseSidebarConfig returns defaults when input is empty string', () => {
+  const m = loadModule();
+  const got = m.parseSidebarConfig('');
+  assert.deepEqual(got.hidden, {});
+  assert.deepEqual(got.collapsed, {});
+});
+
+test('parseSidebarConfig returns defaults on invalid JSON', () => {
+  const m = loadModule();
+  const got = m.parseSidebarConfig('{not valid json');
+  assert.equal(got.v, 1);
+  assert.deepEqual(got.hidden, {});
+});
+
+test('parseSidebarConfig returns defaults when version is in the future', () => {
+  const m = loadModule();
+  const future = JSON.stringify({ v: 999, hidden: { leaderboard: true }, collapsed: {} });
+  const got = m.parseSidebarConfig(future);
+  // forward-compat fallback: unknown version => trust nothing, use defaults
+  assert.deepEqual(got.hidden, {}, 'future version must not leak hidden into runtime config');
+});
+
+test('parseSidebarConfig accepts a valid v:1 payload', () => {
+  const m = loadModule();
+  const stored = JSON.stringify({
+    v: 1,
+    hidden: { leaderboard: true, starred: true },
+    collapsed: { tools: true }
+  });
+  const got = m.parseSidebarConfig(stored);
+  assert.equal(got.hidden.leaderboard, true);
+  assert.equal(got.hidden.starred, true);
+  assert.equal(got.collapsed.tools, true);
+});
+
+test('parseSidebarConfig preserves unknown hidden keys (forward-compat)', () => {
+  // A future codbash version may add a new sidebar item. When that user
+  // downgrades briefly and we save, we must not destroy the unknown key.
+  const m = loadModule();
+  const stored = JSON.stringify({
+    v: 1,
+    hidden: { 'leaderboard': true, 'future-view-xyz': true },
+    collapsed: {}
+  });
+  const got = m.parseSidebarConfig(stored);
+  assert.equal(got.hidden['future-view-xyz'], true,
+    'unknown keys must be preserved through parse so they survive a save');
+});
+
+test('parseSidebarConfig coerces non-boolean values to booleans', () => {
+  const m = loadModule();
+  const stored = JSON.stringify({
+    v: 1,
+    hidden: { leaderboard: 'yes', starred: 1, activity: 0, cloud: null },
+    collapsed: {}
+  });
+  const got = m.parseSidebarConfig(stored);
+  assert.equal(typeof got.hidden.leaderboard, 'boolean');
+  assert.equal(got.hidden.leaderboard, true);
+  assert.equal(got.hidden.starred, true);
+  // falsy values either become false OR the key is dropped — both are fine, just no crashes
+});
+
+test('parseSidebarConfig rejects when hidden is not an object', () => {
+  const m = loadModule();
+  const stored = JSON.stringify({ v: 1, hidden: 'evil-string', collapsed: {} });
+  const got = m.parseSidebarConfig(stored);
+  assert.deepEqual(got.hidden, {}, 'malformed hidden must fall back to empty');
+});
+
+test('parseSidebarConfig rejects array-as-object attack', () => {
+  // Arrays are typeof 'object' in JS — make sure we explicitly require a plain object.
+  const m = loadModule();
+  const stored = JSON.stringify({ v: 1, hidden: ['leaderboard'], collapsed: {} });
+  const got = m.parseSidebarConfig(stored);
+  assert.deepEqual(got.hidden, {});
+});
+
+test('parseSidebarConfig ignores non-string keys defensively', () => {
+  // JSON.parse can't produce non-string keys, but be paranoid: anything
+  // that ends up in DOM-derived contexts must be a real string.
+  const m = loadModule();
+  const got = m.parseSidebarConfig('{"v":1,"hidden":{"":true},"collapsed":{}}');
+  assert.equal(got.hidden[''], undefined, 'empty-string key has no meaningful target, drop it');
+});
+
+test('parseSidebarConfig rejects payloads larger than 64KB (self-DoS guard)', () => {
+  // Synthesize a 65KB JSON blob. Cap is 64KB (65536 bytes).
+  const m = loadModule();
+  const fat = '{"v":1,"hidden":{' +
+    Array.from({length: 10000}, (_, i) => '"longkey' + i + '":true').join(',') +
+    '},"collapsed":{}}';
+  assert.ok(fat.length > 65536, 'test payload must exceed cap, got ' + fat.length);
+  const got = m.parseSidebarConfig(fat);
+  assert.deepEqual(got.hidden, {}, 'oversized payload falls back to defaults');
+});
+
+test('parseSidebarConfig blocks __proto__, constructor, prototype keys', () => {
+  const m = loadModule();
+  const malicious = JSON.stringify({
+    v: 1,
+    hidden: { '__proto__': true, 'constructor': true, 'prototype': true, 'leaderboard': true },
+    collapsed: {}
+  });
+  const got = m.parseSidebarConfig(malicious);
+  assert.equal(got.hidden.leaderboard, true, 'legit key still preserved');
+  // Use hasOwn to avoid the __proto__ getter — direct access returns the proto.
+  assert.ok(!Object.prototype.hasOwnProperty.call(got.hidden, '__proto__'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(got.hidden, 'constructor'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(got.hidden, 'prototype'));
+});
+
+// ── isItemHidden ────────────────────────────────────────────────
+
+test('isItemHidden returns false for keys not in config (default visible)', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  assert.equal(m.isItemHidden(cfg, 'leaderboard'), false);
+  assert.equal(m.isItemHidden(cfg, 'anything-unknown'), false);
+});
+
+test('isItemHidden returns true when key is hidden', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(JSON.stringify({
+    v: 1, hidden: { leaderboard: true }, collapsed: {}
+  }));
+  assert.equal(m.isItemHidden(cfg, 'leaderboard'), true);
+});
+
+test('isItemHidden never reports Settings as hidden, even if config says so', () => {
+  // Safety: protect the user from locking themselves out.
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(JSON.stringify({
+    v: 1, hidden: { settings: true }, collapsed: {}
+  }));
+  assert.equal(m.isItemHidden(cfg, 'settings'), false);
+});
+
+// ── isSectionCollapsed ──────────────────────────────────────────
+
+test('isSectionCollapsed returns false for sections by default', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  assert.equal(m.isSectionCollapsed(cfg, 'workspace'), false);
+  assert.equal(m.isSectionCollapsed(cfg, 'agents'), false);
+  assert.equal(m.isSectionCollapsed(cfg, 'tools'), false);
+});
+
+test('isSectionCollapsed defaults install-agents sub-section to collapsed', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  assert.equal(m.isSectionCollapsed(cfg, 'install-agents'), true,
+    'install-agents is default-collapsed per design');
+});
+
+test('isSectionCollapsed honors stored value over default', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(JSON.stringify({
+    v: 1, hidden: {}, collapsed: { 'install-agents': false, tools: true }
+  }));
+  assert.equal(m.isSectionCollapsed(cfg, 'install-agents'), false);
+  assert.equal(m.isSectionCollapsed(cfg, 'tools'), true);
+});
+
+// ── setItemHidden / setSectionCollapsed (immutability) ──────────
+
+test('setItemHidden returns a new config object (immutability)', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  const next = m.setItemHidden(cfg, 'leaderboard', true);
+  assert.notStrictEqual(next, cfg, 'must not mutate the input config');
+  assert.equal(cfg.hidden.leaderboard, undefined, 'input unchanged');
+  assert.equal(next.hidden.leaderboard, true);
+});
+
+test('setItemHidden(false) removes the key (does not set to false)', () => {
+  // Smaller storage payload + the "absence === visible" convention stays clean.
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(JSON.stringify({
+    v: 1, hidden: { leaderboard: true }, collapsed: {}
+  }));
+  const next = m.setItemHidden(cfg, 'leaderboard', false);
+  assert.equal(next.hidden.leaderboard, undefined);
+});
+
+test('setItemHidden refuses to hide Settings (returns config unchanged)', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  const next = m.setItemHidden(cfg, 'settings', true);
+  assert.equal(next.hidden.settings, undefined,
+    'Settings must never be persistable as hidden');
+});
+
+test('setSectionCollapsed returns a new config object (immutability)', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  const next = m.setSectionCollapsed(cfg, 'tools', true);
+  assert.notStrictEqual(next, cfg);
+  assert.equal(next.collapsed.tools, true);
+  assert.equal(cfg.collapsed.tools, undefined);
+});
+
+// ── KNOWN_ITEM_KEYS allow-list ──────────────────────────────────
+
+test('KNOWN_ITEM_KEYS includes all current sidebar entries', () => {
+  const m = loadModule();
+  const keys = new Set(m.KNOWN_ITEM_KEYS);
+  // Workspace
+  ['sessions','projects','timeline','activity','running','analytics',
+   'starred','leaderboard','cloud'].forEach(k => {
+    assert.ok(keys.has(k), 'workspace key missing: ' + k);
+  });
+  // Agents
+  ['claude-only','codex-only','qwen-only','kiro-only','cursor-only',
+   'copilot-chat-only','copilot-only','opencode-only','kilo-only'].forEach(k => {
+    assert.ok(keys.has(k), 'agent key missing: ' + k);
+  });
+  // Tools
+  ['export-import','changelog'].forEach(k => {
+    assert.ok(keys.has(k), 'tools key missing: ' + k);
+  });
+  // Install
+  ['install:claude','install:codex','install:qwen','install:kiro',
+   'install:opencode','install:kilo','install:copilot'].forEach(k => {
+    assert.ok(keys.has(k), 'install key missing: ' + k);
+  });
+});
+
+test('KNOWN_ITEM_KEYS does NOT include "settings" (it is always visible)', () => {
+  const m = loadModule();
+  assert.ok(!m.KNOWN_ITEM_KEYS.includes('settings'),
+    'settings must not be a togglable key');
+});
+
+// ── serializeSidebarConfig ──────────────────────────────────────
+
+test('serializeSidebarConfig produces JSON with v:1 envelope', () => {
+  const m = loadModule();
+  const cfg = m.parseSidebarConfig(null);
+  const next = m.setItemHidden(cfg, 'leaderboard', true);
+  const json = m.serializeSidebarConfig(next);
+  const round = JSON.parse(json);
+  assert.equal(round.v, 1);
+  assert.equal(round.hidden.leaderboard, true);
+});
+
+test('serializeSidebarConfig round-trips unknown keys preserved by parse', () => {
+  const m = loadModule();
+  const parsed = m.parseSidebarConfig(JSON.stringify({
+    v: 1, hidden: { 'future-view-xyz': true }, collapsed: {}
+  }));
+  const json = m.serializeSidebarConfig(parsed);
+  const round = JSON.parse(json);
+  assert.equal(round.hidden['future-view-xyz'], true,
+    'unknown keys must survive parse → serialize round-trip');
+});
+
+// ── loadFromStorage / saveToStorage with throwing storage ───────
+
+test('loadFromStorage returns defaults when storage.getItem throws', () => {
+  const m = loadModule();
+  const throwingStorage = {
+    getItem() { throw new Error('SecurityError: storage disabled'); }
+  };
+  const got = m.loadFromStorage(throwingStorage);
+  assert.equal(got.v, 1);
+  assert.deepEqual(got.hidden, {});
+});
+
+test('loadFromStorage handles null storage gracefully', () => {
+  const m = loadModule();
+  const got = m.loadFromStorage(null);
+  assert.equal(got.v, 1);
+});
+
+test('saveToStorage swallows errors when storage.setItem throws', () => {
+  const m = loadModule();
+  const throwingStorage = {
+    setItem() { throw new Error('QuotaExceededError'); }
+  };
+  const cfg = m.parseSidebarConfig(null);
+  // Must not throw — calling site relies on this being safe.
+  assert.doesNotThrow(() => m.saveToStorage(throwingStorage, cfg));
+});
+
+test('saveToStorage uses the documented localStorage key', () => {
+  const m = loadModule();
+  let writtenKey = null;
+  let writtenValue = null;
+  const fakeStorage = {
+    setItem(k, v) { writtenKey = k; writtenValue = v; }
+  };
+  const cfg = m.parseSidebarConfig(null);
+  m.saveToStorage(fakeStorage, m.setItemHidden(cfg, 'leaderboard', true));
+  assert.equal(writtenKey, 'codedash-sidebar-config');
+  assert.ok(writtenValue.includes('"leaderboard":true'));
+});
+
+// ── resetConfig ─────────────────────────────────────────────────
+
+test('resetConfig returns a fresh empty config', () => {
+  const m = loadModule();
+  const reset = m.resetConfig();
+  assert.equal(reset.v, 1);
+  assert.deepEqual(reset.hidden, {});
+  assert.deepEqual(reset.collapsed, {});
+});
+
+test('clearStorage removes the sidebar config key', () => {
+  const m = loadModule();
+  let removedKey = null;
+  const fakeStorage = {
+    removeItem(k) { removedKey = k; }
+  };
+  m.clearStorage(fakeStorage);
+  assert.equal(removedKey, 'codedash-sidebar-config');
+});
+
+test('clearStorage tolerates a throwing removeItem', () => {
+  const m = loadModule();
+  const throwingStorage = { removeItem() { throw new Error('boom'); } };
+  assert.doesNotThrow(() => m.clearStorage(throwingStorage));
+});


### PR DESCRIPTION
## Summary
- Sidebar reorganized into 3 collapsible sections — **Workspace**, **Agents**, **Tools** — with **Install agents** as a default-collapsed sub-section inside Tools. Each entry can be individually hidden via the new **Settings → Sidebar** tab.
- Settings page itself restructured into 4 sub-tabs (**Appearance / Sidebar / Sessions / Integrations**) using the same `.ap-tabs` visual pattern as the Add Project modal.
- All preferences persist locally (`localStorage['codedash-sidebar-config']` v:1 + `codedash-settings-tab`). No server changes, no new endpoints, no network calls.

## What's new

| Surface | Change |
|---|---|
| Sidebar HTML | 3 `<div class="sidebar-group" data-section>` blocks with `<button>` headers; nested install-agents sub-group |
| `src/frontend/sidebar-config.js` (new) | Pure UMD module: `parseSidebarConfig` / `serializeSidebarConfig` / `isItemHidden` / `isSectionCollapsed` / `setItemHidden` / `setSectionCollapsed` / `loadFromStorage` / `saveToStorage` / `clearStorage` / `resetConfig` + `KNOWN_ITEM_KEYS` allow-list |
| `src/frontend/app.js` | `applySidebarConfig`, section-header click handler, `toggleSidebarItem`, two-stage `onResetSidebarClick`, `renderSidebarSettingsGroup`, `onSettingsTabKey` (keyboard nav), `_announceSidebar` (aria-live), tabbed `renderSettings` |
| `src/frontend/styles.css` | `.sidebar-group`, `.sidebar-section-header` (32px min height), chevron rotation, `.sidebar-subgroup` indent, `.settings-sidebar-*` rows, `.settings-tabs`, `.sr-only` |
| Pre-paint script in `index.html` | Tiny IIFE applies persisted `collapsed` class before sidebar markup paints — prevents flash of expanded state |
| `test/sidebar-config.test.js` (new) | 34 `node:test` cases — all green |

## Accessibility
- WAI-ARIA tablist with arrow-key navigation (Left/Right/Home/End), `aria-controls`, `aria-labelledby`, roving `tabindex`.
- `aria-expanded` on section headers; `aria-live="polite"` status region announces show/hide toggles.
- Settings entry is always visible — checkbox is `disabled`, `isItemHidden` short-circuits, `setItemHidden` refuses to write. Three-layer lockout protection.
- `prefers-reduced-motion` suppresses chevron transition.
- Section header contrast raised from `--text-muted` to `--text-secondary` (WCAG 1.4.3 AA).
- Touch targets ≥32px on top sections, ≥28px on sub-sections (WCAG 2.5.8).

## Security
- `localStorage` payload capped at 64 KB (synchronous parse on init — DoS guard).
- `__proto__` / `constructor` / `prototype` keys explicitly blocked in `sanitizeMap`.
- Config stores only booleans; item keys come from a hardcoded allow-list — no path lets user-controlled strings reach the DOM as markup or attribute-context JS.
- All `<a target="_blank">` get `rel="noopener noreferrer"`.

## Spec-driven artifacts
- `docs/design/sidebar-customization.md` — SDD with full UX/a11y section
- `specs/sidebar-customization.feature` — 13 BDD scenarios (happy / empty / loading / error / keyboard / edge)
- `tasks/2026-05-15-sidebar-customization/plan.md` — implementation plan + risk register (all 10 risks closed)
- `tasks/2026-05-15-sidebar-customization/smoke-report.md` — automated smoke verdict

## Deferred (tracked in commit message)
- Cache `.sidebar-item` NodeList in `applySidebarConfig` — premature optimization for ~30 elements
- Count badge on collapsed "Install agents · 7" — cosmetic, follow-up PR

## Test plan
- [ ] `node --test test/sidebar-config.test.js` — 34/34 pass
- [ ] Open dashboard → sidebar shows 3 collapsible sections; Install agents collapsed by default
- [ ] Click "Workspace" header → collapses with chevron ▾→▸; reload → still collapsed
- [ ] Settings → Sidebar → uncheck Leaderboard → hides instantly; reload → still hidden
- [ ] Settings checkbox itself is disabled with tooltip "Settings is always visible"
- [ ] Reset to defaults → first click arms (red "Click again to confirm" + Cancel); auto-disarm after 6s; second click resets
- [ ] Hide every Workspace item → "All items hidden — manage in Settings" hint appears
- [ ] DevTools: `localStorage['codedash-sidebar-config'] = '{garbage'` → reload → default layout, no error UI
- [ ] Settings tab strip: Tab to focus, ← → Home End navigate between tabs; focus follows
- [ ] Visit `#leaderboard` while Leaderboard hidden → view renders, sidebar link stays hidden
- [ ] Tested in dark / light / monokai themes