### PR TITLE
chore: release 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,26 @@
 
 const CHANGELOG = [
   {
+    version: '7.5.0',
+    date: '2026-05-25',
+    title: 'Five new agents, project launcher, subscriptions',
+    changes: [
+      'New agents: Qwen Code, GitHub Copilot Chat (VS Code), GitHub Copilot CLI, Pi, Oh My Pi',
+      'Project launcher: ▶ New / ⟳ Last buttons, GitHub repo onboarding (clone & add)',
+      'Projects view split into Projects (launcher) + History subtabs with per-launch agent picker',
+      'Subscriptions management in Analytics → History: track paid plans + API deposits for all agents',
+      'Background git fetch worker — auto-refresh connected repos on new chat, manual button, or startup',
+      'Sidebar reorganised into collapsible Workspace / Agents / Tools groups + Settings → Sidebar tab',
+      'Codex Desktop import dedup: imported Claude sessions no longer appear twice in the dashboard',
+      'Codex cache invalidation now watches ~/.codex/sessions for new files (no more restart needed)',
+      'Active-session mapping no longer misattributes processes to the wrong session via fallback-latest',
+      'Worktrees collapse to main repo; $HOME-as-git-root no longer leaks dotfiles remote onto sessions',
+      'Windows: Resume preserves backslash paths via Start-Process -WorkingDirectory; PowerShell launcher hardened',
+      'Structured message rendering for Codex and Claude Code session details',
+      'Cloud Sync: project paths now remap across machines via git remote',
+    ],
+  },
+  {
     version: '7.2.0',
     date: '2026-04-17',
     title: 'Recap titles, sort toggle, analytics sub-tabs',


### PR DESCRIPTION
## Summary

Bumps `codbash-app` from **7.4.0** (npm published 2026-04-17, 38 days ago) to **7.5.0**.

## Why a minor bump

5 new agents + 4 user-facing features + 12 stability fixes accumulated. Backward-compatible, no API breaks → minor per SemVer.

## What's in 7.5.0

### New agents (5)
- **Qwen Code** — backend + frontend UI + resume support (#201, #202, #203)
- **GitHub Copilot Chat** (VS Code) — VS Code workspace storage scanner (#171)
- **GitHub Copilot CLI** — `gh copilot` extension scanner + resume (#207)
- **Pi** — JSONL session scanner + `pi --session <path>` resume (#221)
- **Oh My Pi** — Pi fork, separate filter, `omp --resume` (#221)

### Features
- **Project launcher** with `▶ New` / `⟳ Last` buttons + GitHub repo *Clone & Add* (#210)
- **Projects view split** into Projects (launcher) + History subtabs + per-launch agent picker (#211)
- **Subscriptions management** in Analytics → History — track paid plans + API deposits across all agents (#218)
- **Background git fetch worker** — auto-refresh on new chat / manual button / startup (#213)
- **Sidebar customization** — collapsible Workspace/Agents/Tools groups + Settings → Sidebar tab (#216)
- **Structured message rendering** for Codex (#197) and Claude Code (#198) detail views

### Fixes
- Codex Desktop dedup — imported Claude sessions no longer appear twice (#220)
- Codex cache invalidation now watches `~/.codex/sessions` for new files — no more restart needed (#215)
- `/api/active` no longer misattributes processes via `fallback-latest` (#215)
- Worktrees collapse to main repo; `$HOME`-as-git-root no longer leaks dotfiles remote (#212)
- Windows: Resume preserves backslash paths via `Start-Process -WorkingDirectory` (#214)
- Repo-refresh manager-owned timers cancelled on shutdown + tests now actually run in CI (#217)
- Subscriptions: entries beyond 3 now appear without page refresh + XSS hardening on `e.from` (#208)
- Cloud Sync: project paths remap across machines via git remote (#154)

## Verification

- [x] `node -c` clean on all touched JS
- [x] `node --test test/*.test.js` → 144 pass / 0 fail / 2 skipped (cross-platform skips)
- [x] CI matrix green 6/6 across Ubuntu/macOS × Node 18/20/22

## Release flow after merge

```bash
git checkout main && git pull
npm publish --access public
```