### PR TITLE
chore: release 7.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,18 @@
 
 const CHANGELOG = [
   {
+    version: '7.5.1',
+    date: '2026-05-26',
+    title: 'Neuraldeep visual identity + Pi hardening',
+    changes: [
+      'New brand palette: deeper dark backgrounds (#08090C) + neon green accent (#00FF88)',
+      'Inter font + crisper text rendering (antialiased smoothing)',
+      'Smooth 180ms theme cross-fade when switching dark / light / monokai',
+      'Pi / Oh My Pi: tightened resume-target handling — non-Pi Resume buttons no longer routed through Pi-specific helper, /api/launch only forwards resumeTarget for Pi sessions',
+      'CSP relaxed precisely for fonts.googleapis.com / fonts.gstatic.com (no other change)',
+    ],
+  },
+  {
     version: '7.5.0',
     date: '2026-05-25',
     title: 'Five new agents, project launcher, subscriptions',


### PR DESCRIPTION
## Summary

Patch bump from **7.5.0** → **7.5.1**.

## What's in 7.5.1

- **Neuraldeep visual identity** (#225) — new dark palette (#08090C bg + neon #00FF88 accent), Inter font, 180ms theme cross-fade, accent-pulse keyframe, prefers-reduced-motion respected. Monokai theme preserved untouched
- **Pi / Oh My Pi resume-target hardening** (#224) — non-Pi Resume buttons no longer routed through Pi-specific helper, `/api/launch` only forwards `resumeTarget` for Pi sessions, scope tightened to what was actually needed

## Verified

- [x] `node --test test/*.test.js` → 146/0/2 (no regressions)
- [x] CI matrix expected to be green 6/6
- [x] Dark / Light / Monokai themes confirmed visually via Playwright

## After merge

GitHub Release `v7.5.1` → workflow publishes to npm automatically (granular token + bypass 2FA already configured).