### PR TITLE
fix(pi): parse OMP title-before-session logs

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -743,13 +743,34 @@ function parsePiSessionFile(sessionFile) {
   if (lines.length === 0) return null;
 
   let header;
-  try { header = JSON.parse(lines[0]); } catch { return null; }
-  if (!header || header.type !== 'session' || !header.id) return null;
+  let headerLine = -1;
+  for (let i = 0; i < Math.min(lines.length, 50); i++) {
+    try {
+      const entry = JSON.parse(lines[i]);
+      if (entry && entry.type === 'session' && entry.id) {
+        header = entry;
+        headerLine = i;
+        break;
+      }
+    } catch {}
+  }
+  if (!header) return null;
 
   let sessionId = String(header.id);
   if (!SAFE_PI_SESSION_ID.test(sessionId)) return null;
   let projectPath = typeof header.cwd === 'string' ? header.cwd : '';
   let title = typeof header.title === 'string' ? header.title.trim().slice(0, 200) : '';
+  if (!title) {
+    for (let i = 0; i < headerLine; i++) {
+      try {
+        const entry = JSON.parse(lines[i]);
+        if (entry && entry.type === 'title' && typeof entry.title === 'string' && entry.title.trim()) {
+          title = entry.title.trim().slice(0, 200);
+          break;
+        }
+      } catch {}
+    }
+  }
   let msgCount = 0;
   let userMsgCount = 0;
   let firstMsg = '';
@@ -761,7 +782,7 @@ function parsePiSessionFile(sessionFile) {
   let hasUsage = false;
   let explicitCost = false;
 
-  for (let i = 1; i < lines.length; i++) {
+  for (let i = headerLine + 1; i < lines.length; i++) {
     try {
       const entry = JSON.parse(lines[i]);
       const ts = parseTimestamp(entry.timestamp || entry.ts);

--- a/test/pi-session.test.js
+++ b/test/pi-session.test.js
@@ -84,6 +84,20 @@ test('parsePiSessionFile reads OMP header and message summary', () => {
   assert.equal(summary.lastTs, Date.parse('2026-05-24T10:00:04.000Z'));
 });
 
+test('parsePiSessionFile reads title line before OMP session header', () => {
+  const dir = tmpDir();
+  const file = path.join(dir, 'sessions', '--tmp--project--', '2026-05-24T10-00-00.000Z_pi-session-title.jsonl');
+  writeJsonl(file, [
+    { type: 'title', title: 'brief-improve' },
+    { type: 'session', version: 3, id: 'pi-session-title', timestamp: '2026-05-24T10:00:00.000Z', cwd: '/tmp/project' },
+    { type: 'message', timestamp: '2026-05-24T10:00:02.000Z', message: { role: 'user', content: [{ type: 'text', text: 'Please fix this' }] } },
+  ]);
+
+  const summary = parsePiSessionFile(file);
+  assert.equal(summary.sessionId, 'pi-session-title');
+  assert.equal(summary.title, 'brief-improve');
+});
+
 test('parsePiSessionFile rejects unsafe header ids', () => {
   const dir = tmpDir();
   const file = path.join(dir, 'sessions', '--tmp--project--', 'bad.jsonl');


### PR DESCRIPTION
## Summary
- accept Pi/OhMyPi JSONL logs where a title metadata record appears before the session header
- keep parsing scoped to parsePiSessionFile() so scanning/detail/rescan behavior stays unchanged
- use a preceding title record only when the session header has no title

## Why this happened
The original Pi/OhMyPi parser assumed every session JSONL starts with a `session` record on the first line. That matched the Pi logs I tested first.

Oh My Pi changed its session log stream to emit title metadata as its own JSONL record before the session header, for example:

```jsonl
{"type":"title","v":1,"title":"brief-improve","source":"user","updatedAt":"..."}
{"type":"session","version":3,"id":"...","timestamp":"...","cwd":"..."}
```

So the file is still a valid session log, but line 1 is no longer the `session` header. Codbash treated that first `title` record as an invalid header and returned `null`, silently dropping the whole session from scans. Locally this matched the missing-session symptom: Pi/OhMyPi counts went from the old undercount to `pi count: 555`, `ohmy: 431` after parsing the delayed session header.

## Fix
- scan the first 50 lines for the first `{ type: 'session', id }` record instead of requiring it at line 1
- start message parsing after the actual session header
- if the session header has no title, reuse the preceding `title` metadata record
- leave unrelated scan/detail/rescan code untouched

## Validation
- `node --check src/data.js`
- `node --test test/pi-session.test.js` → 14 pass, 0 fail
- local real-data scan after fix: `pi count: 555`, `ohmy: 431`