### PR TITLE
fix: reliable self-update restart (v7.5.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,16 @@
 
 const CHANGELOG = [
   {
+    version: '7.5.2',
+    date: '2026-07-19',
+    title: 'Reliable self-update restart',
+    changes: [
+      'Fix: "Update Now" no longer leaves the server dead after installing the new version — the restart now spawns a fully-detached process instead of an unreliable process.on("exit") handler',
+      'Self-update restarter reclaims the same port/host and skips reopening the browser (the existing tab reloads itself)',
+      'npm install timeout during self-update raised from 60s to 120s for slower connections',
+    ],
+  },
+  {
     version: '7.5.1',
     date: '2026-05-26',
     title: 'Neuraldeep visual identity + Pi hardening',

--- a/src/server.js
+++ b/src/server.js
@@ -795,17 +795,27 @@ function startServer(host, port, openBrowser = true) {
       json(res, { ok: true, message: 'Updating... Page will reload.' });
       // Run update in background after response is sent
       setTimeout(() => {
-        const { execSync } = require('child_process');
+        const { execSync, spawn } = require('child_process');
         try {
-          execSync('npm i -g codbash-app@latest', { stdio: 'inherit', timeout: 60000 });
-          log('UPDATE', 'Updated. Restarting...');
-          // Restart the process
-          process.on('exit', () => {
-            require('child_process').spawn(process.argv[0], process.argv.slice(1), {
-              detached: true, stdio: 'inherit'
-            }).unref();
-          });
-          process.exit(0);
+          execSync('npm i -g codbash-app@latest', { stdio: 'inherit', timeout: 120000 });
+          log('UPDATE', 'Update installed. Restarting server...');
+          // Spawn a FULLY-detached restarter BEFORE exiting. Spawning inside a
+          // `process.on('exit')` handler is unreliable — the event loop is already
+          // draining, so the child frequently never survives and the server ends
+          // up dead (nothing reclaims the port). Instead: detach + unref + ignore
+          // stdio so the child outlives us, become its own process-group leader
+          // (so the restarter's `lsof … | kill -9` on the port can't take it down),
+          // then exit cleanly. The restarter loads the freshly-installed code from
+          // the same argv[1] path that npm just overwrote.
+          const child = spawn(
+            process.argv[0],
+            [process.argv[1], 'restart', `--port=${port}`, `--host=${host}`, '--no-browser'],
+            { detached: true, stdio: 'ignore' }
+          );
+          child.unref();
+          // Give the OS a tick to fully spawn the detached child before we exit
+          // and release the port for the restarter to grab.
+          setTimeout(() => process.exit(0), 250);
         } catch (e) {
           log('ERROR', `Update failed: ${e.message}`);
         }


### PR DESCRIPTION
## Problem

Clicking **Update Now** installed the new version via `npm i -g codbash-app@latest`, but the server then **died and never came back up** — the port was freed yet nothing relistened. The UI kept showing the stale version (`v7.4.0 → v7.5.1`) and the auto `location.reload()` hit a dead server.

## Root cause

`/api/update` spawned the restarter inside a `process.on('exit')` handler:

```js
process.on('exit', () => {
  require('child_process').spawn(process.argv[0], process.argv.slice(1), {
    detached: true, stdio: 'inherit'
  }).unref();
});
process.exit(0);
```

At exit time the event loop is already draining — spawning there is unreliable and the detached child frequently never survives. Net result: server gone, no relisten.

## Fix

- Spawn a **fully-detached** restarter (`detached: true`, `stdio: 'ignore'`, own process group, `.unref()`) **before** exiting, then `process.exit(0)` after a 250ms tick so the port is released for the restarter.
- Restarter reuses the same `--port`/`--host` and passes `--no-browser` (the existing tab reloads itself — no duplicate window).
- Restarter loads freshly-installed code from the same `argv[1]` path npm just overwrote.
- Bumped npm-install timeout 60s → 120s for slower connections.

## Version

Patch bump `7.5.1` → `7.5.2` + changelog entry.

> Note: users currently on the broken updater will still hit the old path once; every self-update after they land on 7.5.2 is reliable.

## Testing

- `node -c` syntax check passes on `server.js` and `changelog.js`.
- Manual restart verified: server comes up on 3847 and reports `7.5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)