### PR TITLE
feat: Recommended tools view (v7.6.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.5.3",
+  "version": "7.6.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,16 @@
 
 const CHANGELOG = [
   {
+    version: '7.6.0',
+    date: '2026-07-19',
+    title: 'Recommended tools',
+    changes: [
+      'New "Recommended" view: handpicked companion apps that pair well with codbash — Copyosity, ccstatusline, RustDesk, iTerm2',
+      'Tick tools you already have; the "installed" state is remembered per browser',
+      'The tool list is a simple config array, so new tools are easy to add',
+    ],
+  },
+  {
     version: '7.5.3',
     date: '2026-07-19',
     title: 'Sidebar hover tooltips',

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1660,6 +1660,11 @@ function render() {
     return;
   }
 
+  if (currentView === 'recommended') {
+    renderRecommended(content);
+    return;
+  }
+
   if (currentView === 'settings') {
     renderSettings(content);
     return;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -212,6 +212,10 @@
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                 Export / Import
             </div>
+            <div class="sidebar-item" data-view="recommended" data-key="recommended">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+                Recommended
+            </div>
             <div class="sidebar-item" data-view="changelog" data-key="changelog">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
                 Changelog

--- a/src/frontend/recommended.js
+++ b/src/frontend/recommended.js
@@ -1,0 +1,107 @@
+// "Recommended tools" view — curated companion apps that pair well with
+// codbash. Ported from TermDeck's "useful links" section. The list is a plain
+// config array so new tools are trivial to add. "Installed" ticks are a
+// per-browser preference stored in localStorage (no server state).
+
+var RECOMMENDED_TOOLS = [
+  {
+    id: 'copyosity',
+    name: 'Copyosity',
+    tagline: 'Native macOS clipboard manager with on-device intelligence — history, OCR, voice, and a command palette from a hotkey.',
+    url: 'https://github.com/vakovalskii/copyosity',
+    platform: 'macOS',
+    category: 'Productivity'
+  },
+  {
+    id: 'ccstatusline',
+    name: 'ccstatusline',
+    tagline: 'Highly customizable status line for Claude Code — model, git branch, token usage and more, with powerline styling.',
+    url: 'https://github.com/sirmalloc/ccstatusline',
+    platform: 'Cross-platform',
+    category: 'Claude Code'
+  },
+  {
+    id: 'rustdesk',
+    name: 'RustDesk',
+    tagline: 'Open-source remote desktop — a self-hostable alternative to TeamViewer / AnyDesk.',
+    url: 'https://rustdesk.com',
+    platform: 'Windows · macOS · Linux',
+    category: 'Remote access'
+  },
+  {
+    id: 'iterm2',
+    name: 'iTerm2',
+    tagline: 'Powerful terminal emulator for macOS with splits, profiles, search and shell integration.',
+    url: 'https://iterm2.com',
+    platform: 'macOS',
+    category: 'Terminal'
+  }
+];
+
+var RECOMMENDED_INSTALLED_KEY = 'codedash-tools-installed';
+
+function _loadInstalledTools() {
+  try {
+    var raw = localStorage.getItem(RECOMMENDED_INSTALLED_KEY);
+    if (!raw) return {};
+    var obj = JSON.parse(raw);
+    return (obj && typeof obj === 'object' && !Array.isArray(obj)) ? obj : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function _saveInstalledTools(map) {
+  try {
+    localStorage.setItem(RECOMMENDED_INSTALLED_KEY, JSON.stringify(map));
+  } catch (e) {
+    // private mode / quota — best-effort persistence.
+  }
+}
+
+// Toggle the "installed" tick for a tool and update just that card in place
+// (no full re-render, so scroll position and other cards are untouched).
+function toggleToolInstalled(id) {
+  var map = _loadInstalledTools();
+  if (map[id]) { delete map[id]; } else { map[id] = true; }
+  _saveInstalledTools(map);
+
+  var on = !!map[id];
+  var card = document.querySelector('.tool-card[data-tool-id="' + id + '"]');
+  if (!card) return;
+  card.classList.toggle('installed', on);
+  var chk = card.querySelector('.tool-installed-check');
+  if (chk) chk.setAttribute('aria-checked', on ? 'true' : 'false');
+  var lbl = card.querySelector('.tool-installed-label');
+  if (lbl) lbl.textContent = on ? 'Installed' : 'Mark installed';
+}
+
+function renderRecommended(container) {
+  var installed = _loadInstalledTools();
+  var html = '<div class="changelog-container">';
+  html += '<h2 class="heatmap-title">Recommended tools</h2>';
+  html += '<p class="tools-intro">Handpicked companion apps that pair well with codbash. Tick the ones you already have.</p>';
+  html += '<div class="tools-grid">';
+
+  RECOMMENDED_TOOLS.forEach(function(t) {
+    var on = !!installed[t.id];
+    html += '<div class="tool-card' + (on ? ' installed' : '') + '" data-tool-id="' + escHtml(t.id) + '">';
+    html += '<div class="tool-card-head">';
+    html += '<span class="tool-name">' + escHtml(t.name) + '</span>';
+    html += '<span class="tool-platform">' + escHtml(t.platform) + '</span>';
+    html += '</div>';
+    html += '<div class="tool-tagline">' + escHtml(t.tagline) + '</div>';
+    html += '<div class="tool-card-foot">';
+    html += '<a class="tool-link" href="' + escHtml(t.url) + '" target="_blank" rel="noopener noreferrer">Open ↗</a>';
+    html += '<button type="button" class="tool-installed-check" role="checkbox" aria-checked="' + (on ? 'true' : 'false') +
+            '" onclick="toggleToolInstalled(\'' + escHtml(t.id) + '\')">';
+    html += '<span class="tool-check-box" aria-hidden="true"></span>';
+    html += '<span class="tool-installed-label">' + (on ? 'Installed' : 'Mark installed') + '</span>';
+    html += '</button>';
+    html += '</div>';
+    html += '</div>';
+  });
+
+  html += '</div></div>';
+  container.innerHTML = html;
+}

--- a/src/frontend/sidebar-config.js
+++ b/src/frontend/sidebar-config.js
@@ -36,7 +36,7 @@
     'claude-only', 'codex-only', 'qwen-only', 'pi-original-only', 'ohmypi-only', 'kiro-only', 'cursor-only',
     'copilot-chat-only', 'copilot-only', 'opencode-only', 'kilo-only',
     // Tools (Settings is intentionally absent — always visible)
-    'export-import', 'changelog',
+    'export-import', 'recommended', 'changelog',
     // Install agents
     'install:claude', 'install:codex', 'install:qwen', 'install:pi', 'install:ohmypi',
     'install:kiro', 'install:opencode', 'install:kilo', 'install:copilot'
@@ -75,6 +75,7 @@
     'kilo-only': 'Show only Kilo sessions',
     // Tools
     'export-import': 'Back up or restore your sessions as an archive',
+    'recommended': 'Handpicked companion apps that pair well with codbash',
     'changelog': 'What’s new in each codbash release',
     'settings': 'Themes, sidebar layout and other preferences',
     // Install agents (copy the install command)

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2750,6 +2750,100 @@ body {
 
 .changelog-container { padding: 20px; max-width: 700px; }
 
+/* ── Recommended tools view ────────────────────────────────── */
+.tools-intro {
+    color: var(--text-secondary);
+    font-size: 13px;
+    margin: 4px 0 20px;
+}
+.tools-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 14px;
+}
+.tool-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.tool-card:hover {
+    border-color: var(--accent-blue);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+.tool-card.installed {
+    border-color: var(--accent-green);
+}
+.tool-card-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+}
+.tool-name { font-size: 15px; font-weight: 600; color: var(--text-primary); }
+.tool-platform {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+.tool-tagline { font-size: 12.5px; line-height: 1.5; color: var(--text-secondary); flex: 1; }
+.tool-card-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 2px;
+}
+.tool-link {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent-blue);
+    text-decoration: none;
+}
+.tool-link:hover { text-decoration: underline; }
+.tool-installed-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 5px 9px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    color: var(--text-secondary);
+    font-size: 11.5px;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.tool-installed-check:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.tool-check-box {
+    width: 14px;
+    height: 14px;
+    border: 1.5px solid var(--text-muted);
+    border-radius: 4px;
+    flex-shrink: 0;
+    position: relative;
+    transition: all 0.15s;
+}
+.tool-card.installed .tool-installed-check { color: var(--accent-green); border-color: var(--accent-green); }
+.tool-card.installed .tool-check-box { background: var(--accent-green); border-color: var(--accent-green); }
+.tool-card.installed .tool-check-box::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 4px;
+    height: 8px;
+    border: solid var(--bg-card);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
 .changelog-entry {
     border-left: 2px solid var(--border);
     padding: 0 0 24px 20px;

--- a/src/html.js
+++ b/src/html.js
@@ -14,6 +14,7 @@ const JS_FILES = [
   'analytics.js',
   'leaderboard.js',
   'cloud.js',
+  'recommended.js',
 ];
 
 function buildHTML() {


### PR DESCRIPTION
## What

A new **Recommended** view (in the sidebar Tools section) showing curated companion apps that pair well with codbash — ported from TermDeck's "useful links" section:

- **Copyosity** — native macOS clipboard manager (github.com/vakovalskii/copyosity)
- **ccstatusline** — customizable status line for Claude Code (github.com/sirmalloc/ccstatusline)
- **RustDesk** — open-source remote desktop (rustdesk.com)
- **iTerm2** — macOS terminal (iterm2.com)

Each card links out and has a **"Mark installed"** toggle; the tick is remembered per browser.

## How

- New render module `src/frontend/recommended.js` (registered in `html.js`).
- `RECOMMENDED_TOOLS` is a plain config array — adding a tool is a one-liner.
- `render()` dispatch for `currentView === 'recommended'`; nav item + `data-key`/`data-view`; `NAV_HELP` entry (also unit-tested); themed card CSS for dark/light/monokai.
- Installed state persists in `localStorage` (`codedash-tools-installed`), updated in place without re-rendering the whole view.

## Testing

- `node --test test/*.test.js` → **158 pass, 2 skipped (win32), 0 fail**.
- Verified live in a browser: 4 cards render with correct names/platforms/links; toggling "installed" flips the card state + persists; the tick survives a full page reload.

## Version

Minor bump `7.5.3` → `7.6.0` (new view/feature) + changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)