### PR TITLE
feat: Workspace saved start commands (v7.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,16 @@
 
 const CHANGELOG = [
   {
+    version: '7.9.0',
+    date: '2026-07-20',
+    title: 'Workspace — saved start commands',
+    changes: [
+      'Save your own agent start commands (e.g. a proxied launch: HTTPS_PROXY=… claude --dangerously-skip-permissions) and fire them into any pane from the Launch menu',
+      'New "Commands" manager to add / delete saved commands; proxy passwords are masked in the UI',
+      'Stored on your machine at ~/.codedash/workspace-commands.json (mode 0600), not in the browser',
+    ],
+  },
+  {
     version: '7.8.0',
     date: '2026-07-20',
     title: 'Workspace — iTerm-like tabs & splits',

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2831,6 +2831,44 @@ body {
 
 .workspace-tabpanes { flex: 1; min-height: 0; display: flex; }
 
+/* Saved-commands manager modal */
+.ws-cmd-modal {
+    position: fixed; inset: 0; z-index: 300;
+    display: flex; align-items: center; justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+}
+.ws-cmd-dialog {
+    width: 560px; max-width: 92vw; max-height: 80vh;
+    display: flex; flex-direction: column;
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 12px; padding: 16px; gap: 10px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+.ws-cmd-head { display: flex; align-items: center; justify-content: space-between; font-weight: 600; color: var(--text-primary); }
+.ws-cmd-close { background: transparent; border: none; color: var(--text-muted); font-size: 20px; cursor: pointer; }
+.ws-cmd-note { font-size: 11px; color: var(--text-muted); line-height: 1.5; }
+.ws-cmd-note code { background: var(--bg-input); padding: 1px 4px; border-radius: 4px; }
+.ws-cmd-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; min-height: 40px; }
+.ws-cmd-empty { color: var(--text-muted); font-size: 12px; padding: 8px 2px; }
+.ws-cmd-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 10px; background: var(--bg-secondary);
+    border: 1px solid var(--border); border-radius: 8px;
+}
+.ws-cmd-info { flex: 1; min-width: 0; }
+.ws-cmd-name { font-size: 13px; color: var(--text-primary); font-weight: 500; }
+.ws-cmd-cmd { display: block; font-size: 11px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ws-cmd-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.ws-cmd-del:hover { color: var(--accent-red); border-color: var(--accent-red); }
+.ws-cmd-form { display: flex; flex-direction: column; gap: 6px; border-top: 1px solid var(--border); padding-top: 10px; }
+.ws-cmd-input {
+    background: var(--bg-input); color: var(--text-primary);
+    border: 1px solid var(--border); border-radius: 6px; padding: 7px 9px; font-size: 12px;
+    font-family: Menlo, Monaco, monospace;
+}
+.ws-cmd-save { align-self: flex-end; }
+.ws-cmd-error { color: var(--accent-red); font-size: 12px; min-height: 14px; }
+
 /* Grid of terminal panes. 1–3 panes = equal columns; 4 = 2×2. Only the active
    tab's grid is shown; hidden grids keep their ptys alive. */
 .workspace-grid {

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -36,6 +36,40 @@ var _wsTabSeq = 0;
 var _wsPaneSeq = 0;
 var _wsToken = null;
 var _wsVendorLoaded = false;
+var _wsSavedCommands = [];   // [{ id, name, command }]
+
+// Mask credentials in a URL userinfo (proxy passwords) for display only.
+function _wsMaskSecrets(cmd) {
+  return String(cmd).replace(/(:\/\/[^:/@\s]+:)[^@\s]+(@)/g, '$1****$2');
+}
+
+function _wsLoadCommands() {
+  return fetch('/api/terminal/commands')
+    .then(function (r) { return r.json(); })
+    .then(function (d) { _wsSavedCommands = (d && d.commands) || []; _wsRefreshLaunchers(); })
+    .catch(function () { _wsSavedCommands = []; });
+}
+
+// <option>s for a pane's Launch menu: built-in agents + saved commands.
+function _wsLaunchOptionsHtml() {
+  var html = '<option value="">Launch ▾</option>';
+  html += '<optgroup label="Agents">';
+  WORKSPACE_AGENTS.forEach(function (a) { html += '<option value="' + escHtml(a.cmd) + '">' + escHtml(a.label) + '</option>'; });
+  html += '</optgroup>';
+  if (_wsSavedCommands.length) {
+    html += '<optgroup label="Saved">';
+    _wsSavedCommands.forEach(function (c) { html += '<option value="' + escHtml(c.command) + '">' + escHtml(c.name) + '</option>'; });
+    html += '</optgroup>';
+  }
+  return html;
+}
+
+// Refresh every open pane's Launch menu in place (after commands change).
+function _wsRefreshLaunchers() {
+  Array.prototype.forEach.call(document.querySelectorAll('.ws-pane-launch'), function (sel) {
+    sel.innerHTML = _wsLaunchOptionsHtml();
+  });
+}
 
 // ── vendor ──────────────────────────────────────────────────────────────────
 function _loadWorkspaceVendor() {
@@ -149,14 +183,12 @@ function _wsConnectPane(pane) {
 
 // ── markup ──────────────────────────────────────────────────────────────────
 function _wsPaneMarkup(pane) {
-  var opts = '<option value="">Launch ▾</option>';
-  WORKSPACE_AGENTS.forEach(function (a) { opts += '<option value="' + escHtml(a.cmd) + '">' + escHtml(a.label) + '</option>'; });
   return '' +
     '<div class="ws-pane" data-pane-id="' + escHtml(pane.id) + '">' +
       '<div class="ws-pane-bar">' +
         '<span class="ws-pane-status" id="wsStatus-' + escHtml(pane.id) + '">connecting…</span>' +
-        '<select class="ws-pane-launch" title="Launch an agent in this pane" ' +
-          'onchange="launchAgentInPane(\'' + escHtml(pane.id) + '\', this.value); this.selectedIndex=0;">' + opts + '</select>' +
+        '<select class="ws-pane-launch" title="Launch an agent or saved command in this pane" ' +
+          'onchange="launchAgentInPane(\'' + escHtml(pane.id) + '\', this.value); this.selectedIndex=0;">' + _wsLaunchOptionsHtml() + '</select>' +
         '<button class="ws-pane-close" title="Close pane" onclick="closeWorkspacePane(\'' + escHtml(pane.id) + '\')">&times;</button>' +
       '</div>' +
       '<div class="ws-pane-term" id="wsTermHost-' + escHtml(pane.id) + '"></div>' +
@@ -332,6 +364,92 @@ function launchAgentInPane(id, cmd) {
   if (pane.term) pane.term.focus();
 }
 
+// ── Saved-commands manager (modal) ──────────────────────────────────────────
+function _wsActivePaneId() {
+  var tab = _wsActiveTab();
+  return tab && tab.panes[0] ? tab.panes[0].id : null;
+}
+
+function _wsCommandsListHtml() {
+  if (!_wsSavedCommands.length) return '<div class="ws-cmd-empty">No saved commands yet.</div>';
+  return _wsSavedCommands.map(function (c) {
+    return '<div class="ws-cmd-row">' +
+      '<div class="ws-cmd-info">' +
+        '<div class="ws-cmd-name">' + escHtml(c.name) + '</div>' +
+        '<code class="ws-cmd-cmd">' + escHtml(_wsMaskSecrets(c.command)) + '</code>' +
+      '</div>' +
+      '<div class="ws-cmd-actions">' +
+        '<button class="toolbar-btn" title="Run in the active pane" onclick="runSavedCommand(\'' + escHtml(c.id) + '\')">Run</button>' +
+        '<button class="toolbar-btn ws-cmd-del" title="Delete" onclick="deleteWorkspaceCommand(\'' + escHtml(c.id) + '\')">&times;</button>' +
+      '</div>' +
+    '</div>';
+  }).join('');
+}
+
+function _wsRenderCommandsModalBody() {
+  var el = document.getElementById('wsCmdList');
+  if (el) el.innerHTML = _wsCommandsListHtml();
+}
+
+function openWorkspaceCommands() {
+  var existing = document.getElementById('wsCmdModal');
+  if (existing) existing.remove();
+  var modal = document.createElement('div');
+  modal.id = 'wsCmdModal';
+  modal.className = 'ws-cmd-modal';
+  modal.innerHTML =
+    '<div class="ws-cmd-dialog">' +
+      '<div class="ws-cmd-head"><span>Saved commands</span>' +
+        '<button class="ws-cmd-close" onclick="closeWorkspaceCommands()">&times;</button></div>' +
+      '<div class="ws-cmd-note">Stored on your machine at <code>~/.codedash/workspace-commands.json</code> (0600). ' +
+        'Fine for proxy launches — the value is typed straight into the pane shell.</div>' +
+      '<div class="ws-cmd-list" id="wsCmdList">' + _wsCommandsListHtml() + '</div>' +
+      '<div class="ws-cmd-form">' +
+        '<input id="wsCmdName" class="ws-cmd-input" placeholder="Name (e.g. Claude via proxy)" maxlength="120">' +
+        '<input id="wsCmdCommand" class="ws-cmd-input" placeholder="HTTPS_PROXY=\'…\' claude --dangerously-skip-permissions">' +
+        '<button class="toolbar-btn ws-cmd-save" onclick="saveWorkspaceCommand()">Save</button>' +
+      '</div>' +
+      '<div class="ws-cmd-error" id="wsCmdError"></div>' +
+    '</div>';
+  modal.addEventListener('click', function (e) { if (e.target === modal) closeWorkspaceCommands(); });
+  document.body.appendChild(modal);
+  var nameEl = document.getElementById('wsCmdName');
+  if (nameEl) nameEl.focus();
+}
+
+function closeWorkspaceCommands() {
+  var m = document.getElementById('wsCmdModal');
+  if (m) m.remove();
+}
+
+function saveWorkspaceCommand() {
+  var name = (document.getElementById('wsCmdName') || {}).value || '';
+  var command = (document.getElementById('wsCmdCommand') || {}).value || '';
+  var errEl = document.getElementById('wsCmdError');
+  if (errEl) errEl.textContent = '';
+  fetch('/api/terminal/commands', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: name, command: command })
+  }).then(function (r) { return r.json(); }).then(function (d) {
+    if (!d.ok) { if (errEl) errEl.textContent = d.error || 'Could not save'; return; }
+    document.getElementById('wsCmdName').value = '';
+    document.getElementById('wsCmdCommand').value = '';
+    return _wsLoadCommands().then(_wsRenderCommandsModalBody);
+  }).catch(function () { if (errEl) errEl.textContent = 'Request failed'; });
+}
+
+function deleteWorkspaceCommand(id) {
+  fetch('/api/terminal/commands/' + encodeURIComponent(id), { method: 'DELETE' })
+    .then(function (r) { return r.json(); })
+    .then(function () { return _wsLoadCommands().then(_wsRenderCommandsModalBody); });
+}
+
+function runSavedCommand(id) {
+  var cmd = _wsSavedCommands.find(function (c) { return c.id === id; });
+  var paneId = _wsActivePaneId();
+  if (cmd && paneId) { launchAgentInPane(paneId, cmd.command); closeWorkspaceCommands(); }
+}
+
 // ── mount ───────────────────────────────────────────────────────────────────
 async function renderWorkspace(container) {
   // Idempotent: background refreshes call render() while on this view.
@@ -366,6 +484,7 @@ async function renderWorkspace(container) {
           '<button class="toolbar-btn ws-layout-btn" id="wsLayout-4" title="4 panes (2×2)" aria-label="4 panes" onclick="setWorkspaceLayout(4)">' + _WS_ICON_4 + '</button>' +
         '</div>' +
         '<button class="toolbar-btn" id="wsAddPane" title="Add a pane to this tab" onclick="addWorkspacePane(null)">+ Pane</button>' +
+        '<button class="toolbar-btn" title="Manage saved start commands" onclick="openWorkspaceCommands()">Commands</button>' +
         '<span style="flex:1"></span>' +
         '<span class="workspace-hint">Double-click a tab to rename</span>' +
       '</div>' +
@@ -379,4 +498,5 @@ async function renderWorkspace(container) {
   _wsTabs = [{ id: 't' + (++_wsTabSeq), name: 'Tab 1', panes: [{ id: 'p' + (++_wsPaneSeq), cmd: null }] }];
   _wsActiveTabId = _wsTabs[0].id;
   _wsRenderAll();
+  _wsLoadCommands();
 }

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ const { getHTML } = require('./html');
 const projectsApi = require('./projects');
 const settingsApi = require('./settings');
 const terminal = require('./terminal');
+const workspaceCommands = require('./workspace-commands');
 // Element-level allowlist for launch flags. terminals.js currently only checks
 // for 'skip-permissions'; this set is the surface area we accept from clients.
 const ALLOWED_LAUNCH_FLAGS = new Set(['skip-permissions']);
@@ -169,6 +170,25 @@ function startServer(host, port, openBrowser = true) {
       // what gates the WS shell — see terminal.verifyUpgradeAuth.
       const status = terminal.terminalStatus();
       jsonLog(res, { available: status.available, error: status.error, hint: status.hint, token: terminal.getToken() });
+    }
+
+    // ── Saved Workspace commands (may contain proxy secrets; stored 0600) ──
+    else if (pathname === '/api/terminal/commands' && req.method === 'GET') {
+      jsonLog(res, { commands: workspaceCommands.loadCommands() });
+    }
+    else if (pathname === '/api/terminal/commands' && req.method === 'POST') {
+      readBody(req, (body) => {
+        let data; try { data = JSON.parse(body || '{}'); } catch (e) { data = {}; }
+        workspaceCommands.addCommand(data.name, data.command)
+          .then((cmd) => jsonLog(res, { ok: true, command: cmd }))
+          .catch((err) => jsonLog(res, { ok: false, error: err.message }, 400));
+      });
+    }
+    else if (pathname.startsWith('/api/terminal/commands/') && req.method === 'DELETE') {
+      const id = pathname.slice('/api/terminal/commands/'.length);
+      workspaceCommands.removeCommand(id)
+        .then((list) => jsonLog(res, { ok: true, commands: list }))
+        .catch((err) => jsonLog(res, { ok: false, error: err.message }, 400));
     }
 
     // ── Repo Auto-Refresh API ───────────────

--- a/src/workspace-commands.js
+++ b/src/workspace-commands.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// Saved Workspace commands — user-defined start commands for coding agents,
+// e.g. a proxied launch:
+//   HTTPS_PROXY='http://user:pass@host:port' claude --dangerously-skip-permissions
+//
+// These often embed secrets (proxy credentials), so they live server-side in
+// <CODBASH_SETTINGS_DIR or ~/.codedash>/workspace-commands.json at mode 0600
+// (NOT localStorage, which is readable by any script/extension on the page).
+// Atomic tmp+rename writes serialized through a promise-chain mutex, mirroring
+// settings.js / projects.js.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const MAX_COMMANDS = 100;
+const MAX_NAME = 120;
+const MAX_COMMAND = 8192;
+// Reject control chars except tab (\x09). A newline would let one saved entry
+// inject a second command line silently when typed into the shell.
+const CONTROL_CHARS = /[\x00-\x08\x0A-\x1F\x7F]/;
+
+function dir() {
+  return process.env.CODBASH_SETTINGS_DIR || path.join(os.homedir(), '.codedash');
+}
+function file() {
+  return path.join(dir(), 'workspace-commands.json');
+}
+function ensureDir(d) {
+  if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+}
+
+function sanitizeEntry(e) {
+  if (!e || typeof e !== 'object') return null;
+  const name = typeof e.name === 'string' ? e.name.trim().slice(0, MAX_NAME) : '';
+  const command = typeof e.command === 'string' ? e.command.trim() : '';
+  if (!name || !command || command.length > MAX_COMMAND) return null;
+  if (CONTROL_CHARS.test(command) || CONTROL_CHARS.test(name)) return null;
+  const id = typeof e.id === 'string' && /^[a-f0-9]{12}$/.test(e.id) ? e.id : null;
+  return {
+    id: id || crypto.randomBytes(6).toString('hex'),
+    name: name,
+    command: command,
+    createdAt: typeof e.createdAt === 'string' ? e.createdAt : new Date().toISOString(),
+  };
+}
+
+// Reader tolerates a missing / corrupt file by returning an empty list.
+function loadCommands() {
+  let raw;
+  try { raw = fs.readFileSync(file(), 'utf8'); } catch { return []; }
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch { return []; }
+  const list = parsed && Array.isArray(parsed.commands) ? parsed.commands : [];
+  return list.map(sanitizeEntry).filter(Boolean).slice(0, MAX_COMMANDS);
+}
+
+function writeAtomic(list) {
+  const fp = file();
+  ensureDir(path.dirname(fp));
+  const tmp = fp + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify({ commands: list }, null, 2), { mode: 0o600 });
+  if (process.platform !== 'win32') { try { fs.chmodSync(tmp, 0o600); } catch {} }
+  fs.renameSync(tmp, fp);
+  if (process.platform !== 'win32') { try { fs.chmodSync(fp, 0o600); } catch {} }
+}
+
+let _writeLock = Promise.resolve();
+function withWriteLock(fn) {
+  const next = _writeLock.then(fn, fn);
+  _writeLock = next.catch(() => {});
+  return next;
+}
+
+function addCommand(name, command) {
+  return withWriteLock(() => {
+    const entry = sanitizeEntry({ name: name, command: command });
+    if (!entry) throw new Error('invalid command: name and command required, no newlines');
+    const list = loadCommands();
+    if (list.length >= MAX_COMMANDS) throw new Error('too many saved commands');
+    list.push(entry);
+    writeAtomic(list);
+    return entry;
+  });
+}
+
+function removeCommand(id) {
+  return withWriteLock(() => {
+    const list = loadCommands().filter((c) => c.id !== id);
+    writeAtomic(list);
+    return list;
+  });
+}
+
+module.exports = {
+  loadCommands,
+  addCommand,
+  removeCommand,
+  // exported for tests
+  sanitizeEntry,
+  _file: file,
+};

--- a/test/workspace-commands.test.js
+++ b/test/workspace-commands.test.js
@@ -1,0 +1,69 @@
+// Tests for src/workspace-commands.js — the saved-command store.
+// Uses a temp CODBASH_SETTINGS_DIR so it never touches the real ~/.codedash.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function freshModule() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-wc-'));
+  process.env.CODBASH_SETTINGS_DIR = dir;
+  delete require.cache[require.resolve('../src/workspace-commands')];
+  return { m: require('../src/workspace-commands'), dir };
+}
+
+test('sanitizeEntry accepts a proxied launch command', () => {
+  const { m } = freshModule();
+  const e = m.sanitizeEntry({ name: 'proxy claude', command: "HTTPS_PROXY='http://u:p@1.2.3.4:48921' claude --dangerously-skip-permissions" });
+  assert.ok(e);
+  assert.equal(e.name, 'proxy claude');
+  assert.match(e.id, /^[a-f0-9]{12}$/);
+});
+
+test('sanitizeEntry rejects newlines (command injection), empties, and control chars', () => {
+  const { m } = freshModule();
+  assert.equal(m.sanitizeEntry({ name: 'x', command: 'claude\nrm -rf /' }), null);
+  assert.equal(m.sanitizeEntry({ name: '', command: 'claude' }), null);
+  assert.equal(m.sanitizeEntry({ name: 'x', command: '' }), null);
+  assert.equal(m.sanitizeEntry({ name: 'x', command: 'a\x07b' }), null);
+});
+
+test('addCommand persists and loadCommands returns it', async () => {
+  const { m } = freshModule();
+  const saved = await m.addCommand('cmd one', 'claude');
+  const list = m.loadCommands();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].id, saved.id);
+  assert.equal(list[0].command, 'claude');
+});
+
+test('addCommand rejects an invalid command', async () => {
+  const { m } = freshModule();
+  await assert.rejects(() => m.addCommand('bad', 'a\nb'));
+});
+
+test('removeCommand deletes by id', async () => {
+  const { m } = freshModule();
+  const a = await m.addCommand('a', 'claude');
+  await m.addCommand('b', 'codex');
+  const after = await m.removeCommand(a.id);
+  assert.equal(after.length, 1);
+  assert.equal(after[0].name, 'b');
+});
+
+test('the store file is written 0600 (POSIX)', async () => {
+  if (process.platform === 'win32') return;
+  const { m } = freshModule();
+  await m.addCommand('a', 'claude');
+  const mode = fs.statSync(m._file()).mode & 0o777;
+  assert.equal(mode, 0o600);
+});
+
+test('loadCommands tolerates a missing / corrupt file', () => {
+  const { m, dir } = freshModule();
+  assert.deepEqual(m.loadCommands(), []);
+  fs.writeFileSync(path.join(dir, 'workspace-commands.json'), 'not json{');
+  assert.deepEqual(m.loadCommands(), []);
+});


### PR DESCRIPTION
## What

Save your own agent **start commands** — e.g. a proxied launch:

```
HTTPS_PROXY='http://user:pass@host:port' claude --dangerously-skip-permissions
```

…and fire them into any pane from the per-pane **Launch** menu (under a new "Saved" group). A **Commands** manager lets you add/delete them.

## Where they're stored (and why)

These commands carry secrets (proxy credentials), so they live **server-side** at `~/.codedash/workspace-commands.json`, **mode 0600** — not `localStorage` (which any script/extension on the page can read). In the UI, proxy passwords are **masked** (`://user:****@`); the full value is only ever typed into the pane shell.

## How

- **`src/workspace-commands.js`** — atomic tmp+rename writes behind a promise-chain mutex (mirrors `settings.js`/`projects.js`). Entries reject newlines/control chars so a saved command can't silently inject a second shell line.
- **`server.js`** — `GET` / `POST` / `DELETE /api/terminal/commands`.
- **`workspace.js`** — saved commands populate each pane's Launch menu; the manager modal adds/deletes with masking; launch menus refresh in place; list loads on mount.

## Testing

- 7 new store tests (sanitize / add / remove / 0600 perms / corrupt-file tolerance).
- Browser: saved the exact proxied-`claude` example → appears masked in the manager, present with the **full** value in the Launch menu, persisted to the 0600 file. Full suite **173 pass, 2 skipped, 0 fail**.

## Version

Minor bump `7.8.0` → `7.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)