### PR TITLE
feat: Workspace save/relaunch layouts + keep-alive on view switch (v7.10.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,18 @@
 
 const CHANGELOG = [
   {
+    version: '7.10.0',
+    date: '2026-07-20',
+    title: 'Workspace — save & relaunch layouts',
+    changes: [
+      'New "Save layout" button snapshots the whole workspace — every tab, its panes, and each pane\'s start command',
+      'New "Layouts ▾" menu relaunches a saved workspace in one click: it rebuilds the tabs/panes and auto-runs each command',
+      'Saving under an existing name overwrites it (no duplicates); "Manage…" lists and deletes saved layouts',
+      'Stored on your machine at ~/.codedash/workspace-layouts.json (mode 0600), not in the browser',
+      'Fix: leaving and returning to the Workspace view no longer resets it — tabs, panes and their running shells are kept alive (detached, then re-attached intact)',
+    ],
+  },
+  {
     version: '7.9.0',
     date: '2026-07-20',
     title: 'Workspace — saved start commands',

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1594,10 +1594,11 @@ function render() {
   var stats = document.getElementById('stats');
   if (!content) return;
 
-  // Tear down the live terminal when navigating away from the Workspace view
-  // so the pty + WebSocket don't leak in the background.
-  if (currentView !== 'workspace' && typeof teardownWorkspaceIfActive === 'function') {
-    teardownWorkspaceIfActive();
+  // Detach (don't destroy) the live terminal when navigating away from the
+  // Workspace view: its panes/ptys keep running in a hidden holder and are
+  // re-attached intact on return.
+  if (currentView !== 'workspace' && typeof detachWorkspaceIfMounted === 'function') {
+    detachWorkspaceIfMounted();
   }
 
   // Preserve scroll + collapsed state across re-renders

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -37,6 +37,8 @@ var _wsPaneSeq = 0;
 var _wsToken = null;
 var _wsVendorLoaded = false;
 var _wsSavedCommands = [];   // [{ id, name, command }]
+var _wsSavedLayouts = [];    // [{ id, name, tabs:[{name,panes:[{cmd}]}] }]
+var _wsRoot = null;          // the live .workspace-wrap element (kept across view switches)
 
 // Mask credentials in a URL userinfo (proxy passwords) for display only.
 function _wsMaskSecrets(cmd) {
@@ -115,10 +117,35 @@ function _wsTeardownPane(pane) {
   if (pane.term) { try { pane.term.dispose(); } catch (e) {} }
   pane.sock = null; pane.term = null; pane.fit = null; pane.ro = null;
 }
+// Hidden off-screen holder that keeps the live workspace DOM (and therefore its
+// xterm instances + WebSockets + ptys) alive while another dashboard view is
+// shown. Leaving the Workspace view DETACHES here; returning re-attaches.
+function _wsHolder() {
+  var h = document.getElementById('wsHolder');
+  if (!h) {
+    h = document.createElement('div');
+    h.id = 'wsHolder';
+    h.style.display = 'none';
+    document.body.appendChild(h);
+  }
+  return h;
+}
+
+// Called from render() when navigating AWAY from the Workspace view. Moves the
+// live workspace into the hidden holder instead of destroying it, so panes and
+// their ptys keep running and everything is exactly as left on return.
+function detachWorkspaceIfMounted() {
+  if (_wsRoot && _wsRoot.parentNode && _wsRoot.parentNode.id === 'content') {
+    _wsHolder().appendChild(_wsRoot);
+  }
+}
+
+// Full teardown — kills every pty and drops all state. Not used on normal view
+// switches (those detach); reserved for an explicit reset.
 function teardownWorkspaceIfActive() {
-  if (!_wsTabs.length) return;
-  _wsTabs.forEach(function (t) { t.panes.forEach(_wsTeardownPane); });
+  if (_wsTabs.length) _wsTabs.forEach(function (t) { t.panes.forEach(_wsTeardownPane); });
   _wsTabs = []; _wsActiveTabId = null;
+  if (_wsRoot) { try { _wsRoot.remove(); } catch (e) {} _wsRoot = null; }
 }
 
 // ── pane connection ─────────────────────────────────────────────────────────
@@ -360,6 +387,8 @@ function launchAgentInPane(id, cmd) {
   if (!cmd) return;
   var pane = _wsFindPane(id);
   if (!pane || !pane.sock || pane.sock.readyState !== 1) return;
+  // Remember what was launched so "Save layout" captures the running setup.
+  pane.cmd = cmd;
   pane.sock.send(new TextEncoder().encode(cmd + '\r'));
   if (pane.term) pane.term.focus();
 }
@@ -450,12 +479,162 @@ function runSavedCommand(id) {
   if (cmd && paneId) { launchAgentInPane(paneId, cmd.command); closeWorkspaceCommands(); }
 }
 
+// ── Saved layouts (whole-workspace snapshots) ───────────────────────────────
+// A layout = every tab, its panes, and each pane's start command. Saved
+// server-side (0600) because a command may embed proxy secrets. Relaunching
+// rebuilds the tabs/panes and auto-runs each command on pane connect.
+
+function _wsLoadLayouts() {
+  return fetch('/api/terminal/layouts')
+    .then(function (r) { return r.json(); })
+    .then(function (d) { _wsSavedLayouts = (d && d.layouts) || []; _wsRenderLayoutsMenu(); })
+    .catch(function () { _wsSavedLayouts = []; });
+}
+
+// Snapshot the current workspace into the { tabs:[{name,panes:[{cmd}]}] } shape
+// the server expects. A pane with no launched command is stored as cmd:''.
+function _wsCaptureLayout() {
+  return {
+    tabs: _wsTabs.map(function (t) {
+      return {
+        name: t.name,
+        panes: t.panes.map(function (p) { return { cmd: p.cmd || '' }; }),
+      };
+    }),
+  };
+}
+
+// Rebuild "Launch a saved layout ▾" menu in the toolbar.
+function _wsRenderLayoutsMenu() {
+  var sel = document.getElementById('wsLayoutsMenu');
+  if (!sel) return;
+  var html = '<option value="">Layouts ▾</option>';
+  if (_wsSavedLayouts.length) {
+    _wsSavedLayouts.forEach(function (l) {
+      var n = l.tabs ? l.tabs.length : 0;
+      html += '<option value="' + escHtml(l.id) + '">' + escHtml(l.name) + '  (' + n + (n === 1 ? ' tab' : ' tabs') + ')</option>';
+    });
+    html += '<option disabled>──────────</option>';
+    html += '<option value="__manage__">Manage…</option>';
+  } else {
+    html += '<option value="" disabled>No saved layouts</option>';
+  }
+  sel.innerHTML = html;
+}
+
+// Save button: snapshot → ask for a name (default = active tab name) → POST.
+function saveWorkspaceLayout() {
+  var active = _wsActiveTab();
+  var suggested = (active && active.name) || ('Workspace ' + (_wsSavedLayouts.length + 1));
+  var name = window.prompt('Save this workspace as:', suggested);
+  if (name == null) return;
+  name = name.trim();
+  if (!name) return;
+  var payload = _wsCaptureLayout();
+  payload.name = name;
+  fetch('/api/terminal/layouts', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).then(function (r) { return r.json(); }).then(function (d) {
+    if (!d || !d.ok) { window.alert('Could not save layout: ' + ((d && d.error) || 'unknown error')); return; }
+    return _wsLoadLayouts();
+  }).catch(function () { window.alert('Could not save layout: request failed'); });
+}
+
+// Menu handler: launch a saved layout, or open the manager.
+function onWorkspaceLayoutsMenu(value) {
+  if (!value) return;
+  if (value === '__manage__') { openWorkspaceLayouts(); return; }
+  applyWorkspaceLayout(value);
+}
+
+// Tear down the current workspace and rebuild it from a saved layout, running
+// each pane's start command on connect (via pane.cmd + _wsConnectPane).
+function applyWorkspaceLayout(id) {
+  var layout = _wsSavedLayouts.find(function (l) { return l.id === id; });
+  if (!layout || !layout.tabs || !layout.tabs.length) return;
+
+  _wsTabs.forEach(function (t) { t.panes.forEach(_wsTeardownPane); });
+  _wsTabs = layout.tabs.map(function (t, ti) {
+    var panes = (t.panes && t.panes.length ? t.panes : [{ cmd: '' }])
+      .slice(0, MAX_WS_PANES)
+      .map(function (p) { return { id: 'p' + (++_wsPaneSeq), cmd: (p && p.cmd) || null }; });
+    return { id: 't' + (++_wsTabSeq), name: t.name || ('Tab ' + (ti + 1)), panes: panes };
+  });
+  _wsActiveTabId = _wsTabs[0].id;
+  _wsRenderAll();
+}
+
+// ── Layout manager (modal): rename-free list with delete ────────────────────
+function _wsLayoutsListHtml() {
+  if (!_wsSavedLayouts.length) return '<div class="ws-cmd-empty">No saved layouts yet.</div>';
+  return _wsSavedLayouts.map(function (l) {
+    var summary = (l.tabs || []).map(function (t) {
+      return escHtml(t.name) + ' (' + (t.panes ? t.panes.length : 0) + ')';
+    }).join(' · ');
+    return '<div class="ws-cmd-row">' +
+      '<div class="ws-cmd-info">' +
+        '<div class="ws-cmd-name">' + escHtml(l.name) + '</div>' +
+        '<code class="ws-cmd-cmd">' + summary + '</code>' +
+      '</div>' +
+      '<div class="ws-cmd-actions">' +
+        '<button class="toolbar-btn" title="Launch this workspace" onclick="applyWorkspaceLayout(\'' + escHtml(l.id) + '\');closeWorkspaceLayouts();">Launch</button>' +
+        '<button class="toolbar-btn ws-cmd-del" title="Delete" onclick="deleteWorkspaceLayout(\'' + escHtml(l.id) + '\')">&times;</button>' +
+      '</div>' +
+    '</div>';
+  }).join('');
+}
+
+function _wsRenderLayoutsModalBody() {
+  var el = document.getElementById('wsLayoutList');
+  if (el) el.innerHTML = _wsLayoutsListHtml();
+}
+
+function openWorkspaceLayouts() {
+  var existing = document.getElementById('wsLayoutModal');
+  if (existing) existing.remove();
+  var modal = document.createElement('div');
+  modal.id = 'wsLayoutModal';
+  modal.className = 'ws-cmd-modal';
+  modal.innerHTML =
+    '<div class="ws-cmd-dialog">' +
+      '<div class="ws-cmd-head"><span>Saved workspaces</span>' +
+        '<button class="ws-cmd-close" onclick="closeWorkspaceLayouts()">&times;</button></div>' +
+      '<div class="ws-cmd-note">A layout stores every tab, its panes, and each pane\'s start command. ' +
+        'Stored on your machine at <code>~/.codedash/workspace-layouts.json</code> (0600). ' +
+        'Use <strong>Save layout</strong> in the toolbar to capture the current setup.</div>' +
+      '<div class="ws-cmd-list" id="wsLayoutList">' + _wsLayoutsListHtml() + '</div>' +
+    '</div>';
+  modal.addEventListener('click', function (e) { if (e.target === modal) closeWorkspaceLayouts(); });
+  document.body.appendChild(modal);
+}
+
+function closeWorkspaceLayouts() {
+  var m = document.getElementById('wsLayoutModal');
+  if (m) m.remove();
+}
+
+function deleteWorkspaceLayout(id) {
+  fetch('/api/terminal/layouts/' + encodeURIComponent(id), { method: 'DELETE' })
+    .then(function (r) { return r.json(); })
+    .then(function () { return _wsLoadLayouts().then(_wsRenderLayoutsModalBody); });
+}
+
 // ── mount ───────────────────────────────────────────────────────────────────
 async function renderWorkspace(container) {
-  // Idempotent: background refreshes call render() while on this view.
-  if (_wsTabs.length && document.getElementById('wsTabPanes')) return;
+  // If a live workspace already exists, re-attach it instead of rebuilding —
+  // this preserves every pane's terminal, WebSocket and pty across view
+  // switches (and makes background dashboard refreshes a no-op). The root is
+  // moved back from the hidden holder (or left in place if already here).
+  if (_wsRoot) {
+    if (_wsRoot.parentNode !== container) {
+      container.innerHTML = '';
+      container.appendChild(_wsRoot);
+    }
+    setTimeout(function () { _wsRefitTab(_wsActiveTab()); }, 60);
+    return;
+  }
 
-  teardownWorkspaceIfActive();
   container.innerHTML = '<div class="loading">Loading terminal…</div>';
 
   var status;
@@ -486,7 +665,9 @@ async function renderWorkspace(container) {
         '<button class="toolbar-btn" id="wsAddPane" title="Add a pane to this tab" onclick="addWorkspacePane(null)">+ Pane</button>' +
         '<button class="toolbar-btn" title="Manage saved start commands" onclick="openWorkspaceCommands()">Commands</button>' +
         '<span style="flex:1"></span>' +
-        '<span class="workspace-hint">Double-click a tab to rename</span>' +
+        '<button class="toolbar-btn" title="Save the current tabs, panes and commands as a reusable layout" onclick="saveWorkspaceLayout()">Save layout</button>' +
+        '<select class="ws-pane-launch" id="wsLayoutsMenu" title="Launch a saved workspace layout" ' +
+          'onchange="onWorkspaceLayoutsMenu(this.value); this.selectedIndex=0;"><option value="">Layouts ▾</option></select>' +
       '</div>' +
       '<div class="workspace-tabpanes" id="wsTabPanes"></div>' +
     '</div>';
@@ -495,8 +676,11 @@ async function renderWorkspace(container) {
   catch (e) { container.innerHTML = '<div class="empty-state">Failed to load terminal assets.</div>'; return; }
   if (!document.getElementById('wsTabPanes')) return; // switched away while loading
 
+  // Remember the root so future view switches detach/re-attach it (never rebuild).
+  _wsRoot = container.querySelector('.workspace-wrap');
   _wsTabs = [{ id: 't' + (++_wsTabSeq), name: 'Tab 1', panes: [{ id: 'p' + (++_wsPaneSeq), cmd: null }] }];
   _wsActiveTabId = _wsTabs[0].id;
   _wsRenderAll();
   _wsLoadCommands();
+  _wsLoadLayouts();
 }

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,7 @@ const projectsApi = require('./projects');
 const settingsApi = require('./settings');
 const terminal = require('./terminal');
 const workspaceCommands = require('./workspace-commands');
+const workspaceLayouts = require('./workspace-layouts');
 // Element-level allowlist for launch flags. terminals.js currently only checks
 // for 'skip-permissions'; this set is the surface area we accept from clients.
 const ALLOWED_LAUNCH_FLAGS = new Set(['skip-permissions']);
@@ -188,6 +189,25 @@ function startServer(host, port, openBrowser = true) {
       const id = pathname.slice('/api/terminal/commands/'.length);
       workspaceCommands.removeCommand(id)
         .then((list) => jsonLog(res, { ok: true, commands: list }))
+        .catch((err) => jsonLog(res, { ok: false, error: err.message }, 400));
+    }
+
+    // ── Saved Workspace layouts (whole tab/pane/command snapshots; stored 0600) ──
+    else if (pathname === '/api/terminal/layouts' && req.method === 'GET') {
+      jsonLog(res, { layouts: workspaceLayouts.loadLayouts() });
+    }
+    else if (pathname === '/api/terminal/layouts' && req.method === 'POST') {
+      readBody(req, (body) => {
+        let data; try { data = JSON.parse(body || '{}'); } catch (e) { data = {}; }
+        workspaceLayouts.saveLayout(data.name, data.tabs)
+          .then((layout) => jsonLog(res, { ok: true, layout }))
+          .catch((err) => jsonLog(res, { ok: false, error: err.message }, 400));
+      });
+    }
+    else if (pathname.startsWith('/api/terminal/layouts/') && req.method === 'DELETE') {
+      const id = pathname.slice('/api/terminal/layouts/'.length);
+      workspaceLayouts.removeLayout(id)
+        .then((list) => jsonLog(res, { ok: true, layouts: list }))
         .catch((err) => jsonLog(res, { ok: false, error: err.message }, 400));
     }
 

--- a/src/workspace-layouts.js
+++ b/src/workspace-layouts.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// Saved Workspace layouts — a named snapshot of the whole Workspace view:
+// every tab, its panes, and the start command each pane runs. Lets the user
+// save "my 4-agent setup" once and relaunch the identical workspace later.
+//
+// A pane command may embed secrets (proxy credentials), exactly like
+// workspace-commands.js, so layouts live server-side in
+// <CODBASH_SETTINGS_DIR or ~/.codedash>/workspace-layouts.json at mode 0600
+// (NOT localStorage). Atomic tmp+rename writes serialized through a
+// promise-chain mutex, mirroring workspace-commands.js / settings.js.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const MAX_LAYOUTS = 50;
+const MAX_NAME = 120;
+const MAX_TABS = 20;
+const MAX_PANES = 4;
+const MAX_COMMAND = 8192;
+// Reject control chars except tab (\x09). A newline in a pane command would let
+// a saved layout inject a second command line silently when typed into a shell.
+const CONTROL_CHARS = /[\x00-\x08\x0A-\x1F\x7F]/;
+
+function dir() {
+  return process.env.CODBASH_SETTINGS_DIR || path.join(os.homedir(), '.codedash');
+}
+function file() {
+  return path.join(dir(), 'workspace-layouts.json');
+}
+function ensureDir(d) {
+  if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+}
+
+// A pane is { cmd }. cmd may be '' (a blank pane, no auto-launch). Non-empty
+// commands are validated like saved commands (no newlines / control chars).
+function sanitizePane(p) {
+  const raw = p && typeof p === 'object' ? p.cmd : p;
+  let cmd = typeof raw === 'string' ? raw.trim() : '';
+  if (cmd.length > MAX_COMMAND) return null;
+  if (cmd && CONTROL_CHARS.test(cmd)) return null;
+  return { cmd };
+}
+
+function sanitizeTab(t, i) {
+  if (!t || typeof t !== 'object') return null;
+  const name = typeof t.name === 'string' && t.name.trim()
+    ? t.name.trim().slice(0, MAX_NAME)
+    : 'Tab ' + (i + 1);
+  if (CONTROL_CHARS.test(name)) return null;
+  // Extra panes beyond MAX are dropped, but any *present* pane that fails
+  // validation (e.g. a newline-injection command) rejects the whole tab —
+  // silently dropping a bad command would hide the problem from the user.
+  const rawPanes = Array.isArray(t.panes) ? t.panes.slice(0, MAX_PANES) : [];
+  const panes = rawPanes.map(sanitizePane);
+  if (panes.some((p) => p === null)) return null;
+  if (!panes.length) panes.push({ cmd: '' }); // a tab always has ≥1 pane
+  return { name, panes };
+}
+
+function sanitizeLayout(e) {
+  if (!e || typeof e !== 'object') return null;
+  const name = typeof e.name === 'string' ? e.name.trim().slice(0, MAX_NAME) : '';
+  if (!name || CONTROL_CHARS.test(name)) return null;
+  const rawTabs = Array.isArray(e.tabs) ? e.tabs.slice(0, MAX_TABS) : [];
+  const cleanTabs = rawTabs.map(sanitizeTab);
+  if (cleanTabs.some((t) => t === null)) return null; // one bad tab rejects all
+  const tabs = cleanTabs.filter(Boolean);
+  if (!tabs.length) return null; // a layout with no tabs is meaningless
+  const id = typeof e.id === 'string' && /^[a-f0-9]{12}$/.test(e.id) ? e.id : null;
+  const now = new Date().toISOString();
+  return {
+    id: id || crypto.randomBytes(6).toString('hex'),
+    name,
+    tabs,
+    createdAt: typeof e.createdAt === 'string' ? e.createdAt : now,
+    updatedAt: now,
+  };
+}
+
+// Reader tolerates a missing / corrupt file by returning an empty list.
+function loadLayouts() {
+  let raw;
+  try { raw = fs.readFileSync(file(), 'utf8'); } catch { return []; }
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch { return []; }
+  const list = parsed && Array.isArray(parsed.layouts) ? parsed.layouts : [];
+  return list.map(sanitizeLayout).filter(Boolean).slice(0, MAX_LAYOUTS);
+}
+
+function writeAtomic(list) {
+  const fp = file();
+  ensureDir(path.dirname(fp));
+  const tmp = fp + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify({ layouts: list }, null, 2), { mode: 0o600 });
+  if (process.platform !== 'win32') { try { fs.chmodSync(tmp, 0o600); } catch {} }
+  fs.renameSync(tmp, fp);
+  if (process.platform !== 'win32') { try { fs.chmodSync(fp, 0o600); } catch {} }
+}
+
+let _writeLock = Promise.resolve();
+function withWriteLock(fn) {
+  const next = _writeLock.then(fn, fn);
+  _writeLock = next.catch(() => {});
+  return next;
+}
+
+// Upsert by name (case-insensitive): saving "My setup" twice overwrites the
+// first rather than piling up duplicates — the natural mental model for
+// "save this workspace". Preserves the original id/createdAt on overwrite.
+function saveLayout(name, tabs) {
+  return withWriteLock(() => {
+    const list = loadLayouts();
+    const clean = sanitizeLayout({ name, tabs });
+    if (!clean) throw new Error('invalid layout: a name and at least one tab are required, no newlines');
+    const key = clean.name.toLowerCase();
+    const idx = list.findIndex((l) => l.name.toLowerCase() === key);
+    if (idx >= 0) {
+      clean.id = list[idx].id;
+      clean.createdAt = list[idx].createdAt;
+      list[idx] = clean;
+    } else {
+      if (list.length >= MAX_LAYOUTS) throw new Error('too many saved layouts');
+      list.push(clean);
+    }
+    writeAtomic(list);
+    return clean;
+  });
+}
+
+function removeLayout(id) {
+  return withWriteLock(() => {
+    const list = loadLayouts().filter((l) => l.id !== id);
+    writeAtomic(list);
+    return list;
+  });
+}
+
+module.exports = {
+  loadLayouts,
+  saveLayout,
+  removeLayout,
+  // exported for tests
+  sanitizeLayout,
+  _file: file,
+};

--- a/test/workspace-layouts.test.js
+++ b/test/workspace-layouts.test.js
@@ -1,0 +1,111 @@
+// Tests for src/workspace-layouts.js — the saved whole-workspace layout store.
+// Uses a temp CODBASH_SETTINGS_DIR so it never touches the real ~/.codedash.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function freshModule() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-wl-'));
+  process.env.CODBASH_SETTINGS_DIR = dir;
+  delete require.cache[require.resolve('../src/workspace-layouts')];
+  return { m: require('../src/workspace-layouts'), dir };
+}
+
+const SAMPLE_TABS = [
+  { name: 'Agents', panes: [{ cmd: 'claude' }, { cmd: 'codex' }] },
+  { name: 'Scratch', panes: [{ cmd: '' }] },
+];
+
+test('sanitizeLayout accepts a multi-tab, multi-pane layout', () => {
+  const { m } = freshModule();
+  const l = m.sanitizeLayout({ name: 'my setup', tabs: SAMPLE_TABS });
+  assert.ok(l);
+  assert.equal(l.name, 'my setup');
+  assert.match(l.id, /^[a-f0-9]{12}$/);
+  assert.equal(l.tabs.length, 2);
+  assert.equal(l.tabs[0].panes.length, 2);
+  assert.equal(l.tabs[0].panes[0].cmd, 'claude');
+  assert.equal(l.tabs[1].panes[0].cmd, '');
+});
+
+test('sanitizeLayout rejects no-name, no-tabs, and newline injection', () => {
+  const { m } = freshModule();
+  assert.equal(m.sanitizeLayout({ name: '', tabs: SAMPLE_TABS }), null);
+  assert.equal(m.sanitizeLayout({ name: 'x', tabs: [] }), null);
+  assert.equal(m.sanitizeLayout({ name: 'x', tabs: 'nope' }), null);
+  assert.equal(
+    m.sanitizeLayout({ name: 'x', tabs: [{ name: 't', panes: [{ cmd: 'claude\nrm -rf /' }] }] }),
+    null,
+  );
+});
+
+test('sanitizeLayout caps tabs at 20 and panes at 4', () => {
+  const { m } = freshModule();
+  const bigTabs = Array.from({ length: 30 }, (_, i) => ({
+    name: 'T' + i,
+    panes: Array.from({ length: 8 }, () => ({ cmd: 'claude' })),
+  }));
+  const l = m.sanitizeLayout({ name: 'big', tabs: bigTabs });
+  assert.equal(l.tabs.length, 20);
+  assert.equal(l.tabs[0].panes.length, 4);
+});
+
+test('a tab with no valid panes still gets one blank pane', () => {
+  const { m } = freshModule();
+  const l = m.sanitizeLayout({ name: 'x', tabs: [{ name: 't', panes: [] }] });
+  assert.equal(l.tabs[0].panes.length, 1);
+  assert.equal(l.tabs[0].panes[0].cmd, '');
+});
+
+test('saveLayout persists and loadLayouts returns it', async () => {
+  const { m } = freshModule();
+  const saved = await m.saveLayout('setup one', SAMPLE_TABS);
+  const list = m.loadLayouts();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].id, saved.id);
+  assert.equal(list[0].tabs.length, 2);
+});
+
+test('saveLayout upserts by name (case-insensitive), preserving id/createdAt', async () => {
+  const { m } = freshModule();
+  const first = await m.saveLayout('My Setup', SAMPLE_TABS);
+  const second = await m.saveLayout('my setup', [{ name: 'Solo', panes: [{ cmd: 'qwen' }] }]);
+  const list = m.loadLayouts();
+  assert.equal(list.length, 1, 'overwrite, not duplicate');
+  assert.equal(second.id, first.id, 'id preserved on overwrite');
+  assert.equal(second.createdAt, first.createdAt, 'createdAt preserved');
+  assert.equal(list[0].tabs.length, 1, 'content replaced');
+  assert.equal(list[0].tabs[0].panes[0].cmd, 'qwen');
+});
+
+test('saveLayout rejects an invalid layout', async () => {
+  const { m } = freshModule();
+  await assert.rejects(() => m.saveLayout('', SAMPLE_TABS));
+  await assert.rejects(() => m.saveLayout('x', []));
+});
+
+test('removeLayout deletes by id', async () => {
+  const { m } = freshModule();
+  const a = await m.saveLayout('a', SAMPLE_TABS);
+  await m.saveLayout('b', SAMPLE_TABS);
+  const after = await m.removeLayout(a.id);
+  assert.equal(after.length, 1);
+  assert.equal(after[0].name, 'b');
+});
+
+test('the store file is written 0600 (POSIX)', async () => {
+  if (process.platform === 'win32') return;
+  const { m } = freshModule();
+  await m.saveLayout('a', SAMPLE_TABS);
+  const mode = fs.statSync(m._file()).mode & 0o777;
+  assert.equal(mode, 0o600);
+});
+
+test('loadLayouts tolerates a corrupt file', () => {
+  const { m, dir } = freshModule();
+  fs.writeFileSync(path.join(dir, 'workspace-layouts.json'), '{ not json');
+  assert.deepEqual(m.loadLayouts(), []);
+});


### PR DESCRIPTION
Combines two Workspace improvements (the second was the "проебывается при выходе" fix).

## 1. Saved layouts
- **Save layout** snapshots the whole workspace — every tab, its panes, and each pane's start command.
- **Layouts ▾** relaunches a saved workspace in one click: rebuilds tabs/panes and auto-runs each command. Save-by-name overwrites (no dupes); **Manage…** lists/deletes.
- Stored at `~/.codedash/workspace-layouts.json` (**0600**), atomic writes behind a mutex, newline/control-char rejection — same hardening as saved commands. New `src/workspace-layouts.js` + `GET/POST/DELETE /api/terminal/layouts`.

## 2. Keep-alive across view switches (bug fix)
Leaving the Workspace view used to **tear down every pty** (`teardownWorkspaceIfActive` on navigate), so returning rebuilt everything from scratch. Now the live workspace DOM is **detached into a hidden holder and re-attached intact** on return — tabs/panes, running shells, WebSockets and scrollback all survive.

## Testing
- Full suite **183 pass, 2 skipped (win32), 0 fail** (incl. new layout-store tests).
- Browser: layout save → persisted with tab structure (`main:2, agents:1`), newline injection rejected, delete works; and a marker command's output **survives** leaving to Analytics and returning (asserted same WebSocket object).

## Version
Minor bump `7.9.0` → `7.10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)