### PR TITLE
feat: Workspace status bar + focused pane, Overview landing, tidy sidebar (v7.12.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.10.1",
+  "version": "7.11.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.11.0",
+  "version": "7.12.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,12 +2,14 @@
 
 const CHANGELOG = [
   {
-    version: '7.10.1',
+    version: '7.11.0',
     date: '2026-07-20',
-    title: 'Workspace — focused pane targeting',
+    title: 'Workspace — live status bar + focused pane',
     changes: [
-      'Click a pane to focus it — it gets a blue border, and launched agents / saved commands now go to THAT pane instead of always the first one',
-      'The active pane is highlighted so it is always clear where a command will land',
+      'A live terminal status bar now sits at the very top whenever terminals are running — visible from any view, showing each pane\'s state (active / idle / limit / exited), its tab and command',
+      'Account-limit detection: when an agent hits a rate/usage limit, its pane is flagged "limit" in the bar (heuristic on output)',
+      'Click any status chip to jump straight to that pane',
+      'Click a pane to focus it (blue border) — launched agents / saved commands now go to THAT pane instead of always the first one',
     ],
   },
   {

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -10,6 +10,7 @@ const CHANGELOG = [
       'Click any terminal card to jump straight into that pane in the Workspace',
       'Cards refresh live — status (active / idle / limit / exited) updates as your agents run',
       'The sidebar now starts with every section collapsed, so the Overview stays the focus; open only the sections you use and the app remembers your choice',
+      'Fix: the update check could hang on a stalled npm registry instead of failing gracefully — the request now times out cleanly so the "update available" notification reappears reliably',
     ],
   },
   {

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,15 @@
 
 const CHANGELOG = [
   {
+    version: '7.10.1',
+    date: '2026-07-20',
+    title: 'Workspace — focused pane targeting',
+    changes: [
+      'Click a pane to focus it — it gets a blue border, and launched agents / saved commands now go to THAT pane instead of always the first one',
+      'The active pane is highlighted so it is always clear where a command will land',
+    ],
+  },
+  {
     version: '7.10.0',
     date: '2026-07-20',
     title: 'Workspace — save & relaunch layouts',

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,17 @@
 
 const CHANGELOG = [
   {
+    version: '7.12.0',
+    date: '2026-07-20',
+    title: 'Overview landing + tidy sidebar',
+    changes: [
+      'New "Overview" view is now the landing screen — your workspace at a glance: every running terminal as a live card (tab, status, command, folder), plus quick actions to open a terminal, relaunch a saved layout or fire a saved command',
+      'Click any terminal card to jump straight into that pane in the Workspace',
+      'Cards refresh live — status (active / idle / limit / exited) updates as your agents run',
+      'The sidebar now starts with every section collapsed, so the Overview stays the focus; open only the sections you use and the app remembers your choice',
+    ],
+  },
+  {
     version: '7.11.0',
     date: '2026-07-20',
     title: 'Workspace — live status bar + focused pane',

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -5,7 +5,7 @@
 
 let allSessions = [];
 let filteredSessions = [];
-let currentView = 'sessions';  // sessions, projects, timeline, activity, starred
+let currentView = 'overview';  // overview (landing), sessions, projects, timeline, activity, starred
 let grouped = true;
 let layout = localStorage.getItem('codedash-layout') || 'grid'; // 'grid' or 'list'
 let groupingMode = normalizeGroupingMode(localStorage.getItem('codedash-grouping-mode'));
@@ -1674,6 +1674,11 @@ function render() {
 
   if (currentView === 'workspace') {
     renderWorkspace(content);
+    return;
+  }
+
+  if (currentView === 'overview') {
+    renderOverview(content);
     return;
   }
 

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -29,13 +29,19 @@
     // Defer to DOM-ready so .sidebar-group nodes exist. Script is placed
     // before <div class="sidebar">, so we use a microtask via setTimeout(0).
     document.addEventListener('DOMContentLoaded', function () {
+      // Sections start collapsed in the markup. Apply stored collapsed=true as
+      // well, and — importantly — EXPAND sections the user explicitly opened
+      // (stored collapsed=false) so their choice survives without a flash.
       Object.keys(collapsed).forEach(function (id) {
-        if (collapsed[id] !== true) return;
         var group = document.querySelector('.sidebar-group[data-section="' + id.replace(/"/g, '') + '"]');
-        if (group) {
+        if (!group) return;
+        var hdr = group.querySelector(':scope > .sidebar-section-header');
+        if (collapsed[id] === true) {
           group.classList.add('collapsed');
-          var hdr = group.querySelector(':scope > .sidebar-section-header');
           if (hdr) hdr.setAttribute('aria-expanded', 'false');
+        } else if (collapsed[id] === false) {
+          group.classList.remove('collapsed');
+          if (hdr) hdr.setAttribute('aria-expanded', 'true');
         }
       });
     });
@@ -50,14 +56,20 @@
         <span class="version-badge" id="versionBadge"></span>
     </div>
 
+    <!-- Overview — always-visible landing (sits above the collapsible groups) -->
+    <div class="sidebar-item active" data-view="overview" data-key="overview">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
+        Overview
+    </div>
+
     <!-- Workspace section -->
-    <div class="sidebar-group" data-section="workspace">
-        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="workspace" aria-expanded="true" aria-controls="sidebarSectionWorkspace">
+    <div class="sidebar-group collapsed" data-section="workspace">
+        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="workspace" aria-expanded="false" aria-controls="sidebarSectionWorkspace">
             <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
             <span>Workspace</span>
         </button>
         <div class="sidebar-section-body" id="sidebarSectionWorkspace">
-            <div class="sidebar-item active" data-view="sessions">
+            <div class="sidebar-item" data-view="sessions">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
                 All Sessions
             </div>
@@ -101,8 +113,8 @@
     </div>
 
     <!-- Agents section -->
-    <div class="sidebar-group" data-section="agents">
-        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="agents" aria-expanded="true" aria-controls="sidebarSectionAgents">
+    <div class="sidebar-group collapsed" data-section="agents">
+        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="agents" aria-expanded="false" aria-controls="sidebarSectionAgents">
             <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
             <span>Agents</span>
         </button>
@@ -159,8 +171,8 @@
     </div>
 
     <!-- Tools section -->
-    <div class="sidebar-group" data-section="tools">
-        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="tools" aria-expanded="true" aria-controls="sidebarSectionTools">
+    <div class="sidebar-group collapsed" data-section="tools">
+        <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="tools" aria-expanded="false" aria-controls="sidebarSectionTools">
             <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
             <span>Tools</span>
         </button>

--- a/src/frontend/overview.js
+++ b/src/frontend/overview.js
@@ -1,0 +1,98 @@
+// Overview — the landing "workspace at a glance": running terminals (with live
+// status) + quick actions (new terminal, launch a saved layout / command).
+// Reads the live workspace state from workspace.js (loaded before this file).
+
+function _ovPanes() {
+  if (typeof _wsAllPanes !== 'function') return [];
+  return _wsAllPanes().filter(function (x) { return x.pane.sock || x.pane.exited; });
+}
+
+function renderOverview(container) {
+  // Make sure saved lists are available even if the terminal was never opened.
+  if (typeof _wsLoadCommands === 'function' && (!window._wsSavedCommands || !_wsSavedCommands.length)) _wsLoadCommands();
+  if (typeof _wsLoadLayouts === 'function' && (!window._wsSavedLayouts || !_wsSavedLayouts.length)) _wsLoadLayouts();
+  // Keep the status loop ticking so cards refresh even before Workspace mounts.
+  if (typeof _wsStartStatusLoop === 'function') _wsStartStatusLoop();
+
+  var panes = _ovPanes();
+  var html = '<div class="ov-wrap" id="ovWrap">';
+  html += '<div class="ov-head">' +
+    '<h2 class="heatmap-title">Workspace</h2>' +
+    '<button class="toolbar-btn ov-primary" onclick="overviewNewTerminal()">+ New terminal</button>' +
+    '</div>';
+
+  html += '<div class="ov-section-title">Terminals</div>';
+  if (!panes.length) {
+    html += '<div class="empty-state" style="text-align:left;max-width:460px">' +
+      'No terminals running yet. Open one to run shells and agents right here — ' +
+      'sessions survive switching views.<br><br>' +
+      '<button class="toolbar-btn ov-primary" onclick="overviewNewTerminal()">Open a terminal</button></div>';
+  } else {
+    html += '<div class="ov-grid">';
+    panes.forEach(function (x) {
+      var st = (typeof _wsPaneStatus === 'function') ? _wsPaneStatus(x.pane) : 'idle';
+      var meta = (window.WS_STATUS_META && WS_STATUS_META[st]) || { label: st, cls: st };
+      var cmd = x.pane.cmd || 'shell';
+      var masked = (typeof _wsMaskSecrets === 'function') ? _wsMaskSecrets(cmd) : cmd;
+      html += '<button class="ov-card ' + meta.cls + '" ' +
+        'onclick="jumpToWorkspacePane(\'' + escHtml(x.tab.id) + '\',\'' + escHtml(x.pane.id) + '\')">' +
+        '<div class="ov-card-top"><span class="ov-dot"></span>' +
+        '<span class="ov-tab">' + escHtml(x.tab.name) + '</span>' +
+        '<span class="ov-st">' + escHtml(meta.label) + '</span></div>' +
+        '<div class="ov-cmd">' + escHtml(masked) + '</div>' +
+        '<div class="ov-cwd">' + escHtml(x.pane.cwd || '~') + '</div>' +
+        '</button>';
+    });
+    html += '</div>';
+  }
+
+  if (window._wsSavedLayouts && _wsSavedLayouts.length) {
+    html += '<div class="ov-section-title">Saved layouts</div><div class="ov-chips">';
+    _wsSavedLayouts.forEach(function (l) {
+      html += '<button class="toolbar-btn" onclick="overviewLaunchLayout(\'' + escHtml(l.id) + '\')">▸ ' + escHtml(l.name) + '</button>';
+    });
+    html += '</div>';
+  }
+
+  if (window._wsSavedCommands && _wsSavedCommands.length) {
+    html += '<div class="ov-section-title">Saved commands</div><div class="ov-chips">';
+    _wsSavedCommands.forEach(function (c) {
+      var masked = (typeof _wsMaskSecrets === 'function') ? _wsMaskSecrets(c.command) : c.command;
+      html += '<button class="toolbar-btn" title="' + escHtml(masked) + '" onclick="overviewRunCommand(\'' + escHtml(c.id) + '\')">▸ ' + escHtml(c.name) + '</button>';
+    });
+    html += '</div>';
+  }
+
+  html += '</div>';
+  container.innerHTML = html;
+}
+
+// Live refresh: re-render while Overview is the current view (cheap — a few
+// cards). Called from the workspace status loop.
+function _ovRefreshIfCurrent() {
+  if (typeof currentView !== 'undefined' && currentView === 'overview') {
+    var c = document.getElementById('content');
+    if (c && document.getElementById('ovWrap')) renderOverview(c);
+  }
+}
+
+function overviewNewTerminal() {
+  var had = (window._wsTabs && _wsTabs.length) || 0;
+  if (typeof setView === 'function') setView('workspace');
+  setTimeout(function () { if (had && typeof addWorkspaceTab === 'function') addWorkspaceTab(); }, 90);
+}
+
+function overviewLaunchLayout(id) {
+  if (typeof setView === 'function') setView('workspace');
+  setTimeout(function () { if (typeof applyWorkspaceLayout === 'function') applyWorkspaceLayout(id); }, 90);
+}
+
+function overviewRunCommand(id) {
+  if (typeof setView === 'function') setView('workspace');
+  setTimeout(function () {
+    var c = (window._wsSavedCommands || []).find(function (x) { return x.id === id; });
+    if (!c || !_wsTabs.length) return;
+    var pid = (typeof _wsActivePaneId === 'function') ? _wsActivePaneId() : null;
+    if (pid && typeof launchAgentInPane === 'function') launchAgentInPane(pid, c.command);
+  }, 160);
+}

--- a/src/frontend/sidebar-config.js
+++ b/src/frontend/sidebar-config.js
@@ -29,6 +29,8 @@
   var BLOCKED_KEYS = { '__proto__': true, 'constructor': true, 'prototype': true };
 
   var KNOWN_ITEM_KEYS = [
+    // Landing
+    'overview',
     // Workspace
     'sessions', 'workspace', 'projects', 'timeline', 'activity', 'running',
     'analytics', 'starred', 'leaderboard', 'cloud',
@@ -42,7 +44,12 @@
     'install:kiro', 'install:opencode', 'install:kilo', 'install:copilot'
   ];
 
+  // Top-level sections start collapsed for a clean landing; users who expand
+  // them have that choice persisted (isSectionCollapsed honors stored values).
   var DEFAULT_COLLAPSED = {
+    'workspace': true,
+    'agents': true,
+    'tools': true,
     'install-agents': true
   };
 
@@ -52,6 +59,7 @@
   // by the sidebar-config unit test (every KNOWN_ITEM_KEY must have help).
   var NAV_HELP = {
     // Workspace
+    'overview': 'Your workspace at a glance — running terminals and quick actions',
     'sessions': 'Every AI coding session across all agents, in one place',
     'workspace': 'A live terminal in your browser — run shells and agents without leaving codbash',
     'projects': 'Browse sessions grouped by project folder',

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2831,6 +2831,41 @@ body {
 
 .workspace-tabpanes { flex: 1; min-height: 0; display: flex; }
 
+/* ── Global terminal status bar (top of .main, shown when terminals run) ── */
+.ws-statusbar {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 6px 14px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    flex-shrink: 0;
+}
+.ws-sb-summary { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.ws-sb-title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); }
+.ws-sb-count { font-size: 12px; font-weight: 700; color: var(--text-primary); }
+.ws-sb-tag { font-size: 10px; padding: 1px 6px; border-radius: 10px; }
+.ws-sb-tag.active { color: var(--accent-green); background: rgba(0,255,136,0.12); }
+.ws-sb-tag.limit { color: var(--accent-red); background: rgba(248,113,113,0.14); }
+.ws-sb-tag.exited { color: var(--text-muted); background: rgba(148,153,165,0.12); }
+.ws-sb-chips { display: flex; align-items: center; gap: 6px; }
+.ws-chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 9px; font-size: 11px;
+    background: var(--bg-card); color: var(--text-secondary);
+    border: 1px solid var(--border); border-radius: 20px; cursor: pointer; white-space: nowrap;
+}
+.ws-chip:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.ws-chip-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-muted); flex-shrink: 0; }
+.ws-chip.active .ws-chip-dot { background: var(--accent-green); box-shadow: 0 0 5px var(--accent-green); }
+.ws-chip.limit .ws-chip-dot { background: var(--accent-red); }
+.ws-chip.exited .ws-chip-dot { background: var(--text-muted); opacity: 0.5; }
+.ws-chip-st { font-size: 9px; text-transform: uppercase; letter-spacing: 0.4px; color: var(--text-muted); }
+.ws-chip.active .ws-chip-st { color: var(--accent-green); }
+.ws-chip.limit { border-color: var(--accent-red); }
+.ws-chip.limit .ws-chip-st { color: var(--accent-red); }
+
 /* Saved-commands manager modal */
 .ws-cmd-modal {
     position: fixed; inset: 0; z-index: 300;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2896,6 +2896,9 @@ body {
     overflow: hidden;
     background: #08090c;
 }
+/* The pane the user is "in": launched commands / resume land here. */
+.ws-pane.focused { border-color: var(--accent-blue); box-shadow: 0 0 0 1px var(--accent-blue); }
+.ws-pane.focused .ws-pane-bar { background: color-mix(in srgb, var(--accent-blue) 14%, var(--bg-secondary)); }
 .ws-pane-bar {
     display: flex;
     align-items: center;

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2831,6 +2831,35 @@ body {
 
 .workspace-tabpanes { flex: 1; min-height: 0; display: flex; }
 
+/* ── Overview landing ── */
+.ov-wrap { padding: 24px; max-width: 900px; }
+.ov-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.ov-primary { border-color: var(--accent-blue); color: var(--accent-blue); }
+.ov-section-title {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--text-muted); margin: 22px 0 10px;
+}
+.ov-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
+.ov-card {
+    display: flex; flex-direction: column; gap: 6px; text-align: left;
+    padding: 14px; background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 12px; cursor: pointer; transition: border-color 0.15s;
+}
+.ov-card:hover { border-color: var(--accent-blue); }
+.ov-card.limit { border-color: var(--accent-red); }
+.ov-card-top { display: flex; align-items: center; gap: 8px; }
+.ov-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); }
+.ov-card.active .ov-dot { background: var(--accent-green); box-shadow: 0 0 6px var(--accent-green); }
+.ov-card.limit .ov-dot { background: var(--accent-red); }
+.ov-card.exited .ov-dot { opacity: 0.5; }
+.ov-tab { font-weight: 600; color: var(--text-primary); font-size: 13px; flex: 1; }
+.ov-st { font-size: 9px; text-transform: uppercase; letter-spacing: 0.4px; color: var(--text-muted); }
+.ov-card.active .ov-st { color: var(--accent-green); }
+.ov-card.limit .ov-st { color: var(--accent-red); }
+.ov-cmd { font-family: Menlo, Monaco, monospace; font-size: 12px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ov-cwd { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ov-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+
 /* ── Global terminal status bar (top of .main, shown when terminals run) ── */
 .ws-statusbar {
     display: flex;

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -124,7 +124,11 @@ function _wsUpdateStatusBar() {
 
 function _wsStartStatusLoop() {
   if (_wsStatusTimer) return;
-  _wsStatusTimer = setInterval(_wsUpdateStatusBar, 1000);
+  _wsStatusTimer = setInterval(function () {
+    _wsUpdateStatusBar();
+    // Keep the Overview landing's cards live too.
+    if (typeof _ovRefreshIfCurrent === 'function') _ovRefreshIfCurrent();
+  }, 1000);
 }
 
 // Jump from a status chip to that pane: show Workspace, activate its tab, focus it.

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -50,6 +50,96 @@ function _wsSetFocusedPane(id) {
   });
 }
 
+// ── Live status (top bar) ───────────────────────────────────────────────────
+// Account-limit cues we can spot in agent output (heuristic, extend freely).
+var WS_LIMIT_RE = /rate.?limit|usage limit|too many requests|\b429\b|quota (?:exceeded|reached)|limit reached|overloaded|insufficient.*(?:quota|credit)/i;
+var _wsStatusTimer = null;
+
+function _wsNow() { try { return performance.now(); } catch (e) { return 0; } }
+
+// Per-pane status: exited > limit > active (recent output) > idle.
+function _wsPaneStatus(pane) {
+  if (pane.exited || (pane.sock && pane.sock.readyState > 1)) return 'exited';
+  if (pane.flaggedLimit) return 'limit';
+  if (pane.lastOutputAt && (_wsNow() - pane.lastOutputAt) < 2500) return 'active';
+  return 'idle';
+}
+
+var WS_STATUS_META = {
+  active: { label: 'active', cls: 'active' },
+  idle: { label: 'idle', cls: 'idle' },
+  limit: { label: 'limit', cls: 'limit' },
+  exited: { label: 'exited', cls: 'exited' },
+};
+
+function _wsAllPanes() {
+  var out = [];
+  _wsTabs.forEach(function (t) { t.panes.forEach(function (p) { out.push({ tab: t, pane: p }); }); });
+  return out;
+}
+
+// The bar lives at the very top of .main so it shows on every view (not just
+// Workspace). It appears only while there are live terminal panes.
+function _wsEnsureStatusBar() {
+  var bar = document.getElementById('wsStatusBar');
+  if (bar) return bar;
+  var main = document.querySelector('.main');
+  if (!main) return null;
+  bar = document.createElement('div');
+  bar.id = 'wsStatusBar';
+  bar.className = 'ws-statusbar';
+  bar.style.display = 'none';
+  main.insertBefore(bar, main.firstChild);
+  return bar;
+}
+
+function _wsUpdateStatusBar() {
+  var bar = _wsEnsureStatusBar();
+  if (!bar) return;
+  var items = _wsAllPanes().filter(function (x) { return x.pane.sock || x.pane.exited; });
+  if (!items.length) { bar.style.display = 'none'; bar.innerHTML = ''; return; }
+
+  var counts = { active: 0, idle: 0, limit: 0, exited: 0 };
+  var chips = items.map(function (x) {
+    var st = _wsPaneStatus(x.pane);
+    counts[st]++;
+    var meta = WS_STATUS_META[st];
+    var cmd = x.pane.cmd ? x.pane.cmd.split(/\s+/)[0].replace(/^\w+=.*/, '') || x.pane.cmd : 'shell';
+    var label = escHtml(x.tab.name) + ' · ' + escHtml(cmd);
+    return '<button class="ws-chip ' + meta.cls + '" title="' + escHtml(x.pane.cwd || '') + '" ' +
+      'onclick="jumpToWorkspacePane(\'' + escHtml(x.tab.id) + '\',\'' + escHtml(x.pane.id) + '\')">' +
+      '<span class="ws-chip-dot"></span>' + label +
+      '<span class="ws-chip-st">' + meta.label + '</span></button>';
+  }).join('');
+
+  var summary = '<span class="ws-sb-title">Terminals</span>' +
+    '<span class="ws-sb-count">' + items.length + '</span>' +
+    (counts.active ? '<span class="ws-sb-tag active">' + counts.active + ' active</span>' : '') +
+    (counts.limit ? '<span class="ws-sb-tag limit">' + counts.limit + ' limit</span>' : '') +
+    (counts.exited ? '<span class="ws-sb-tag exited">' + counts.exited + ' exited</span>' : '');
+
+  bar.innerHTML = '<div class="ws-sb-summary">' + summary + '</div><div class="ws-sb-chips">' + chips + '</div>';
+  bar.style.display = 'flex';
+}
+
+function _wsStartStatusLoop() {
+  if (_wsStatusTimer) return;
+  _wsStatusTimer = setInterval(_wsUpdateStatusBar, 1000);
+}
+
+// Jump from a status chip to that pane: show Workspace, activate its tab, focus it.
+function jumpToWorkspacePane(tabId, paneId) {
+  if (typeof setView === 'function') setView('workspace');
+  setTimeout(function () {
+    activateWorkspaceTab(tabId);
+    _wsSetFocusedPane(paneId);
+    var host = document.getElementById('wsTermHost-' + paneId);
+    var pane = _wsFindPane(paneId);
+    if (pane && pane.term) { try { pane.term.focus(); } catch (e) {} }
+    if (host && host.scrollIntoView) host.scrollIntoView({ block: 'nearest' });
+  }, 30);
+}
+
 // Mask credentials in a URL userinfo (proxy passwords) for display only.
 function _wsMaskSecrets(cmd) {
   return String(cmd).replace(/(:\/\/[^:/@\s]+:)[^@\s]+(@)/g, '$1****$2');
@@ -156,6 +246,8 @@ function teardownWorkspaceIfActive() {
   if (_wsTabs.length) _wsTabs.forEach(function (t) { t.panes.forEach(_wsTeardownPane); });
   _wsTabs = []; _wsActiveTabId = null;
   if (_wsRoot) { try { _wsRoot.remove(); } catch (e) {} _wsRoot = null; }
+  if (_wsStatusTimer) { clearInterval(_wsStatusTimer); _wsStatusTimer = null; }
+  _wsUpdateStatusBar();
 }
 
 // ── pane connection ─────────────────────────────────────────────────────────
@@ -192,22 +284,29 @@ function _wsConnectPane(pane) {
   pane.sock = sock;
 
   var enc = new TextEncoder();
+  var dec = new TextDecoder();
   function setStatus(txt) { var el = document.getElementById('wsStatus-' + pane.id); if (el) el.textContent = txt; }
 
-  sock.onopen = function () { setStatus('connected'); };
+  sock.onopen = function () { setStatus('connected'); pane.exited = false; };
   sock.onmessage = function (ev) {
     if (typeof ev.data === 'string') {
       var msg; try { msg = JSON.parse(ev.data); } catch (e) { return; }
       if (msg.t === 'ready') {
+        pane.cwd = msg.cwd;
         setStatus(_wsShortCwd(msg.cwd));
         if (pane.cmd) setTimeout(function () { if (sock.readyState === 1) sock.send(enc.encode(pane.cmd + '\r')); }, 120);
-      } else if (msg.t === 'exit') { setStatus('exited (' + msg.code + ')'); }
+      } else if (msg.t === 'exit') { pane.exited = true; setStatus('exited (' + msg.code + ')'); _wsUpdateStatusBar(); }
       else if (msg.t === 'error') { setStatus('error'); term.write('\r\n\x1b[31m' + (msg.message || 'error') + '\x1b[0m\r\n'); }
       return;
     }
+    // Raw output: mark the pane active and scan a bounded tail for account-limit
+    // cues so the top status bar can flag it.
+    pane.lastOutputAt = _wsNow();
+    var text = dec.decode(new Uint8Array(ev.data));
+    if (WS_LIMIT_RE.test(text)) pane.flaggedLimit = true;
     term.write(new Uint8Array(ev.data));
   };
-  sock.onclose = function () { setStatus('disconnected'); };
+  sock.onclose = function () { setStatus('disconnected'); pane.exited = true; _wsUpdateStatusBar(); };
   sock.onerror = function () { setStatus('connection error'); };
 
   term.onData(function (data) { if (sock.readyState === 1) sock.send(enc.encode(data)); });
@@ -411,8 +510,11 @@ function launchAgentInPane(id, cmd) {
   if (!pane || !pane.sock || pane.sock.readyState !== 1) return;
   // Remember what was launched so "Save layout" captures the running setup.
   pane.cmd = cmd;
+  pane.flaggedLimit = false;          // fresh attempt clears any prior limit flag
+  pane.lastOutputAt = _wsNow();
   pane.sock.send(new TextEncoder().encode(cmd + '\r'));
   if (pane.term) pane.term.focus();
+  _wsUpdateStatusBar();
 }
 
 // ── Saved-commands manager (modal) ──────────────────────────────────────────
@@ -711,4 +813,6 @@ async function renderWorkspace(container) {
   _wsRenderAll();
   _wsLoadCommands();
   _wsLoadLayouts();
+  _wsStartStatusLoop();
+  _wsUpdateStatusBar();
 }

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -39,6 +39,16 @@ var _wsVendorLoaded = false;
 var _wsSavedCommands = [];   // [{ id, name, command }]
 var _wsSavedLayouts = [];    // [{ id, name, tabs:[{name,panes:[{cmd}]}] }]
 var _wsRoot = null;          // the live .workspace-wrap element (kept across view switches)
+var _wsFocusedPaneId = null; // the pane the user is currently in (target for commands)
+
+// Mark a pane as focused: remember it and highlight its box so it's obvious
+// where a launched command will land.
+function _wsSetFocusedPane(id) {
+  _wsFocusedPaneId = id;
+  Array.prototype.forEach.call(document.querySelectorAll('.ws-pane'), function (el) {
+    el.classList.toggle('focused', el.getAttribute('data-pane-id') === id);
+  });
+}
 
 // Mask credentials in a URL userinfo (proxy passwords) for display only.
 function _wsMaskSecrets(cmd) {
@@ -169,6 +179,11 @@ function _wsConnectPane(pane) {
   try { fit.fit(); } catch (e) {}
   pane.term = term; pane.fit = fit;
 
+  // Track which pane the user is "in": focusing/clicking the terminal marks it
+  // as the focused pane, so saved commands / resume land where you're looking.
+  host.addEventListener('focusin', function () { _wsSetFocusedPane(pane.id); });
+  host.addEventListener('mousedown', function () { _wsSetFocusedPane(pane.id); });
+
   var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
   var url = proto + '//' + location.host + '/ws/terminal' +
     '?token=' + encodeURIComponent(_wsToken) + '&cols=' + term.cols + '&rows=' + term.rows;
@@ -289,6 +304,13 @@ function _wsRenderPanes() {
 
   // Refit the active tab shortly after it becomes visible (0-size while hidden).
   setTimeout(function () { _wsRefitTab(_wsActiveTab()); }, 60);
+
+  // Ensure a focused pane is always highlighted within the active tab.
+  var at = _wsActiveTab();
+  if (at && at.panes.length) {
+    var focusedInTab = _wsFocusedPaneId && at.panes.some(function (p) { return p.id === _wsFocusedPaneId; });
+    _wsSetFocusedPane(focusedInTab ? _wsFocusedPaneId : at.panes[0].id);
+  }
 }
 
 function _wsSyncLayoutButtons() {
@@ -394,9 +416,15 @@ function launchAgentInPane(id, cmd) {
 }
 
 // ── Saved-commands manager (modal) ──────────────────────────────────────────
+// The pane a launched command should target: the focused pane if it belongs to
+// the active tab, otherwise that tab's first pane.
 function _wsActivePaneId() {
   var tab = _wsActiveTab();
-  return tab && tab.panes[0] ? tab.panes[0].id : null;
+  if (!tab || !tab.panes.length) return null;
+  if (_wsFocusedPaneId && tab.panes.some(function (p) { return p.id === _wsFocusedPaneId; })) {
+    return _wsFocusedPaneId;
+  }
+  return tab.panes[0].id;
 }
 
 function _wsCommandsListHtml() {
@@ -408,7 +436,7 @@ function _wsCommandsListHtml() {
         '<code class="ws-cmd-cmd">' + escHtml(_wsMaskSecrets(c.command)) + '</code>' +
       '</div>' +
       '<div class="ws-cmd-actions">' +
-        '<button class="toolbar-btn" title="Run in the active pane" onclick="runSavedCommand(\'' + escHtml(c.id) + '\')">Run</button>' +
+        '<button class="toolbar-btn" title="Run in the focused pane (highlighted)" onclick="runSavedCommand(\'' + escHtml(c.id) + '\')">Run</button>' +
         '<button class="toolbar-btn ws-cmd-del" title="Delete" onclick="deleteWorkspaceCommand(\'' + escHtml(c.id) + '\')">&times;</button>' +
       '</div>' +
     '</div>';
@@ -431,7 +459,7 @@ function openWorkspaceCommands() {
       '<div class="ws-cmd-head"><span>Saved commands</span>' +
         '<button class="ws-cmd-close" onclick="closeWorkspaceCommands()">&times;</button></div>' +
       '<div class="ws-cmd-note">Stored on your machine at <code>~/.codedash/workspace-commands.json</code> (0600). ' +
-        'Fine for proxy launches — the value is typed straight into the pane shell.</div>' +
+        'Fine for proxy launches — the value is typed into the <strong>focused pane</strong> (the one with the blue border).</div>' +
       '<div class="ws-cmd-list" id="wsCmdList">' + _wsCommandsListHtml() + '</div>' +
       '<div class="ws-cmd-form">' +
         '<input id="wsCmdName" class="ws-cmd-input" placeholder="Name (e.g. Claude via proxy)" maxlength="120">' +

--- a/src/html.js
+++ b/src/html.js
@@ -16,6 +16,7 @@ const JS_FILES = [
   'cloud.js',
   'recommended.js',
   'workspace.js',
+  'overview.js',
 ];
 
 function buildHTML() {

--- a/src/server.js
+++ b/src/server.js
@@ -1399,7 +1399,7 @@ function getBrowserHost(host) {
 // ── npm version check ───────────────────
 function fetchLatestVersion(packageName) {
   return new Promise((resolve, reject) => {
-    https.get(`https://registry.npmjs.org/${packageName}/latest`, { timeout: 5000 }, (res) => {
+    const req = https.get(`https://registry.npmjs.org/${packageName}/latest`, { timeout: 5000 }, (res) => {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
@@ -1407,7 +1407,12 @@ function fetchLatestVersion(packageName) {
           resolve(JSON.parse(data).version);
         } catch { reject(); }
       });
-    }).on('error', reject);
+    });
+    req.on('error', reject);
+    // The `timeout` option only emits an event — without this the socket is
+    // never torn down, so a stalled registry would hang /api/version forever
+    // instead of falling back to "no update available".
+    req.on('timeout', () => { req.destroy(new Error('registry timeout')); });
   });
 }
 

--- a/test/sidebar-config.test.js
+++ b/test/sidebar-config.test.js
@@ -168,17 +168,14 @@ test('isItemHidden never reports Settings as hidden, even if config says so', ()
 
 // ── isSectionCollapsed ──────────────────────────────────────────
 
-test('isSectionCollapsed returns false for sections by default', () => {
+test('isSectionCollapsed defaults all sidebar sections to collapsed', () => {
+  // By design, the app starts with every sidebar group collapsed so the
+  // Overview landing view is the focus on first paint.
   const m = loadModule();
   const cfg = m.parseSidebarConfig(null);
-  assert.equal(m.isSectionCollapsed(cfg, 'workspace'), false);
-  assert.equal(m.isSectionCollapsed(cfg, 'agents'), false);
-  assert.equal(m.isSectionCollapsed(cfg, 'tools'), false);
-});
-
-test('isSectionCollapsed defaults install-agents sub-section to collapsed', () => {
-  const m = loadModule();
-  const cfg = m.parseSidebarConfig(null);
+  assert.equal(m.isSectionCollapsed(cfg, 'workspace'), true);
+  assert.equal(m.isSectionCollapsed(cfg, 'agents'), true);
+  assert.equal(m.isSectionCollapsed(cfg, 'tools'), true);
   assert.equal(m.isSectionCollapsed(cfg, 'install-agents'), true,
     'install-agents is default-collapsed per design');
 });


### PR DESCRIPTION
Ships the Workspace super-app work up to **v7.12.0**.

## Overview landing (new default view)
- Live cards for every running terminal (tab, status, command, folder)
- Click a card to jump straight into that pane
- Quick actions: open a terminal, relaunch a saved layout / command
- Sidebar sections now start collapsed so Overview stays the focus (choice remembered)

## Workspace (7.11.0)
- Live terminal status bar at the top, visible from any view
- Account-limit detection flags panes that hit a rate/usage limit
- Click a status chip to jump to that pane; focused-pane targeting for launched commands

## Fixes
- Harden the npm version check: the registry request could hang on a stalled
  socket instead of falling back, which suppressed the "update available"
  notification. Now times out cleanly.

## Testing
- 182 pass / 0 fail / 2 skipped (win32-only)
- Full browser pass (Playwright): Overview landing, new terminal → live shell,
  running-terminal card, jump-to-pane with keep-alive, section collapse/expand,
  clean reload with zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)