### PR TITLE
feat: project-aware terminals, richer Overview, tidier sidebar (v7.13.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.12.0",
+  "version": "7.13.0",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,21 @@
 
 const CHANGELOG = [
   {
+    version: '7.13.0',
+    date: '2026-07-20',
+    title: 'Project-aware terminals, richer Overview, tidier sidebar',
+    changes: [
+      'Overview is now a real dashboard: headline stats (sessions, active agents, terminals, spend), your recent sessions as clickable cards, and live terminals grouped by project folder',
+      'Every session card gets an "Open here" button — it opens a terminal in that session\'s project folder with the agent\'s resume command prefilled (you press Enter when ready; it never auto-runs)',
+      'Projects: a "Terminal ▾" control opens up to 4 panes cd\'d into a project folder, and each project shows how many terminals are running in it (click to jump)',
+      'Switching a tab\'s split layout (or closing a tab) now asks before killing running terminals — no more losing live panes by accident',
+      'The whole sidebar can be collapsed for full-width content (a floating handle brings it back); the state is remembered',
+      'Sidebar tidy-up: the terminal is now a top-level "Terminal" item, groups are renamed (Sessions / Agents / Tools), and every group starts collapsed so the Overview stays in focus',
+      'The top terminal status bar no longer jitters — it shows each terminal\'s (renamable) tab name, with the command in the tooltip',
+      '"Add project" now autocompletes from the folders codbash already knows about, so you pick instead of typing a full path',
+    ],
+  },
+  {
     version: '7.12.0',
     date: '2026-07-20',
     title: 'Overview landing + tidy sidebar',

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -1067,6 +1067,9 @@ async function loadSessions() {
     _analyticsHtmlCache = null;
     _analyticsCacheUrl = null;
     applyFilters();
+    // Keep the Overview landing in sync once sessions land (it renders before
+    // this fetch resolves on a cold start).
+    if (typeof _ovRefreshIfCurrent === 'function') _ovRefreshIfCurrent();
     // Progressive loading: if server is still loading cursor vscdb sessions, auto-refresh
     if (resp.headers.get('X-Loading') === '1') {
       setTimeout(loadSessions, 2000);
@@ -1140,6 +1143,9 @@ async function pollActiveSessions() {
     _prevActiveKey = newKey;
 
     activeSessions = newActive;
+
+    // Reflect the new active-agent count on the Overview landing.
+    if (typeof _ovRefreshIfCurrent === 'function') _ovRefreshIfCurrent();
 
     // Only touch cards that changed
     document.querySelectorAll('.card').forEach(function(card) {
@@ -1400,6 +1406,11 @@ function renderCard(s, idx) {
   html += '<span class="card-tags">' + tagHtml;
   html += '<button class="tag-add-btn" onclick="showTagDropdown(event, \'' + s.id + '\')" title="Add tag">+</button>';
   html += '</span>';
+  // Open the session's project folder in the in-app terminal with the agent's
+  // resume command prefilled (awaiting Enter).
+  if (s.git_root || s.project) {
+    html += '<button class="card-gen-btn card-open-here" onclick="event.stopPropagation();openSessionInWorkspace(\'' + escJsString(s.id) + '\')" title="Open a terminal in this project (resume prefilled)">&#9654;</button>';
+  }
   if (s.has_detail) {
     var btnTitle = sessionTitles[s.id] ? 'Regenerate AI title' : 'Generate AI title';
     var btnIcon = sessionTitles[s.id] ? '&#8635;' : '&#9883;';
@@ -2000,6 +2011,14 @@ function scrollToInstallAgents() {
   if (section && section.scrollIntoView) section.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }
 
+// Live Workspace panes whose resolved cwd is this project folder.
+function _projectLiveTerminals(projPath) {
+  if (!projPath || typeof _wsAllPanes !== 'function') return [];
+  return _wsAllPanes().filter(function (x) {
+    return x.pane && !x.pane.exited && x.pane.cwd === projPath;
+  });
+}
+
 function renderLauncherCard(projKey, projInfo) {
   var projName = projInfo.name;
   var projPath = projInfo.path;
@@ -2067,10 +2086,30 @@ function renderLauncherCard(projKey, projInfo) {
       : 'Resume last session (' + lastId.slice(0,8) + ')';
     html += '<button class="git-project-launch-btn"' + (toolMissing ? ' aria-describedby="toolMissingHint"' : '') + ' data-sess-id="' + escHtml(lastId) + '" data-sess-tool="' + escHtml(lastTool) + '" data-proj-path="' + escHtml(projPath) + '" onclick="resumeLastProjectSession(this.dataset.sessId,this.dataset.sessTool,this.dataset.projPath)" title="' + escHtml(lastTitle) + '" aria-label="' + escHtml(lastTitle) + '">&#x21bb; Last</button>';
   }
+  // Open in-app terminals (Workspace) pre-cd'd into this project folder (1-4).
+  if (projPath) {
+    html += '<select class="git-project-launch-btn ws-proj-term" title="Open terminals in this folder (in-app Workspace)" ' +
+      'data-proj-path="' + escHtml(projPath) + '" ' +
+      'onchange="spawnProjectTerminals(this.dataset.projPath, this.value); this.selectedIndex=0;">' +
+      '<option value="">&#8862; Terminal &#9662;</option>' +
+      '<option value="1">1 pane</option><option value="2">2 panes</option>' +
+      '<option value="3">3 panes</option><option value="4">4 panes</option>' +
+      '</select>';
+  }
   if (projInfo.manualId) {
     html += '<button class="git-project-launch-btn" data-proj-id="' + escHtml(projInfo.manualId) + '" data-proj-name="' + escHtml(projName) + '" onclick="unregisterProject(this.dataset.projId,this.dataset.projName)" title="Remove from registry (does not delete files)">&times;</button>';
   }
   html += '</div>';
+
+  // Show terminals already running in this folder, with a jump-to link.
+  var liveT = _projectLiveTerminals(projPath);
+  if (liveT.length) {
+    var first = liveT[0];
+    html += '<button class="launcher-card-link launcher-card-term" ' +
+      'data-tab="' + escHtml(first.tab.id) + '" data-pane="' + escHtml(first.pane.id) + '" ' +
+      'onclick="jumpToWorkspacePane(this.dataset.tab, this.dataset.pane)">&#9679; ' +
+      liveT.length + ' terminal' + (liveT.length === 1 ? '' : 's') + ' running &rarr;</button>';
+  }
 
   if (totalSessions > 0) {
     html += '<button class="launcher-card-link" data-proj-key="' + escHtml(projKey) + '" data-proj-name="' + escHtml(projName) + '" onclick="viewProjectInHistory(this.dataset.projKey,this.dataset.projName)">View ' + totalSessions + ' session' + (totalSessions === 1 ? '' : 's') + ' →</button>';
@@ -2515,14 +2554,10 @@ function _initSidebarConfig() {
 function applySidebarConfig() {
   var cfg = _initSidebarConfig();
 
-  // Sections (including nested install-agents): toggle .collapsed + aria-expanded.
-  document.querySelectorAll('.sidebar-group[data-section]').forEach(function(group) {
-    var id = group.getAttribute('data-section');
-    var collapsed = SidebarConfig.isSectionCollapsed(cfg, id);
-    group.classList.toggle('collapsed', collapsed);
-    var header = group.querySelector(':scope > .sidebar-section-header');
-    if (header) header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
-  });
+  // Section groups always start collapsed (see markup); expanding a section is
+  // a transient, per-session choice handled directly in the header click. We
+  // deliberately do NOT drive .collapsed from stored config here, so the app
+  // always opens tidy with the Overview in focus.
 
   // Items: hide based on data-key (preferred) or data-view (legacy fallback).
   // Settings is force-visible by isItemHidden.
@@ -2624,13 +2659,12 @@ function _onSidebarSectionHeaderClick(event) {
   var target = event.target.closest('[data-role="section-header"]');
   if (!target) return;
   event.stopPropagation();
-  var sectionId = target.getAttribute('data-section-target');
-  if (!sectionId) return;
-  var cfg = _initSidebarConfig();
-  var next = !SidebarConfig.isSectionCollapsed(cfg, sectionId);
-  _sidebarConfig = SidebarConfig.setSectionCollapsed(cfg, sectionId, next);
-  SidebarConfig.saveToStorage(_storage(), _sidebarConfig);
-  applySidebarConfig();
+  // Expansion is transient (per-session) — toggle the DOM directly rather than
+  // persisting, so a reload always returns to the tidy all-collapsed start.
+  var group = target.closest('.sidebar-group[data-section]');
+  if (!group) return;
+  var collapsed = group.classList.toggle('collapsed');
+  target.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
 }
 
 function _bindSidebarHeaders() {
@@ -2646,6 +2680,17 @@ function toggleSidebarItem(key, visible) {
   _sidebarConfig = SidebarConfig.setItemHidden(cfg, key, !visible);
   SidebarConfig.saveToStorage(_storage(), _sidebarConfig);
   applySidebarConfig();
+}
+
+// Collapse/expand the entire sidebar to give the content full width. State is
+// persisted so it survives reloads (applied pre-paint in index.html too).
+function toggleSidebar(force) {
+  var hide = (typeof force === 'boolean') ? force : !document.body.classList.contains('sidebar-hidden');
+  document.body.classList.toggle('sidebar-hidden', hide);
+  var st = _storage();
+  try { if (st) { if (hide) st.setItem('codedash-sidebar-hidden', '1'); else st.removeItem('codedash-sidebar-hidden'); } } catch (e) {}
+  // Terminals need a refit when the viewport width changes.
+  if (typeof _wsRefitTab === 'function') setTimeout(function () { try { _wsRefitTab(_wsActiveTab()); } catch (e) {} }, 260);
 }
 
 function resetSidebarConfig() {
@@ -3938,12 +3983,28 @@ async function unregisterProject(id, name) {
 
 // ── Add Project modal ─────────────────────────────────────────
 
+// Offer the folders codbash already knows about (from every session's git
+// root / project path) as autocomplete options, so "Add project" is a pick
+// rather than typing a full path from memory.
+function _populateProjectPathSuggestions() {
+  var dl = document.getElementById('apPathSuggestions');
+  if (!dl) return;
+  var seen = {};
+  (typeof allSessions !== 'undefined' && allSessions ? allSessions : []).forEach(function (s) {
+    var p = s.git_root || s.project;
+    if (p && p.charAt(0) === '/' && !seen[p]) seen[p] = true;
+  });
+  var paths = Object.keys(seen).sort();
+  dl.innerHTML = paths.map(function (p) { return '<option value="' + escHtml(p) + '"></option>'; }).join('');
+}
+
 function openAddProject() {
   var overlay = document.getElementById('addProjectOverlay');
   if (!overlay) return;
   overlay.classList.add('open');
   overlay.setAttribute('aria-hidden', 'false');
   addProjectSwitchTab('local');
+  _populateProjectPathSuggestions();
   var input = document.getElementById('apLocalPath');
   if (input) { input.value = ''; setTimeout(function() { input.focus(); }, 50); }
   var err = document.getElementById('apLocalError'); if (err) err.textContent = '';

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -12,40 +12,18 @@
 <body>
 
 <script>
-// Pre-paint sidebar state restore: applies collapsed sections from
-// localStorage before the sidebar markup paints, so a user who collapsed
-// "Agents" doesn't see it flash open on reload. The full applySidebarConfig()
-// runs later from init() and reconciles everything (including hidden items
-// and the chevron rotation), but the .collapsed class needs to land before
-// first paint to prevent the flash. This script runs synchronously before
-// the <div class="sidebar"> below.
+// Pre-paint sidebar state: the whole-sidebar collapse toggle needs to land
+// before first paint to avoid a flash. Section groups always start collapsed
+// (see markup) — expanding a section is a transient, per-session choice, so we
+// deliberately do NOT restore expanded sections here.
 (function () {
   try {
-    var raw = window.localStorage && window.localStorage.getItem('codedash-sidebar-config');
-    if (!raw || typeof raw !== 'string' || raw.length > 65536) return;
-    var cfg = JSON.parse(raw);
-    if (!cfg || typeof cfg !== 'object' || cfg.v !== 1 || !cfg.collapsed) return;
-    var collapsed = cfg.collapsed;
-    // Defer to DOM-ready so .sidebar-group nodes exist. Script is placed
-    // before <div class="sidebar">, so we use a microtask via setTimeout(0).
-    document.addEventListener('DOMContentLoaded', function () {
-      // Sections start collapsed in the markup. Apply stored collapsed=true as
-      // well, and — importantly — EXPAND sections the user explicitly opened
-      // (stored collapsed=false) so their choice survives without a flash.
-      Object.keys(collapsed).forEach(function (id) {
-        var group = document.querySelector('.sidebar-group[data-section="' + id.replace(/"/g, '') + '"]');
-        if (!group) return;
-        var hdr = group.querySelector(':scope > .sidebar-section-header');
-        if (collapsed[id] === true) {
-          group.classList.add('collapsed');
-          if (hdr) hdr.setAttribute('aria-expanded', 'false');
-        } else if (collapsed[id] === false) {
-          group.classList.remove('collapsed');
-          if (hdr) hdr.setAttribute('aria-expanded', 'true');
-        }
+    if (window.localStorage && window.localStorage.getItem('codedash-sidebar-hidden') === '1') {
+      document.addEventListener('DOMContentLoaded', function () {
+        document.body.classList.add('sidebar-hidden');
       });
-    });
-  } catch (_e) { /* private mode or malformed — applySidebarConfig will recover */ }
+    }
+  } catch (_e) { /* private mode — init() will recover */ }
 })();
 </script>
 
@@ -54,28 +32,31 @@
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
         codbash
         <span class="version-badge" id="versionBadge"></span>
+        <button type="button" class="sidebar-collapse-btn" title="Collapse sidebar" aria-label="Collapse sidebar" onclick="toggleSidebar()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+        </button>
     </div>
 
-    <!-- Overview — always-visible landing (sits above the collapsible groups) -->
+    <!-- Overview + Terminal — always-visible landing items (above the groups) -->
     <div class="sidebar-item active" data-view="overview" data-key="overview">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="9" rx="1"/><rect x="14" y="3" width="7" height="5" rx="1"/><rect x="14" y="12" width="7" height="9" rx="1"/><rect x="3" y="16" width="7" height="5" rx="1"/></svg>
         Overview
     </div>
+    <div class="sidebar-item" data-view="workspace" data-key="workspace">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="18" rx="2"/><polyline points="6 8 9 11 6 14"/><line x1="12" y1="15" x2="17" y2="15"/></svg>
+        Terminal
+    </div>
 
-    <!-- Workspace section -->
+    <!-- Sessions section -->
     <div class="sidebar-group collapsed" data-section="workspace">
         <button type="button" class="sidebar-section-header" data-role="section-header" data-section-target="workspace" aria-expanded="false" aria-controls="sidebarSectionWorkspace">
             <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
-            <span>Workspace</span>
+            <span>Sessions</span>
         </button>
         <div class="sidebar-section-body" id="sidebarSectionWorkspace">
             <div class="sidebar-item" data-view="sessions">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
                 All Sessions
-            </div>
-            <div class="sidebar-item" data-view="workspace" data-key="workspace">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="18" rx="2"/><polyline points="6 8 9 11 6 14"/><line x1="12" y1="15" x2="17" y2="15"/></svg>
-                Workspace
             </div>
             <div class="sidebar-item" data-view="projects">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
@@ -179,7 +160,7 @@
         <div class="sidebar-section-body" id="sidebarSectionTools">
 
             <!-- Install agents sub-section (default collapsed) -->
-            <div class="sidebar-group sidebar-subgroup" data-section="install-agents">
+            <div class="sidebar-group sidebar-subgroup collapsed" data-section="install-agents">
                 <button type="button" class="sidebar-section-header sidebar-subsection-header" data-role="section-header" data-section-target="install-agents" aria-expanded="false" aria-controls="sidebarSectionInstallAgents">
                     <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
                     <span>Install agents</span>
@@ -249,6 +230,11 @@
     </div>
 </div>
 
+<!-- Floating re-open handle, shown only when the sidebar is collapsed -->
+<button type="button" class="sidebar-reopen-btn" title="Show sidebar" aria-label="Show sidebar" onclick="toggleSidebar()">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+</button>
+
 <div class="main">
     <div class="toolbar">
         <input type="text" class="search-box" placeholder="Search sessions, projects... (press /)" oninput="onSearch(this.value)">
@@ -312,8 +298,9 @@
         <div class="ap-body">
             <div class="ap-pane" id="apPaneLocal" role="tabpanel">
                 <label for="apLocalPath">Folder path on this machine</label>
-                <input type="text" id="apLocalPath" placeholder="/Users/me/code/my-project" autocomplete="off" aria-describedby="apLocalHint" />
-                <div class="ap-hint" id="apLocalHint">Must be an existing directory. <code>~</code> is expanded.</div>
+                <input type="text" id="apLocalPath" placeholder="/Users/me/code/my-project" autocomplete="off" aria-describedby="apLocalHint" list="apPathSuggestions" />
+                <datalist id="apPathSuggestions"></datalist>
+                <div class="ap-hint" id="apLocalHint">Start typing to pick from your known project folders. <code>~</code> is expanded.</div>
                 <div class="ap-error" id="apLocalError" role="alert"></div>
             </div>
             <div class="ap-pane" id="apPaneOwned" style="display:none" role="tabpanel">

--- a/src/frontend/overview.js
+++ b/src/frontend/overview.js
@@ -1,51 +1,142 @@
-// Overview — the landing "workspace at a glance": running terminals (with live
-// status) + quick actions (new terminal, launch a saved layout / command).
-// Reads the live workspace state from workspace.js (loaded before this file).
+// Overview — the landing "workspace at a glance": headline stats, running
+// terminals (live status), recent sessions, and quick actions (new terminal,
+// launch a saved layout / command). Reuses globals + helpers from app.js and
+// the live workspace state from workspace.js (both loaded before this file).
 
 function _ovPanes() {
   if (typeof _wsAllPanes !== 'function') return [];
   return _wsAllPanes().filter(function (x) { return x.pane.sock || x.pane.exited; });
 }
 
+function _ovProjectKey(cwd) {
+  if (!cwd) return 'no folder';
+  var base = (typeof _wsProjectBasename === 'function') ? _wsProjectBasename(cwd) : cwd;
+  return base || cwd;
+}
+
+function _ovGreeting() {
+  var h = new Date().getHours();
+  var g = h < 5 ? 'Good night' : h < 12 ? 'Good morning' : h < 18 ? 'Good afternoon' : 'Good evening';
+  var d = new Date().toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
+  return g + ' — ' + d;
+}
+
+// Cost is fetched once and cached (60s) so the live re-render doesn't flicker
+// or hammer the endpoint on every status tick.
+var _ovCost = null, _ovCostAt = 0, _ovCostInFlight = false;
+function _ovEnsureCost() {
+  var now = Date.now();
+  if (_ovCostInFlight) return;
+  if (_ovCost && (now - _ovCostAt) < 60000) return;
+  _ovCostInFlight = true;
+  fetch('/api/analytics/cost').then(function (r) { return r.json(); }).then(function (d) {
+    _ovCost = d; _ovCostAt = Date.now(); _ovCostInFlight = false;
+    _ovRefreshIfCurrent();
+  }).catch(function () { _ovCostInFlight = false; });
+}
+function _ovFmtMoney(n) {
+  if (typeof n !== 'number' || !isFinite(n)) return '$0';
+  if (n >= 1000) return '$' + (n / 1000).toFixed(1) + 'k';
+  if (n >= 100) return '$' + n.toFixed(0);
+  return '$' + n.toFixed(2);
+}
+
+function _ovStat(num, label, sub) {
+  return '<div class="ov-stat"><div class="ov-stat-num">' + num + '</div>' +
+    '<div class="ov-stat-label">' + escHtml(label) + '</div>' +
+    (sub ? '<div class="ov-stat-sub">' + escHtml(sub) + '</div>' : '') + '</div>';
+}
+
 function renderOverview(container) {
-  // Make sure saved lists are available even if the terminal was never opened.
+  // Make sure the data we lean on is available even on a cold landing.
   if (typeof _wsLoadCommands === 'function' && (!window._wsSavedCommands || !_wsSavedCommands.length)) _wsLoadCommands();
   if (typeof _wsLoadLayouts === 'function' && (!window._wsSavedLayouts || !_wsSavedLayouts.length)) _wsLoadLayouts();
-  // Keep the status loop ticking so cards refresh even before Workspace mounts.
   if (typeof _wsStartStatusLoop === 'function') _wsStartStatusLoop();
+  var sessions = (typeof allSessions !== 'undefined' && allSessions) ? allSessions : [];
+  if (!sessions.length && typeof loadSessions === 'function') loadSessions();
+  _ovEnsureCost();
 
   var panes = _ovPanes();
+  var liveTerms = panes.filter(function (x) { return !x.pane.exited; }).length;
+  var activeAgents = (typeof activeSessions !== 'undefined' && activeSessions) ? Object.keys(activeSessions).length : 0;
+
   var html = '<div class="ov-wrap" id="ovWrap">';
   html += '<div class="ov-head">' +
-    '<h2 class="heatmap-title">Workspace</h2>' +
+    '<div><h2 class="heatmap-title">Overview</h2>' +
+    '<div class="ov-sub">' + escHtml(_ovGreeting()) + '</div></div>' +
     '<button class="toolbar-btn ov-primary" onclick="overviewNewTerminal()">+ New terminal</button>' +
     '</div>';
 
+  // ── Headline stats ──
+  var todayCost = _ovCost ? _ovFmtMoney(_ovCost.todayCost) : '…';
+  var totalCost = _ovCost ? _ovFmtMoney(_ovCost.totalCost) : '…';
+  var costSub = _ovCost ? ('today ' + _ovFmtMoney(_ovCost.todayCost)) : '';
+  html += '<div class="ov-stats">' +
+    _ovStat(sessions.length, 'Sessions', '') +
+    _ovStat(activeAgents, 'Active agents', activeAgents ? 'running now' : '') +
+    _ovStat(liveTerms, 'Terminals', liveTerms ? 'in workspace' : '') +
+    _ovStat(totalCost, 'Total spend', costSub) +
+    '</div>';
+
+  // ── Terminals ──
   html += '<div class="ov-section-title">Terminals</div>';
   if (!panes.length) {
-    html += '<div class="empty-state" style="text-align:left;max-width:460px">' +
+    html += '<div class="empty-state" style="text-align:left;max-width:460px;margin:0">' +
       'No terminals running yet. Open one to run shells and agents right here — ' +
       'sessions survive switching views.<br><br>' +
       '<button class="toolbar-btn ov-primary" onclick="overviewNewTerminal()">Open a terminal</button></div>';
   } else {
-    html += '<div class="ov-grid">';
+    // Group the live terminals by their project folder so you see, at a glance,
+    // which projects have terminals running.
+    var groups = {};
+    var order = [];
     panes.forEach(function (x) {
-      var st = (typeof _wsPaneStatus === 'function') ? _wsPaneStatus(x.pane) : 'idle';
-      var meta = (window.WS_STATUS_META && WS_STATUS_META[st]) || { label: st, cls: st };
-      var cmd = x.pane.cmd || 'shell';
-      var masked = (typeof _wsMaskSecrets === 'function') ? _wsMaskSecrets(cmd) : cmd;
-      html += '<button class="ov-card ' + meta.cls + '" ' +
-        'onclick="jumpToWorkspacePane(\'' + escHtml(x.tab.id) + '\',\'' + escHtml(x.pane.id) + '\')">' +
-        '<div class="ov-card-top"><span class="ov-dot"></span>' +
-        '<span class="ov-tab">' + escHtml(x.tab.name) + '</span>' +
-        '<span class="ov-st">' + escHtml(meta.label) + '</span></div>' +
-        '<div class="ov-cmd">' + escHtml(masked) + '</div>' +
-        '<div class="ov-cwd">' + escHtml(x.pane.cwd || '~') + '</div>' +
+      var key = _ovProjectKey(x.pane.cwd);
+      if (!groups[key]) { groups[key] = []; order.push(key); }
+      groups[key].push(x);
+    });
+    order.forEach(function (key) {
+      html += '<div class="ov-proj-label">' + escHtml(key) + '</div><div class="ov-grid">';
+      groups[key].forEach(function (x) {
+        var st = (typeof _wsPaneStatus === 'function') ? _wsPaneStatus(x.pane) : 'idle';
+        var meta = (window.WS_STATUS_META && WS_STATUS_META[st]) || { label: st, cls: st };
+        var cmd = x.pane.cmd || 'shell';
+        var masked = (typeof _wsMaskSecrets === 'function') ? _wsMaskSecrets(cmd) : cmd;
+        html += '<button class="ov-card ' + meta.cls + '" ' +
+          'onclick="jumpToWorkspacePane(\'' + escHtml(x.tab.id) + '\',\'' + escHtml(x.pane.id) + '\')">' +
+          '<div class="ov-card-top"><span class="ov-dot"></span>' +
+          '<span class="ov-tab">' + escHtml(x.tab.name) + '</span>' +
+          '<span class="ov-st">' + escHtml(meta.label) + '</span></div>' +
+          '<div class="ov-cmd">' + escHtml(masked) + '</div>' +
+          '<div class="ov-cwd">' + escHtml(x.pane.cwd || '~') + '</div>' +
+          '</button>';
+      });
+      html += '</div>';
+    });
+  }
+
+  // ── Recent sessions ──
+  var recent = sessions.slice().sort(function (a, b) { return (b.last_ts || 0) - (a.last_ts || 0); }).slice(0, 6);
+  if (recent.length) {
+    html += '<div class="ov-section-title">Recent sessions</div><div class="ov-grid">';
+    recent.forEach(function (s) {
+      var badge = (typeof getToolLabel === 'function') ? getToolLabel(s.tool, true) : (s.tool || '');
+      var proj = s.project_short || ((typeof getProjectName === 'function') ? getProjectName(s.project) : s.project) || '~';
+      var txt = (s.recap || s.first_message || '').slice(0, 130);
+      var when = (typeof timeAgo === 'function') ? timeAgo(s.last_ts) : '';
+      html += '<button class="ov-card ov-session" onclick="ovOpenSession(\'' + escJsString(s.id) + '\')">' +
+        '<div class="ov-card-top">' +
+        '<span class="ov-badge tool-' + escHtml(s.tool) + '">' + escHtml(badge) + '</span>' +
+        '<span class="ov-tab">' + escHtml(proj) + '</span>' +
+        '<span class="ov-st">' + escHtml(when) + '</span></div>' +
+        '<div class="ov-desc">' + escHtml(txt) + '</div>' +
+        '<div class="ov-cwd">' + escHtml(String(s.messages || 0)) + ' msgs</div>' +
         '</button>';
     });
     html += '</div>';
   }
 
+  // ── Quick actions ──
   if (window._wsSavedLayouts && _wsSavedLayouts.length) {
     html += '<div class="ov-section-title">Saved layouts</div><div class="ov-chips">';
     _wsSavedLayouts.forEach(function (l) {
@@ -67,13 +158,19 @@ function renderOverview(container) {
   container.innerHTML = html;
 }
 
-// Live refresh: re-render while Overview is the current view (cheap — a few
-// cards). Called from the workspace status loop.
+// Live refresh: re-render while Overview is the current view (cheap — reads
+// cached data). Called from the workspace status loop.
 function _ovRefreshIfCurrent() {
   if (typeof currentView !== 'undefined' && currentView === 'overview') {
     var c = document.getElementById('content');
     if (c && document.getElementById('ovWrap')) renderOverview(c);
   }
+}
+
+function ovOpenSession(id) {
+  var list = (typeof allSessions !== 'undefined' && allSessions) ? allSessions : [];
+  var s = list.find(function (x) { return x.id === id; });
+  if (s && typeof openDetail === 'function') openDetail(s);
 }
 
 function overviewNewTerminal() {

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -150,7 +150,52 @@ body {
     flex-shrink: 0;
     overflow-y: auto;
     overflow-x: hidden;
+    transition: width 0.2s ease, padding 0.2s ease;
 }
+
+/* Whole-sidebar collapse (toggleSidebar) — width→0, content clipped. */
+body.sidebar-hidden .sidebar {
+    width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    border-right: none;
+    overflow: hidden;
+}
+.sidebar-collapse-btn {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 4px;
+}
+.sidebar-collapse-btn:hover { color: var(--text-primary); background: rgba(255,255,255,0.06); }
+.sidebar-collapse-btn svg { width: 16px; height: 16px; }
+.sidebar-reopen-btn {
+    position: fixed;
+    top: 12px;
+    left: 10px;
+    z-index: 60;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+}
+.sidebar-reopen-btn:hover { color: var(--text-primary); border-color: var(--accent-blue); }
+.sidebar-reopen-btn svg { width: 16px; height: 16px; }
+body.sidebar-hidden .sidebar-reopen-btn { display: flex; }
+body.sidebar-hidden .toolbar { padding-left: 52px; }
 
 .sidebar-brand {
     padding: 8px 20px 20px;
@@ -2832,9 +2877,34 @@ body {
 .workspace-tabpanes { flex: 1; min-height: 0; display: flex; }
 
 /* ── Overview landing ── */
-.ov-wrap { padding: 24px; max-width: 900px; }
-.ov-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.ov-wrap { padding: 24px; max-width: 1040px; }
+.ov-head { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 16px; }
+.ov-sub { font-size: 13px; color: var(--text-muted); margin-top: 4px; }
 .ov-primary { border-color: var(--accent-blue); color: var(--accent-blue); }
+
+.ov-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 4px; }
+.ov-stat {
+    padding: 16px; background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 12px; display: flex; flex-direction: column; gap: 2px;
+}
+.ov-stat-num { font-size: 26px; font-weight: 700; color: var(--text-primary); line-height: 1.1; }
+.ov-stat-label { font-size: 12px; color: var(--text-secondary); }
+.ov-stat-sub { font-size: 11px; color: var(--text-muted); }
+
+.ov-badge {
+    font-size: 10px; font-weight: 600; padding: 2px 7px; border-radius: 6px;
+    background: var(--bg-hover); color: var(--text-secondary); white-space: nowrap;
+}
+.ov-desc {
+    font-size: 12px; color: var(--text-secondary); line-height: 1.4;
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.ov-session .ov-dot { display: none; }
+.ov-proj-label {
+    font-size: 11px; font-weight: 600; color: var(--text-secondary);
+    margin: 12px 0 6px; font-family: Menlo, Monaco, monospace;
+}
+.ov-proj-label:first-of-type { margin-top: 0; }
 .ov-section-title {
     font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px;
     color: var(--text-muted); margin: 22px 0 10px;

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -40,6 +40,7 @@ var _wsSavedCommands = [];   // [{ id, name, command }]
 var _wsSavedLayouts = [];    // [{ id, name, tabs:[{name,panes:[{cmd}]}] }]
 var _wsRoot = null;          // the live .workspace-wrap element (kept across view switches)
 var _wsFocusedPaneId = null; // the pane the user is currently in (target for commands)
+var _wsPendingOpen = null;   // {name?, cwd?, panes?} to open on the next mount (see openInWorkspace)
 
 // Mark a pane as focused: remember it and highlight its box so it's obvious
 // where a launched command will land.
@@ -93,24 +94,37 @@ function _wsEnsureStatusBar() {
   return bar;
 }
 
+var _wsStatusSig = '';
 function _wsUpdateStatusBar() {
   var bar = _wsEnsureStatusBar();
   if (!bar) return;
   var items = _wsAllPanes().filter(function (x) { return x.pane.sock || x.pane.exited; });
-  if (!items.length) { bar.style.display = 'none'; bar.innerHTML = ''; return; }
+  if (!items.length) {
+    if (_wsStatusSig !== '') { _wsStatusSig = ''; bar.style.display = 'none'; bar.innerHTML = ''; }
+    return;
+  }
 
   var counts = { active: 0, idle: 0, limit: 0, exited: 0 };
+  var sigParts = [];
   var chips = items.map(function (x) {
     var st = _wsPaneStatus(x.pane);
     counts[st]++;
     var meta = WS_STATUS_META[st];
-    var cmd = x.pane.cmd ? x.pane.cmd.split(/\s+/)[0].replace(/^\w+=.*/, '') || x.pane.cmd : 'shell';
-    var label = escHtml(x.tab.name) + ' · ' + escHtml(cmd);
-    return '<button class="ws-chip ' + meta.cls + '" title="' + escHtml(x.pane.cwd || '') + '" ' +
+    // The chip shows the (renamable) tab name only — clean and stable. The
+    // command lands in the tooltip so it never makes the bar jitter.
+    var tip = (x.pane.cwd || '') + (x.pane.cmd ? '  —  ' + _wsMaskSecrets(x.pane.cmd) : '');
+    sigParts.push(x.tab.id + ':' + x.pane.id + ':' + x.tab.name + ':' + st);
+    return '<button class="ws-chip ' + meta.cls + '" title="' + escHtml(tip) + '" ' +
       'onclick="jumpToWorkspacePane(\'' + escHtml(x.tab.id) + '\',\'' + escHtml(x.pane.id) + '\')">' +
-      '<span class="ws-chip-dot"></span>' + label +
+      '<span class="ws-chip-dot"></span>' + escHtml(x.tab.name) +
       '<span class="ws-chip-st">' + meta.label + '</span></button>';
   }).join('');
+
+  // Skip the DOM rebuild when nothing changed — this is what stops the bar
+  // from visibly "twitching" on every 1s tick.
+  var sig = sigParts.join('|');
+  if (sig === _wsStatusSig) return;
+  _wsStatusSig = sig;
 
   var summary = '<span class="ws-sb-title">Terminals</span>' +
     '<span class="ws-sb-count">' + items.length + '</span>' +
@@ -282,7 +296,8 @@ function _wsConnectPane(pane) {
 
   var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
   var url = proto + '//' + location.host + '/ws/terminal' +
-    '?token=' + encodeURIComponent(_wsToken) + '&cols=' + term.cols + '&rows=' + term.rows;
+    '?token=' + encodeURIComponent(_wsToken) + '&cols=' + term.cols + '&rows=' + term.rows +
+    (pane.wantCwd ? '&cwd=' + encodeURIComponent(pane.wantCwd) : '');
   var sock = new WebSocket(url);
   sock.binaryType = 'arraybuffer';
   pane.sock = sock;
@@ -298,7 +313,10 @@ function _wsConnectPane(pane) {
       if (msg.t === 'ready') {
         pane.cwd = msg.cwd;
         setStatus(_wsShortCwd(msg.cwd));
+        // cmd auto-runs (trailing \r); prefill is typed but NOT executed so the
+        // user can review/edit a resume command before pressing Enter.
         if (pane.cmd) setTimeout(function () { if (sock.readyState === 1) sock.send(enc.encode(pane.cmd + '\r')); }, 120);
+        else if (pane.prefill) setTimeout(function () { if (sock.readyState === 1) sock.send(enc.encode(pane.prefill)); if (pane.term) pane.term.focus(); }, 120);
       } else if (msg.t === 'exit') { pane.exited = true; setStatus('exited (' + msg.code + ')'); _wsUpdateStatusBar(); }
       else if (msg.t === 'error') { setStatus('error'); term.write('\r\n\x1b[31m' + (msg.message || 'error') + '\x1b[0m\r\n'); }
       return;
@@ -437,6 +455,74 @@ function addWorkspaceTab() {
   _wsRenderAll();
 }
 
+// ── Open a project / resume a session into the terminal ──────────────────────
+// A "spec" describes a tab to open: { name?, cwd?, panes?:[{cwd,cmd,prefill}] }.
+// If panes is omitted, a single pane is created from the top-level cwd/cmd/prefill.
+function _wsProjectBasename(p) {
+  if (!p) return '';
+  return String(p).replace(/[\/\\]+$/, '').split(/[\/\\]/).pop() || String(p);
+}
+function _wsTabName(spec) {
+  return spec.name || _wsProjectBasename(spec.cwd) || ('Tab ' + (_wsTabs.length + 1));
+}
+function _wsBuildPanes(spec) {
+  var list = (spec.panes && spec.panes.length) ? spec.panes
+    : [{ cwd: spec.cwd, cmd: spec.cmd, prefill: spec.prefill }];
+  list = list.slice(0, MAX_WS_PANES);
+  return list.map(function (pc) {
+    return { id: 'p' + (++_wsPaneSeq), cmd: pc.cmd || null, prefill: pc.prefill || null, wantCwd: pc.cwd || null };
+  });
+}
+
+// Open a spec in the Workspace. If the terminal is already mounted, append a new
+// tab; otherwise stash it and let renderWorkspace seed it as the first tab.
+function openInWorkspace(spec) {
+  if (_wsRoot) {
+    var tab = { id: 't' + (++_wsTabSeq), name: _wsTabName(spec), panes: _wsBuildPanes(spec) };
+    _wsTabs.push(tab);
+    _wsActiveTabId = tab.id;
+    _wsRenderAll();
+  } else {
+    _wsPendingOpen = spec;
+  }
+  if (typeof setView === 'function') setView('workspace');
+}
+
+// Best-effort per-agent resume command. Prefilled (not auto-run) so the user
+// can review/edit before pressing Enter — safe even where syntax varies.
+function _wsResumeCommand(tool, id) {
+  switch (tool) {
+    case 'claude':
+    case 'claude-ext': return 'claude --resume ' + id;
+    case 'codex': return 'codex resume ' + id;
+    case 'opencode': return 'opencode';
+    case 'kiro': return 'kiro-cli';
+    case 'qwen': return 'qwen';
+    case 'gemini': return 'gemini';
+    case 'pi': return 'pi';
+    default: return '';
+  }
+}
+
+// Card action: open a pane in the session's project folder with the agent's
+// resume command prefilled (awaiting Enter). Used by the session cards.
+function openSessionInWorkspace(sessionId) {
+  var list = (typeof allSessions !== 'undefined' && allSessions) ? allSessions : [];
+  var s = list.find(function (x) { return x.id === sessionId; });
+  if (!s) return;
+  var cwd = s.git_root || s.project || null;
+  var resume = _wsResumeCommand(s.tool, s.id);
+  openInWorkspace({ name: _wsProjectBasename(cwd) || s.tool, cwd: cwd, prefill: resume || null });
+}
+
+// Projects action: open up to `n` (1-4) panes all cd'd into a project folder.
+function spawnProjectTerminals(cwd, n) {
+  n = Math.max(1, Math.min(MAX_WS_PANES, parseInt(n, 10) || 1));
+  var panes = [];
+  for (var i = 0; i < n; i++) panes.push({ cwd: cwd });
+  openInWorkspace({ name: _wsProjectBasename(cwd), cwd: cwd, panes: panes });
+}
+
 function activateWorkspaceTab(id) {
   if (id === _wsActiveTabId) return;
   _wsActiveTabId = id;
@@ -448,6 +534,9 @@ function activateWorkspaceTab(id) {
 function closeWorkspaceTab(id) {
   var idx = _wsTabs.findIndex(function (t) { return t.id === id; });
   if (idx < 0) return;
+  var live = _wsTabs[idx].panes.filter(_wsPaneLive).length;
+  if (live > 0 && !confirm('Close this tab and its ' + live + ' running terminal' +
+      (live === 1 ? '' : 's') + '?')) return;
   _wsTabs[idx].panes.forEach(_wsTeardownPane);
   _wsTabs.splice(idx, 1);
   if (_wsTabs.length === 0) { addWorkspaceTab(); return; }
@@ -479,10 +568,22 @@ function renameWorkspaceTab(id) {
 }
 
 // ── pane ops (operate on the active tab) ────────────────────────────────────
+// A pane is "live" if its terminal is connected and hasn't exited — closing it
+// would kill whatever is running, so we confirm before destroying live panes.
+function _wsPaneLive(p) { return !!(p && p.sock && p.sock.readyState === 1 && !p.exited); }
+
 function setWorkspaceLayout(n) {
   var tab = _wsActiveTab();
   if (!tab) return;
   n = Math.max(1, Math.min(MAX_WS_PANES, n));
+  if (n < tab.panes.length) {
+    var live = tab.panes.slice(n).filter(_wsPaneLive).length;
+    if (live > 0 && !confirm('Switching layout will close ' + live + ' running terminal' +
+        (live === 1 ? '' : 's') + ' in this tab. Continue?')) {
+      _wsSyncLayoutButtons(); // keep the button selection in sync with reality
+      return;
+    }
+  }
   while (tab.panes.length < n) tab.panes.push({ id: 'p' + (++_wsPaneSeq), cmd: null });
   while (tab.panes.length > n) _wsTeardownPane(tab.panes.pop());
   _wsRenderPanes(); _wsSyncLayoutButtons();
@@ -812,7 +913,14 @@ async function renderWorkspace(container) {
 
   // Remember the root so future view switches detach/re-attach it (never rebuild).
   _wsRoot = container.querySelector('.workspace-wrap');
-  _wsTabs = [{ id: 't' + (++_wsTabSeq), name: 'Tab 1', panes: [{ id: 'p' + (++_wsPaneSeq), cmd: null }] }];
+  // If something asked to open a project/session before the terminal had
+  // mounted, seed that tab as the initial one (no throwaway "Tab 1").
+  if (_wsPendingOpen) {
+    var spec = _wsPendingOpen; _wsPendingOpen = null;
+    _wsTabs = [{ id: 't' + (++_wsTabSeq), name: _wsTabName(spec), panes: _wsBuildPanes(spec) }];
+  } else {
+    _wsTabs = [{ id: 't' + (++_wsTabSeq), name: 'Tab 1', panes: [{ id: 'p' + (++_wsPaneSeq), cmd: null }] }];
+  }
   _wsActiveTabId = _wsTabs[0].id;
   _wsRenderAll();
   _wsLoadCommands();


### PR DESCRIPTION
## Overview → a real dashboard
- Headline stats: sessions, active agents, terminals, total/today spend
- Recent sessions as clickable cards
- Live terminals grouped by project folder

## Terminals ↔ projects (the requested feature)
- **Session cards → "Open here"**: opens a pane in that session's project folder with the agent's resume command *prefilled* (you press Enter — never auto-runs)
- **Projects → "Terminal ▾"**: open up to 4 panes cd'd into a project folder; each project shows how many terminals are running in it with a jump link
- Panes accept a `cwd` (WS `&cwd=`, gated by `isSafeLaunchPath`) and a prefill typed without Enter

## Safety fix
- Shrinking a tab's split layout, or closing a tab, now **confirms before killing live terminals** (previously destroyed them silently)

## Sidebar
- **Whole-sidebar collapse** toggle (persisted) + floating reopen handle
- Sections always **start collapsed**; expanding is transient — fixes stale stored state that kept everything expanded
- **Terminal** promoted to a top-level item; groups renamed **Sessions / Agents / Tools**

## Polish
- Top status bar shows the (renamable) tab name, command in tooltip, no more per-second jitter
- "Add project" autocompletes from your known session folders

## Testing
- 182 tests pass / 0 fail / 2 skipped (win32-only)
- Full browser pass (Playwright): Overview stats+grouping, Open-here (mounted & cold), 4-pane project spawn, layout-shrink confirm (accept + cancel-preserves), whole-sidebar collapse/reopen persistence, section-expand transient across reload, folder autocomplete (78 folders), zero app console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)