### PR TITLE
fix: let Overview and Recommended tiles fill the available width

### DIFF
--- a/src/frontend/recommended.js
+++ b/src/frontend/recommended.js
@@ -78,7 +78,7 @@ function toggleToolInstalled(id) {
 
 function renderRecommended(container) {
   var installed = _loadInstalledTools();
-  var html = '<div class="changelog-container">';
+  var html = '<div class="tools-container">';
   html += '<h2 class="heatmap-title">Recommended tools</h2>';
   html += '<p class="tools-intro">Handpicked companion apps that pair well with codbash. Tick the ones you already have.</p>';
   html += '<div class="tools-grid">';

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2877,7 +2877,7 @@ body.sidebar-hidden .toolbar { padding-left: 52px; }
 .workspace-tabpanes { flex: 1; min-height: 0; display: flex; }
 
 /* ── Overview landing ── */
-.ov-wrap { padding: 24px; max-width: 1040px; }
+.ov-wrap { padding: 24px; }
 .ov-head { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 16px; }
 .ov-sub { font-size: 13px; color: var(--text-muted); margin-top: 4px; }
 .ov-primary { border-color: var(--accent-blue); color: var(--accent-blue); }
@@ -3067,6 +3067,7 @@ body.sidebar-hidden .toolbar { padding-left: 52px; }
 .changelog-container { padding: 20px; max-width: 700px; }
 
 /* ── Recommended tools view ────────────────────────────────── */
+.tools-container { padding: 20px; }
 .tools-intro {
     color: var(--text-secondary);
     font-size: 13px;
@@ -3074,7 +3075,7 @@ body.sidebar-hidden .toolbar { padding-left: 52px; }
 }
 .tools-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 14px;
 }
 .tool-card {


### PR DESCRIPTION
## What

On wide screens the **Overview** and **Recommended** views were squeezed to the left with a lot of dead space on the right — unlike Sessions / Projects, which span the full content area.

Cause:
- `.ov-wrap` was capped at `max-width: 1040px`
- Recommended rendered inside `.changelog-container` (`max-width: 700px`), inheriting the changelog's deliberately narrow column

## Changes

- Drop the 1040px cap on `.ov-wrap` — stats, terminal cards and recent-session tiles now flow across the full width (same behavior as Sessions/Projects grids)
- Give Recommended its own full-width `.tools-container` instead of reusing the changelog container
- Switch `.tools-grid` from `auto-fill` to `auto-fit` so the few curated cards stretch evenly across the row instead of leaving empty tracks

## Testing

- `node --test test/*.test.js` — 183 pass, 0 fail (same as CI)
- Verified in browser at 1680px and 900px: tiles fill the width on wide screens, collapse to 2 columns on narrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)