### PR TITLE
feat(desktop): Electron shell for macOS (additive)

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+build/icon.icns
+*.dmg

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,73 @@
+# codbash desktop (Electron)
+
+A native window around the **unmodified** codbash server. This is an *addition*:
+the npm CLI (`codbash run`) and the zero-dependency core are untouched — Electron
+lives entirely in this folder with its own `package.json`.
+
+## How it works
+
+`main.js` (Electron main process):
+
+1. picks a free loopback port,
+2. spawns the real codbash server as a **Node child process**
+   (`node ../bin/cli.js run --port=<p> --host=127.0.0.1 --no-browser`),
+3. waits until `http://127.0.0.1:<p>/` answers,
+4. opens a `BrowserWindow` pointed at it.
+
+The server runs under a normal Node runtime (not Electron's), so the prebuilt
+native `@lydell/node-pty` loads with no rebuild — **the browser terminal keeps
+working**. External `http(s)` links open in the user's real browser.
+
+## Run in development
+
+```bash
+# from the repo root, make sure core deps (incl. the optional terminal) are present
+npm install
+
+cd desktop
+npm install          # fetches electron + electron-builder (dev-only)
+npm start            # launches the app window
+```
+
+Smoke test (launches, verifies server+window, auto-quits):
+
+```bash
+npm run smoke
+```
+
+Override the Node binary used for the server child (rarely needed):
+
+```bash
+CODBASH_NODE=/usr/local/bin/node npm start
+```
+
+## Build a macOS app
+
+```bash
+cd desktop
+npm run dist:mac     # → dist/codbash-<version>.dmg  (universal arm64 + x64)
+```
+
+### Before you ship it
+
+- **Icon**: drop a `build/icon.icns` (1024×1024 source). Without it Electron uses a default icon.
+- **Bundled Node**: the packaged app spawns `node` from `PATH`. For a self-contained
+  DMG, place a `node` binary in the app resources (electron-builder `extraResources`)
+  and `resolveNodeBin()` will prefer it. Most codbash users already have Node, so
+  PATH works out of the box for a dev/internal build.
+- **node_modules**: `@lydell/node-pty` is copied into the packaged resources
+  (see `extraResources`). If you add other optional runtime deps, copy them too.
+- **Signing + notarization** (for Gatekeeper / distribution outside the App Store):
+  set `CSC_LINK`/`CSC_KEY_PASSWORD` (Developer ID cert) and configure notarization
+  in `build.mac`. Do **not** target the Mac App Store — codbash spawns processes,
+  drives Terminal.app via AppleScript, and reads across the filesystem, which the
+  App Store sandbox forbids.
+
+## What is NOT cut
+
+Nothing functional. A desktop app has the same (local) privileges the CLI relies
+on, so sessions, cost, the browser terminal, project launch, terminal detection,
+etc. all work. The only *replacements* for a packaged build are: self-update
+(use an Electron updater instead of `npm i -g`) and not assuming a system
+`sqlite3` on PATH under a sandbox (codbash shells out to it for the SQLite-backed
+agents; macOS ships `sqlite3`, so unsandboxed builds are fine).

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,0 +1,140 @@
+// codbash desktop — Electron shell around the existing codbash server.
+//
+// Design goal: an ADDITION, never a downgrade. We do NOT reimplement anything.
+// The Electron main process boots the unmodified codbash server as a real Node
+// child process (so the native @lydell/node-pty loads under its own Node ABI —
+// no Electron rebuild, the browser terminal keeps working), waits until it
+// answers, then points a BrowserWindow at it.
+'use strict';
+
+const { app, BrowserWindow, shell, dialog, Menu } = require('electron');
+const { spawn } = require('child_process');
+const http = require('http');
+const net = require('net');
+const path = require('path');
+const fs = require('fs');
+
+let serverProc = null;
+let win = null;
+let serverPort = 0;
+const SMOKE = !!process.env.CODBASH_SMOKE; // launch, verify, auto-quit (CI/local test)
+
+// Grab an ephemeral loopback port the OS hands us, then release it for the server.
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Where the codbash server lives: repo layout in dev, bundled resources when packaged.
+function resolveServerEntry() {
+  const dev = path.join(__dirname, '..', 'bin', 'cli.js');
+  const packaged = path.join(process.resourcesPath || '', 'app', 'bin', 'cli.js');
+  return app.isPackaged ? packaged : dev;
+}
+
+// The Node binary used to run the server. We deliberately avoid Electron's own
+// Node (ELECTRON_RUN_AS_NODE) because its ABI differs from the prebuilt
+// node-pty. Prefer an explicit override, then a bundled node, then PATH node.
+function resolveNodeBin() {
+  if (process.env.CODBASH_NODE) return process.env.CODBASH_NODE;
+  const bundled = path.join(process.resourcesPath || '', process.platform === 'win32' ? 'node.exe' : 'node');
+  try { if (app.isPackaged && fs.existsSync(bundled)) return bundled; } catch (_e) {}
+  return process.platform === 'win32' ? 'node.exe' : 'node';
+}
+
+function startServer(port) {
+  const entry = resolveServerEntry();
+  const nodeBin = resolveNodeBin();
+  serverProc = spawn(nodeBin, [entry, 'run', '--port=' + port, '--host=127.0.0.1', '--no-browser'], {
+    env: Object.assign({}, process.env, { CODEDASH_HOST: '127.0.0.1' }),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  serverProc.stdout.on('data', function (d) { process.stdout.write('[codbash] ' + d); });
+  serverProc.stderr.on('data', function (d) { process.stderr.write('[codbash] ' + d); });
+  serverProc.on('exit', function (code) {
+    serverProc = null;
+    if (!app.isQuitting && !SMOKE) {
+      dialog.showErrorBox('codbash stopped', 'The codbash server exited (code ' + code + ').');
+      app.quit();
+    }
+  });
+}
+
+function waitForServer(port, timeoutMs) {
+  const deadline = Date.now() + (timeoutMs || 20000);
+  return new Promise(function (resolve, reject) {
+    function attempt() {
+      const req = http.get({ host: '127.0.0.1', port: port, path: '/', timeout: 1500 }, function (res) {
+        res.resume();
+        if (res.statusCode && res.statusCode < 500) resolve();
+        else retry();
+      });
+      req.on('error', retry);
+      req.on('timeout', function () { req.destroy(); retry(); });
+    }
+    function retry() {
+      if (Date.now() > deadline) reject(new Error('codbash server did not become ready in time'));
+      else setTimeout(attempt, 300);
+    }
+    attempt();
+  });
+}
+
+async function createWindow() {
+  win = new BrowserWindow({
+    width: 1320,
+    height: 860,
+    minWidth: 920,
+    minHeight: 600,
+    title: 'codbash',
+    backgroundColor: '#0b0d12',
+    webPreferences: { contextIsolation: true, nodeIntegration: false, spellcheck: false },
+  });
+
+  // http/https links open in the user's real browser, not inside the app.
+  win.webContents.setWindowOpenHandler(function (details) {
+    if (/^https?:/i.test(details.url)) { shell.openExternal(details.url); return { action: 'deny' }; }
+    return { action: 'allow' };
+  });
+
+  await win.loadURL('http://127.0.0.1:' + serverPort + '/');
+
+  if (SMOKE) {
+    // Smoke test: prove the window + server came up, then leave cleanly.
+    process.stdout.write('[desktop] SMOKE OK — window loaded on port ' + serverPort + '\n');
+    setTimeout(function () { app.isQuitting = true; app.quit(); }, 1200);
+  }
+}
+
+app.whenReady().then(async function () {
+  try {
+    serverPort = await getFreePort();
+    startServer(serverPort);
+    await waitForServer(serverPort);
+    await createWindow();
+  } catch (e) {
+    dialog.showErrorBox('codbash failed to start', String((e && e.message) || e));
+    app.isQuitting = true;
+    app.quit();
+    return;
+  }
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('before-quit', function () {
+  app.isQuitting = true;
+  if (serverProc) { try { serverProc.kill(); } catch (_e) {} }
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "codbash-desktop",
+  "productName": "codbash",
+  "version": "7.13.0",
+  "private": true,
+  "description": "Desktop shell (Electron) for codbash — wraps the codbash server in a native window.",
+  "main": "main.js",
+  "author": "Valerii Kovalskii",
+  "license": "MIT",
+  "scripts": {
+    "start": "electron .",
+    "smoke": "CODBASH_SMOKE=1 electron .",
+    "dist:mac": "electron-builder --mac dmg",
+    "pack": "electron-builder --dir"
+  },
+  "devDependencies": {
+    "electron": "^33.2.0",
+    "electron-builder": "^25.1.8"
+  },
+  "build": {
+    "appId": "dev.codbash.desktop",
+    "productName": "codbash",
+    "asar": true,
+    "files": [
+      "main.js",
+      "preload.js"
+    ],
+    "extraResources": [
+      { "from": "../bin", "to": "app/bin" },
+      { "from": "../src", "to": "app/src" },
+      { "from": "../package.json", "to": "app/package.json" },
+      { "from": "../node_modules/@lydell", "to": "app/node_modules/@lydell" }
+    ],
+    "mac": {
+      "category": "public.app-category.developer-tools",
+      "target": [
+        { "target": "dmg", "arch": ["arm64", "x64"] }
+      ],
+      "icon": "build/icon.icns"
+    },
+    "dmg": {
+      "title": "codbash ${version}"
+    }
+  }
+}


### PR DESCRIPTION
Adds a `desktop/` Electron wrapper around the **unmodified** codbash server. Purely additive — the zero-dependency CLI core and the published npm package are untouched; Electron lives only in `desktop/` with its own `package.json`.

## How it works
Electron main → picks a free loopback port → spawns the real server as a **Node child** (`node bin/cli.js run --no-browser`) → waits until it answers → opens a `BrowserWindow`.

Running the server under a normal Node runtime (not Electron's ABI) means the prebuilt `@lydell/node-pty` loads with **no rebuild — the browser terminal keeps working**. External links open in the system browser.

## Verified
`CODBASH_SMOKE=1 electron .` boots the server on an ephemeral port (62461), loads the window, serves `/api/sessions`, and quits cleanly.

## Not cut
Nothing functional — a desktop app has the same local privileges the CLI relies on. For a *packaged/notarized* build the only replacements are: an Electron updater instead of `npm i -g`, and not assuming a sandboxed `sqlite3` (macOS ships it; ship unsandboxed / outside the App Store). See `desktop/README.md`.

## Follow-ups (documented, not blocking)
- `build/icon.icns`
- bundle a `node` binary for a self-contained DMG (PATH node works for dev/internal)
- Developer ID signing + notarization

🤖 Generated with [Claude Code](https://claude.com/claude-code)