### PR TITLE
feat(desktop): notify-based updates via GitHub Releases

### DIFF
--- a/desktop/RELEASE.md
+++ b/desktop/RELEASE.md
@@ -69,12 +69,23 @@ xcrun stapler validate "dist/mac-arm64/codbash.app"
 spctl -a -vvv -t install "dist/mac-arm64/codbash.app"
 ```
 
-## 4. Auto-update
+## 4. Updates
 
-The packaged app calls `autoUpdater.checkForUpdatesAndNotify()` on launch and
-every 6 hours. It reads `latest-mac.yml` from the GitHub Release, downloads a
-newer signed DMG in the background, and installs it on quit. Nothing to do
-beyond publishing each release with `--publish always`.
+Two models, depending on whether the build is signed:
+
+- **Now (unsigned): notify-only.** On launch and every 6h the app queries the
+  GitHub `releases/latest` API and, if a newer version exists, offers to open
+  the download page (`main.js` → `checkForUpdates`). This works without signing.
+  Just publish each release (`gh release create v<x> dist/*.dmg …` or
+  `--publish always`) and users get notified.
+- **Later (signed): silent auto-update.** Once a Developer ID cert is in place,
+  swap `checkForUpdates` for `electron-updater`: `npm i electron-updater`, call
+  `autoUpdater.checkForUpdatesAndNotify()`, and publish with `--publish always`
+  so `latest-mac.yml` + the signed DMG land in the Release. macOS silent
+  in-place update **requires** the signature, which is why it's gated on the cert.
+
+The first desktop release (v7.13.0, unsigned, arm64) is published at
+`https://github.com/vakovalskii/codbash/releases/tag/v7.13.0`.
 
 ## CI note
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -113,20 +113,65 @@ async function createWindow() {
   }
 }
 
-// Auto-update from GitHub Releases (only in a packaged, signed build — a dev
-// run has nothing to update against). Failures are non-fatal.
-function initAutoUpdater() {
-  if (!app.isPackaged || SMOKE) return;
-  try {
-    const { autoUpdater } = require('electron-updater');
-    autoUpdater.autoDownload = true;
-    autoUpdater.on('error', function (err) { process.stderr.write('[updater] ' + err + '\n'); });
-    autoUpdater.checkForUpdatesAndNotify();
-    // Re-check every 6 hours while the app stays open.
-    setInterval(function () { autoUpdater.checkForUpdatesAndNotify(); }, 6 * 60 * 60 * 1000);
-  } catch (e) {
-    process.stderr.write('[updater] disabled: ' + (e && e.message) + '\n');
+// Simple semver-ish "is a newer than b" (major.minor.patch).
+function isNewerVersion(a, b) {
+  const pa = String(a).split('.').map(Number);
+  const pb = String(b).split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return true;
+    if ((pa[i] || 0) < (pb[i] || 0)) return false;
   }
+  return false;
+}
+
+// Update check via GitHub Releases. We use a NOTIFY model (fetch the latest
+// release, and if it's newer, offer to open the download page) rather than
+// silent in-place replacement: silent auto-update on macOS requires a signed
+// build, and codbash currently ships unsigned. Once a Developer ID signing
+// identity is in place this can be swapped for electron-updater's silent flow.
+function checkForUpdates(interactive) {
+  if (SMOKE) return;
+  const current = app.getVersion();
+  const opts = {
+    host: 'api.github.com',
+    path: '/repos/vakovalskii/codbash/releases/latest',
+    headers: { 'User-Agent': 'codbash-desktop', 'Accept': 'application/vnd.github+json' },
+    timeout: 8000,
+  };
+  const req = https.get(opts, function (res) {
+    let d = '';
+    res.on('data', function (c) { d += c; });
+    res.on('end', function () {
+      let rel;
+      try { rel = JSON.parse(d); } catch (_e) { return; }
+      const latest = String(rel.tag_name || '').replace(/^v/, '');
+      if (latest && isNewerVersion(latest, current)) {
+        const { dialog } = require('electron');
+        dialog.showMessageBox({
+          type: 'info',
+          message: 'codbash ' + latest + ' is available',
+          detail: 'You have ' + current + '. Open the download page?',
+          buttons: ['Download', 'Later'],
+          defaultId: 0,
+          cancelId: 1,
+        }).then(function (r) {
+          if (r.response === 0) shell.openExternal(rel.html_url || 'https://github.com/vakovalskii/codbash/releases/latest');
+        });
+      } else if (interactive) {
+        const { dialog } = require('electron');
+        dialog.showMessageBox({ type: 'info', message: 'codbash is up to date', detail: 'Version ' + current + '.', buttons: ['OK'] });
+      }
+    });
+  });
+  req.on('error', function () {});
+  req.on('timeout', function () { req.destroy(); });
+}
+
+function initAutoUpdater() {
+  if (SMOKE) return;
+  checkForUpdates(false);
+  // Re-check every 6 hours while the app stays open.
+  setInterval(function () { checkForUpdates(false); }, 6 * 60 * 60 * 1000);
 }
 
 app.whenReady().then(async function () {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,9 +14,6 @@
     "release:mac": "electron-builder --mac dmg --publish always",
     "pack": "electron-builder --dir"
   },
-  "dependencies": {
-    "electron-updater": "^6.3.9"
-  },
   "devDependencies": {
     "@electron/notarize": "^2.5.0",
     "electron": "^33.2.0",
@@ -29,22 +26,43 @@
     "afterSign": "scripts/notarize.js",
     "files": [
       "main.js",
-      "preload.js",
-      "node_modules/**/*"
+      "preload.js"
     ],
     "extraResources": [
-      { "from": "../bin", "to": "app/bin" },
-      { "from": "../src", "to": "app/src" },
-      { "from": "../package.json", "to": "app/package.json" },
-      { "from": "../node_modules/@lydell", "to": "app/node_modules/@lydell" }
+      {
+        "from": "../bin",
+        "to": "app/bin"
+      },
+      {
+        "from": "../src",
+        "to": "app/src"
+      },
+      {
+        "from": "../package.json",
+        "to": "app/package.json"
+      },
+      {
+        "from": "../node_modules/@lydell",
+        "to": "app/node_modules/@lydell"
+      }
     ],
     "publish": [
-      { "provider": "github", "owner": "vakovalskii", "repo": "codbash" }
+      {
+        "provider": "github",
+        "owner": "vakovalskii",
+        "repo": "codbash"
+      }
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [
-        { "target": "dmg", "arch": ["arm64", "x64"] }
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
       ],
       "icon": "build/icon.png",
       "hardenedRuntime": true,


### PR DESCRIPTION
Silent auto-update on macOS needs a signed build; codbash ships unsigned for now. The desktop app therefore uses a **notify** model: on launch + every 6h it checks the GitHub `releases/latest` API and offers to open the download page when a newer version exists. Swappable for electron-updater's silent flow once a Developer ID cert is in place.

Also drops the electron-updater runtime dep (app now needs only Electron + stdlib).

First desktop release published: **v7.13.0** (unsigned, arm64) — https://github.com/vakovalskii/codbash/releases/tag/v7.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)