### PR TITLE
fix(csp): allow GitHub avatar images in img-src

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -121,7 +121,9 @@ function startServer(host, port, openBrowser = true) {
           "font-src 'self' https://fonts.gstatic.com",
           // ws:/wss: for the browser terminal (same-origin WebSocket to /ws/terminal)
           "connect-src 'self' ws: wss:",
-          "img-src 'self' data:",
+          // avatars.githubusercontent.com serves GitHub profile avatars shown in
+          // the cloud profile and leaderboard (avatar_url from the GitHub API)
+          "img-src 'self' data: https://avatars.githubusercontent.com",
           "frame-ancestors 'none'",
           "base-uri 'self'",
         ].join('; '),


### PR DESCRIPTION
## Problem

The cloud profile and leaderboard render GitHub profile avatars from `avatar_url` (`https://avatars.githubusercontent.com/...`), but the `Content-Security-Policy` `img-src` directive only allows `'self'` and `data:`. The browser blocks them:

```
Loading the image 'https://avatars.githubusercontent.com/u/4038111?v=4' violates the
following Content Security Policy directive: "img-src 'self' data:". The action has been blocked.
```

Avatars show as broken images in the UI.

## Fix

Add `https://avatars.githubusercontent.com` to the `img-src` directive in `src/server.js`. Scope is limited to the single GitHub avatar host — no wildcards, other directives untouched.

## Test
- Open the dashboard with a GitHub cloud profile / leaderboard data → avatars now load, no CSP violation in the console.
- `curl -sD - http://localhost:PORT/ | grep -i content-security-policy` shows `img-src 'self' data: https://avatars.githubusercontent.com`.