### PR TITLE
fix: layout save in desktop app + tidier terminal naming (v7.14.1)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codbash-desktop",
   "productName": "codbash",
-  "version": "7.14.0",
+  "version": "7.14.1",
   "private": true,
   "description": "Desktop shell (Electron) for codbash — wraps the codbash server in a native window.",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.14.0",
+  "version": "7.14.1",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,17 @@
 
 const CHANGELOG = [
   {
+    version: '7.14.1',
+    date: '2026-07-20',
+    title: 'Layout save fix + tidier terminal naming',
+    changes: [
+      'Fixed "Save layout" doing nothing in the desktop app — it used the browser prompt, which Electron ignores; now uses an in-app dialog',
+      'Terminal pane headers show the folder name (e.g. "codbash") or the running agent, instead of a bare "~/path"',
+      'Smaller, tidier rename (✎) button on tabs — fixed a style clash with the rename field',
+      'Cmd+D opens a new terminal tab',
+    ],
+  },
+  {
     version: '7.14.0',
     date: '2026-07-20',
     title: 'Named terminals, macOS desktop app',

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -630,6 +630,39 @@ function fallbackCopyText(text) {
   }
 }
 
+// A promise-based text prompt that works everywhere — notably in the Electron
+// desktop app, where window.prompt() is a no-op (returns undefined). Resolves
+// to the entered string, or null if cancelled.
+function codbashPrompt(message, defaultValue) {
+  return new Promise(function (resolve) {
+    var overlay = document.createElement('div');
+    overlay.className = 'cb-prompt-overlay';
+    overlay.innerHTML =
+      '<div class="cb-prompt" role="dialog" aria-modal="true">' +
+        '<div class="cb-prompt-msg"></div>' +
+        '<input type="text" class="cb-prompt-input" />' +
+        '<div class="cb-prompt-actions">' +
+          '<button type="button" class="toolbar-btn cb-prompt-cancel">Cancel</button>' +
+          '<button type="button" class="toolbar-btn cb-prompt-ok">OK</button>' +
+        '</div>' +
+      '</div>';
+    overlay.querySelector('.cb-prompt-msg').textContent = message || '';
+    var input = overlay.querySelector('.cb-prompt-input');
+    input.value = defaultValue == null ? '' : String(defaultValue);
+    document.body.appendChild(overlay);
+    setTimeout(function () { input.focus(); input.select(); }, 20);
+    var done = false;
+    function close(val) { if (done) return; done = true; overlay.remove(); resolve(val); }
+    overlay.querySelector('.cb-prompt-ok').onclick = function () { close(input.value); };
+    overlay.querySelector('.cb-prompt-cancel').onclick = function () { close(null); };
+    overlay.addEventListener('mousedown', function (e) { if (e.target === overlay) close(null); });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); close(input.value); }
+      else if (e.key === 'Escape') { e.preventDefault(); close(null); }
+    });
+  });
+}
+
 function copyText(text, successMsg) {
   var done = function() {
     showToast(successMsg || ('Copied: ' + text));
@@ -637,7 +670,7 @@ function copyText(text, successMsg) {
   };
   var fail = function() {
     if (fallbackCopyText(text)) return done();
-    prompt('Copy this command:', text);
+    codbashPrompt('Copy this command:', text);
     showToast(window.isSecureContext ? 'Clipboard copy failed' : 'Clipboard unavailable on non-secure origin');
     return false;
   };
@@ -2901,6 +2934,15 @@ function deleteFocused() {
 }
 
 document.addEventListener('keydown', function(e) {
+  // Cmd+D (macOS) / Ctrl+Shift+D → new terminal tab. Cmd is safe in the app
+  // (the shell uses Ctrl+D for EOF, which we never intercept).
+  if ((e.key === 'd' || e.key === 'D') && (e.metaKey || (e.ctrlKey && e.shiftKey)) && !e.altKey) {
+    e.preventDefault();
+    if (typeof setView === 'function' && currentView !== 'workspace') setView('workspace');
+    var openTab = function () { if (typeof addWorkspaceTab === 'function') addWorkspaceTab(); };
+    if (currentView === 'workspace' && window._wsRoot) openTab(); else setTimeout(openTab, 120);
+    return;
+  }
   if (e.key === 'Escape') {
     if (pendingDelete) {
       closeConfirm();

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -2859,13 +2859,39 @@ body.sidebar-hidden .toolbar { padding-left: 52px; }
     cursor: pointer; padding: 0 2px; border-radius: 4px;
 }
 .ws-tab-close:hover { color: var(--accent-red); }
-.ws-tab-rename {
-    font-size: 11px; line-height: 1;
+.ws-tab-rename-btn {
+    font-size: 9px; line-height: 1;
     background: transparent; border: none; color: var(--text-muted);
-    cursor: pointer; padding: 0 2px; border-radius: 4px; opacity: 0;
+    cursor: pointer; padding: 0 1px; border-radius: 3px; opacity: 0;
 }
-.ws-tab:hover .ws-tab-rename, .ws-tab.active .ws-tab-rename { opacity: 0.75; }
-.ws-tab-rename:hover { color: var(--accent-blue); opacity: 1; }
+.ws-tab:hover .ws-tab-rename-btn { opacity: 0.6; }
+.ws-tab-rename-btn:hover { color: var(--accent-blue); opacity: 1; }
+.ws-tab-rename-input {
+    font: inherit; font-size: 12px; width: 90px;
+    background: var(--bg-primary); color: var(--text-primary);
+    border: 1px solid var(--accent-blue); border-radius: 4px; padding: 1px 4px;
+}
+
+/* In-app prompt (codbashPrompt) — replaces window.prompt (no-op in Electron). */
+.cb-prompt-overlay {
+    position: fixed; inset: 0; z-index: 1000;
+    background: rgba(0,0,0,0.5);
+    display: flex; align-items: center; justify-content: center;
+}
+.cb-prompt {
+    background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px;
+    padding: 20px; width: 420px; max-width: calc(100vw - 40px);
+    box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+}
+.cb-prompt-msg { font-size: 14px; color: var(--text-primary); margin-bottom: 12px; }
+.cb-prompt-input {
+    width: 100%; box-sizing: border-box; font-size: 14px;
+    background: var(--bg-primary); color: var(--text-primary);
+    border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px;
+}
+.cb-prompt-input:focus { outline: none; border-color: var(--accent-blue); }
+.cb-prompt-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+.cb-prompt-ok { border-color: var(--accent-blue); color: var(--accent-blue); }
 .ws-tab-add {
     align-self: center;
     margin-left: 4px;

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -274,6 +274,19 @@ function _wsShortCwd(cwd) {
   return cwd.replace(/^\/Users\/[^/]+/, '~').replace(/^\/home\/[^/]+/, '~');
 }
 
+// A short, human label for a pane's title bar: the running agent (if any),
+// otherwise the folder name (e.g. "CoWork"), or "~" for the home directory.
+function _wsPaneLabel(pane) {
+  if (pane && pane.cmd) {
+    var w = String(pane.cmd).trim().split(/\s+/)[0];
+    if (w) return w;
+  }
+  var c = (pane && pane.cwd) || '';
+  if (!c) return 'shell';
+  if (/^(\/Users\/[^/]+|\/home\/[^/]+|\/root)\/?$/.test(c)) return '~';
+  return _wsProjectBasename(c);
+}
+
 function _wsConnectPane(pane) {
   var host = document.getElementById('wsTermHost-' + pane.id);
   if (!host) return;
@@ -312,7 +325,7 @@ function _wsConnectPane(pane) {
       var msg; try { msg = JSON.parse(ev.data); } catch (e) { return; }
       if (msg.t === 'ready') {
         pane.cwd = msg.cwd;
-        setStatus(_wsShortCwd(msg.cwd));
+        setStatus(_wsPaneLabel(pane));
         _wsAutoNameTab(pane);
         // cmd auto-runs (trailing \r); prefill is typed but NOT executed so the
         // user can review/edit a resume command before pressing Enter.
@@ -365,7 +378,7 @@ function _wsTabMarkup(tab) {
       'onclick="activateWorkspaceTab(\'' + escHtml(tab.id) + '\')" ondblclick="renameWorkspaceTab(\'' + escHtml(tab.id) + '\')" ' +
       'title="Double-click to rename">' +
       '<span class="ws-tab-name">' + escHtml(tab.name) + '</span>' +
-      '<button class="ws-tab-rename" title="Rename terminal" aria-label="Rename terminal" onclick="event.stopPropagation();renameWorkspaceTab(\'' + escHtml(tab.id) + '\')">&#9998;</button>' +
+      '<button class="ws-tab-rename-btn" title="Rename terminal" aria-label="Rename terminal" onclick="event.stopPropagation();renameWorkspaceTab(\'' + escHtml(tab.id) + '\')">&#9998;</button>' +
       '<button class="ws-tab-close" title="Close tab" onclick="event.stopPropagation();closeWorkspaceTab(\'' + escHtml(tab.id) + '\')">&times;</button>' +
     '</div>';
 }
@@ -569,7 +582,7 @@ function renameWorkspaceTab(id) {
   var el = document.querySelector('.ws-tab[data-tab-id="' + id + '"] .ws-tab-name');
   if (!el) return;
   var input = document.createElement('input');
-  input.className = 'ws-tab-rename';
+  input.className = 'ws-tab-rename-input';
   input.value = tab.name;
   el.replaceWith(input);
   input.focus(); input.select();
@@ -638,6 +651,8 @@ function launchAgentInPane(id, cmd) {
   pane.lastOutputAt = _wsNow();
   pane.sock.send(new TextEncoder().encode(cmd + '\r'));
   if (pane.term) pane.term.focus();
+  var st = document.getElementById('wsStatus-' + pane.id);
+  if (st) st.textContent = _wsPaneLabel(pane);   // reflect the launched agent
   _wsUpdateStatusBar();
 }
 
@@ -780,19 +795,22 @@ function _wsRenderLayoutsMenu() {
 function saveWorkspaceLayout() {
   var active = _wsActiveTab();
   var suggested = (active && active.name) || ('Workspace ' + (_wsSavedLayouts.length + 1));
-  var name = window.prompt('Save this workspace as:', suggested);
-  if (name == null) return;
-  name = name.trim();
-  if (!name) return;
-  var payload = _wsCaptureLayout();
-  payload.name = name;
-  fetch('/api/terminal/layouts', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  }).then(function (r) { return r.json(); }).then(function (d) {
-    if (!d || !d.ok) { window.alert('Could not save layout: ' + ((d && d.error) || 'unknown error')); return; }
-    return _wsLoadLayouts();
-  }).catch(function () { window.alert('Could not save layout: request failed'); });
+  // codbashPrompt (not window.prompt — the latter is a no-op in the Electron app).
+  codbashPrompt('Save this workspace as:', suggested).then(function (name) {
+    if (name == null) return;
+    name = name.trim();
+    if (!name) return;
+    var payload = _wsCaptureLayout();
+    payload.name = name;
+    return fetch('/api/terminal/layouts', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).then(function (r) { return r.json(); }).then(function (d) {
+      if (!d || !d.ok) { showToast('Could not save layout: ' + ((d && d.error) || 'error')); return; }
+      showToast('Saved layout "' + name + '"');
+      return _wsLoadLayouts();
+    }).catch(function () { showToast('Could not save layout: request failed'); });
+  });
 }
 
 // Menu handler: launch a saved layout, or open the manager.


### PR DESCRIPTION
- **Save layout was broken in the desktop app** — it used `window.prompt`, which Electron ignores. Added an in-app modal prompt (`codbashPrompt`).
- **Pane headers** show the folder name (e.g. `codbash`) or the running agent instead of `~/path`.
- Fixed a **class collision** between the rename button and rename input; the ✎ button is now smaller and hover-only.
- **Cmd+D** opens a new terminal tab.

Browser-verified; 182 tests pass, no console errors.