### PR TITLE
feat: move running-projects tree under Terminal (v7.14.3)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codbash-desktop",
   "productName": "codbash",
-  "version": "7.14.2",
+  "version": "7.14.3",
   "private": true,
   "description": "Desktop shell (Electron) for codbash — wraps the codbash server in a native window.",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.14.2",
+  "version": "7.14.3",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,14 @@
 
 const CHANGELOG = [
   {
+    version: '7.14.3',
+    date: '2026-07-20',
+    title: 'Running-projects tree moved under Terminal',
+    changes: [
+      'The running-terminals tree now lives right under the Terminal sidebar item instead of at the bottom of the sidebar',
+    ],
+  },
+  {
     version: '7.14.2',
     date: '2026-07-20',
     title: 'Running-projects sidebar tree + safer pane labels',

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -46,6 +46,8 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="18" rx="2"/><polyline points="6 8 9 11 6 14"/><line x1="12" y1="15" x2="17" y2="15"/></svg>
         Terminal
     </div>
+    <!-- Live tree of projects that currently have running Workspace terminals. -->
+    <div id="wsRunningTree" class="ws-running-tree" style="display:none"></div>
 
     <!-- Sessions section -->
     <div class="sidebar-group collapsed" data-section="workspace">
@@ -223,9 +225,6 @@
             </div>
         </div>
     </div>
-
-    <!-- Live tree of projects that currently have running Workspace terminals. -->
-    <div id="wsRunningTree" class="ws-running-tree" style="display:none"></div>
 
     <span id="sidebarStatus" role="status" aria-live="polite" class="sr-only"></span>
     <div class="sidebar-author">


### PR DESCRIPTION
Moves the running-terminals tree from the sidebar bottom to directly under the **Terminal** item (above Sessions). Browser-verified DOM order; 182 tests pass.