### PR TITLE
fix(workspace): running-agent click — no duplicate spawn, no dead-click

### DIFF
--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -189,14 +189,13 @@ function _wsPaneForCwd(cwd) {
   return hit;
 }
 
-// Click a running-agent row: jump to its Workspace pane if one exists here,
-// otherwise open the session in a new pane (best-effort) or just show Workspace.
+// Click a running-agent row: jump to its Workspace pane if one is open here,
+// otherwise open a plain terminal in the project folder. The agent is ALREADY
+// running, so we must NOT prefill a resume command — that would spawn a second
+// instance. (sessionId/kind are accepted for signature stability but unused.)
 function jumpToRunningAgent(cwd, sessionId, kind) {
   var hit = _wsPaneForCwd(cwd);
   if (hit) { jumpToWorkspacePane(hit.tab.id, hit.pane.id); return; }
-  if (sessionId && typeof openSessionInWorkspace === 'function') {
-    openSessionInWorkspace(sessionId); return;
-  }
   if (cwd && typeof openInWorkspace === 'function') {
     openInWorkspace({ name: _wsProjectBasename(cwd), cwd: cwd });
   }
@@ -210,7 +209,7 @@ function _wsRenderRunningTree() {
   if (!el) return;
   var groups = _wsRunningByProject();
   var sig = groups.map(function (g) {
-    return g.name + ':' + g.items.map(function (a) {
+    return g.cwd + ':' + g.items.map(function (a) {
       return (a.sessionId || a.pid) + '=' + a.kind + '/' + a.status;
     }).join(',');
   }).join('|');


### PR DESCRIPTION
Two bugs in the v7.14.4 sidebar "Running agents" tree, found while it was in use.

1. **Duplicate-spawn / dead-click** (`jumpToRunningAgent`): clicking a running-agent row called `openSessionInWorkspace`, which prefills a **resume** command. But the agent is already running → that starts a *second* instance. And if the session isn't indexed in the dashboard, `openSessionInWorkspace` returns silently → the click does nothing. Fix: jump to the live pane if one exists; otherwise open a **plain** terminal in the project folder (no resume, no no-op).

2. **Stale change-detection** (`_wsRenderRunningTree`): the `_wsRunTreeSig` signature keyed on the folder **basename** instead of the full `cwd`, so two same-named projects (or one stopping while another same-named starts with the same agents) could reuse a stale tree and jump to the wrong folder. Now keyed on full `cwd`.

No version bump — batching into the next patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)