### PR TITLE
chore(release): 7.14.6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codbash-desktop",
   "productName": "codbash",
-  "version": "7.14.5",
+  "version": "7.14.6",
   "private": true,
   "description": "Desktop shell (Electron) for codbash — wraps the codbash server in a native window.",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codbash-app",
-  "version": "7.14.5",
+  "version": "7.14.6",
   "description": "Dashboard + CLI for AI coding agents — Claude Code, Codex, Cursor, OpenCode, Kiro. View, search, resume, convert, sync sessions.",
   "bin": {
     "codbash": "./bin/cli.js",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,18 @@
 
 const CHANGELOG = [
   {
+    version: '7.14.6',
+    date: '2026-07-21',
+    title: 'Folder picker, community fixes, and docs',
+    changes: [
+      'Add project → a native "Browse…" folder picker in the desktop app (opens Finder and fills the absolute path); the browser keeps the folder autocomplete',
+      'Oh My Pi: sessions with a title record before the session header now parse correctly, in both the list and the detail view (thanks @timseriakov)',
+      'GitHub avatars now render in the cloud profile and leaderboard (CSP fix, thanks @mvasilyev)',
+      'Overview and Recommended tiles now fill the available width on wide screens',
+      'Footer credit updated to the Neuraldeep community',
+    ],
+  },
+  {
     version: '7.14.5',
     date: '2026-07-20',
     title: 'Bug-hunt sweep: crash-safety, data-loss fix, and many correctness fixes',


### PR DESCRIPTION
Ships changes merged since 7.14.5: native Add-project folder picker (desktop), Oh My Pi title-before-session parsing (#231/#260), GitHub avatar CSP fix (#249), Overview/Recommended full-width tiles (#243), Neuraldeep footer, signed-release docs + manual npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)