### PR TITLE
feat: detect missing project folders + offer GitHub re-clone

### DIFF
--- a/docs/design/missing-project-detection.md
+++ b/docs/design/missing-project-detection.md
@@ -1,0 +1,69 @@
+# Missing-project detection + re-clone offer
+
+## Цель
+Когда зарегистрированный проект удалён/перемещён на диске, Projects-лаунчер должен
+это заметить: показать дисклеймер на плитке и, при попытке запуска, вернуть понятную
+ошибку «папка отсутствует» с предложением заново скачать актуальную версию с GitHub.
+
+## Проблема
+`projects.json` хранит путь проекта. Если пользователь удалил репо (`rm -rf`),
+плитка остаётся, а запуск (`POST /api/launch`) падает с общей ошибкой
+`invalid or unsafe project path` — пользователь не понимает причину.
+
+## Данные
+- Реестр: `~/.codedash/projects.json` — `{ id, name, path, source, remoteUrl, defaultBranch }`.
+- Признак существования на диске выводится динамически (`fs.statSync().isDirectory()`),
+  в файл не пишется — состояние диска может меняться между запросами.
+
+## Изменения API
+- `GET /api/projects/manual` — к каждому проекту добавляется `exists: boolean`.
+  `git` вычисляется только когда `exists === true`.
+- `POST /api/launch` — если `project` передан и папки нет на диске, вернуть
+  `400 { ok:false, error:'project folder is missing on disk', missing:true,
+  remoteUrl, projectId }` вместо общей ошибки. Проверка идёт до `isSafeLaunchPath`,
+  чтобы отличить «удалено» от «небезопасный путь».
+- `POST /api/projects/reclone` — новый маршрут. Тело `{ id }`. Находит проект в
+  реестре, требует непустой `remoteUrl`, клонирует `remoteUrl` в **исходный** `path`
+  (не в свежий `~/code/<repo>`), чтобы восстановить папку ровно там, где она была.
+  Переиспользует `cloneRepo` (та же защита: только GitHub-remote, назначение под `$HOME`,
+  существующий-тот-же-repo → успех).
+
+## Стыки
+- `src/projects.js` — новый экспорт `pathExists(p)`; `cloneRepo` переиспользуется.
+- `src/server.js` — GET manual enrich, launch guard, новый reclone-маршрут.
+- `src/frontend/app.js` — `mergeRegistryWithSessions` пробрасывает `_exists`/`_remoteUrl`;
+  `renderLauncherCard` рисует missing-состояние; `recloneProject()`; launch-функции
+  обрабатывают `data.missing`.
+- `src/frontend/styles.css` — `.launcher-card-missing`, `.launcher-card-warning`.
+
+## UX & Accessibility
+**Required UI states:**
+- [x] Normal — папка на месте: обычные кнопки запуска.
+- [x] Missing — папка удалена: дисклеймер `role="status"`, кнопки «Re-clone» (если есть
+      GitHub-remote) и «Remove»; кнопки запуска скрыты.
+- [x] Loading — кнопка Re-clone: `disabled` + текст «Cloning…».
+- [x] Error — reclone/launch fail: toast с текстом ошибки, кнопка возвращается в исходное.
+- [x] Success — toast «Re-cloned … from GitHub», перезагрузка реестра → плитка снова обычная.
+
+**Keyboard/SR:** дисклеймер — `role="status"` (объявляется screen reader'ом); кнопки
+имеют `aria-label`; фокус-ринг наследуется от `.git-project-launch-btn:focus-visible`.
+
+## Риски
+- TOCTOU (папку удалили между рендером и кликом) — `addressed_in`: launch-guard в
+  `/api/launch` возвращает `missing:true`; `handleMissingProjectLaunch` предлагает reclone.
+- `missing:true` глобален для `/api/launch`, поэтому обрабатывается на ВСЕХ трёх точках
+  запуска — `addressed_in`: `app.js launchNewProjectSession`/`resumeLastProjectSession` и
+  `detail.js launchSession` (session-detail «Resume»).
+- Symlink-ancestor обход home-containment в `cloneRepo` (окно «папка отсутствует») —
+  `addressed_in`: `projects.js realpathOfNearestAncestor` + `isUnderHome` перед `git clone`.
+- reclone для manual-проекта вне `$HOME` или с non-GitHub remote — `cloneRepo` вернёт
+  понятную ошибку, показываем toast (`addressed`: сообщение об ошибке).
+- Проект без `remoteUrl` (локальная папка) — кнопка Re-clone не рисуется, только Remove.
+- Параллельные reclone одного id — `addressed_in`: `_inFlightReclone` Set в `server.js` (409).
+- HTTP-уровневые тесты новых маршрутов (`/api/launch missing`, `/api/projects/reclone`) —
+  `deferred_to`: follow-up. `startServer` не имеет teardown-seam (интервалы autoSync/heartbeat
+  держат event loop), поэтому route-тест требует рефактора извлечения маршрутов. Interim
+  evidence: scratchpad smoke (register → delete → `exists:false` → `missing:true` → reclone
+  guardrails) — GREEN. Unit-тесты `pathExists`/`cloneRepo` покрыты.
+- Systemic (pre-existing, не в этом PR): mutating POST-маршруты не проверяют `Origin` —
+  `deferred_to`: отдельный follow-up (repo-wide CSRF hardening).

--- a/specs/missing-project-detection.feature
+++ b/specs/missing-project-detection.feature
@@ -1,0 +1,50 @@
+Feature: Missing-project detection and re-clone offer on the Projects launcher
+
+  Background:
+    Given a project "my-repo" is registered with remoteUrl "https://github.com/me/my-repo.git"
+
+  Scenario: Happy path — folder present renders normal launch controls
+    Given the folder for "my-repo" exists on disk
+    When I open the Projects landing
+    Then the tile shows the ▶ New / Last / Terminal launch controls
+    And no "folder is missing" disclaimer is shown
+
+  Scenario: Empty/missing state — deleted folder shows disclaimer
+    Given the folder for "my-repo" was deleted from disk
+    When I open the Projects landing
+    Then the tile is marked as missing
+    And a disclaimer says the folder is missing and can be re-cloned from GitHub
+    And the ▶ New / Last launch controls are hidden
+    And a "Re-clone" and a "Remove" button are shown
+
+  Scenario: Loading state — re-clone in progress
+    Given the folder for "my-repo" is missing
+    When I click "Re-clone"
+    Then the button is disabled and shows "Cloning…"
+
+  Scenario: Success — re-clone restores the folder and normal controls
+    Given the folder for "my-repo" is missing
+    When I click "Re-clone" and the clone succeeds
+    Then a toast confirms the folder was re-cloned from GitHub
+    And the registry is refreshed and the tile returns to the normal launch state
+
+  Scenario: Error — launch of a deleted folder returns an actionable response
+    Given the folder for "my-repo" was deleted after the page loaded
+    When I click ▶ New on the tile
+    Then the server responds 400 with missing=true and the project's remoteUrl
+    And the UI tells me the folder is missing and offers to re-clone it
+
+  Scenario: Negative — local project without a GitHub remote cannot be re-cloned
+    Given a project "local-only" is registered with no remoteUrl
+    And its folder is missing on disk
+    When I open the Projects landing
+    Then the disclaimer tells me to restore the folder or remove it from the list
+    And no "Re-clone" button is shown, only "Remove"
+
+  Scenario: Edge — re-clone into a path outside the home directory fails cleanly
+    Given a project whose stored path is outside the home directory is missing
+    When I click "Re-clone"
+    Then a toast shows the clone error and the button returns to "Re-clone"
+
+  # N/A: keyboard-only — reuses existing .git-project-launch-btn focus-ring and aria-labels;
+  # no new focus-trap or shortcut introduced.

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -2075,6 +2075,14 @@ function scrollToInstallAgents() {
   if (section && section.scrollIntoView) section.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }
 
+// Anchored GitHub-remote check, matching the server's cloneRepo regex
+// (src/projects.js). Used to decide whether to offer "Re-clone" — an unanchored
+// substring test would show the button for a spoofed URL like
+// https://evil.com/github.com/... that the server would then reject.
+function isGithubRemote(url) {
+  return typeof url === 'string' && /^(https:\/\/github\.com\/|git@github\.com:)/.test(url);
+}
+
 // Live Workspace panes whose resolved cwd is this project folder.
 function _projectLiveTerminals(projPath) {
   if (!projPath || typeof _wsAllPanes !== 'function') return [];
@@ -2100,9 +2108,15 @@ function renderLauncherCard(projKey, projInfo) {
 
   var preferredTool = pickPreferredTool(projPath, lastSession);
   var installed = window.installedAgents || [];
-  var canLaunch = installed.length > 0 && !!projPath;
+  // A registered folder can be deleted from disk at any time; `_exists === false`
+  // comes from the server's on-disk check. When missing, we suppress the launch
+  // controls (they'd fail) and surface a re-clone/remove path instead.
+  var exists = projInfo._exists !== false;
+  var remoteUrl = projInfo._remoteUrl || '';
+  var canReclone = !exists && isGithubRemote(remoteUrl);
+  var canLaunch = installed.length > 0 && !!projPath && exists;
 
-  var html = '<div class="launcher-card">';
+  var html = '<div class="launcher-card' + (exists ? '' : ' launcher-card-missing') + '">';
   html += '<div class="launcher-card-header">';
   html += '<span class="launcher-card-dot" style="background:' + color + '"></span>';
   html += '<span class="launcher-card-name" title="' + escHtml(projName) + '">' + escHtml(projName) + '</span>';
@@ -2111,10 +2125,46 @@ function renderLauncherCard(projKey, projInfo) {
   if (projPath) html += '<div class="launcher-card-path" title="' + escHtml(projPath) + '">' + escHtml(projPath) + '</div>';
   html += '<div class="launcher-card-meta">';
   html += '<span>' + (totalSessions === 0 ? 'no sessions yet' : (totalSessions + ' session' + (totalSessions === 1 ? '' : 's'))) + '</span>';
-  if (preferredTool) html += '<span>· next: ' + escHtml(agentLabel(preferredTool)) + '</span>';
+  if (exists && preferredTool) html += '<span>· next: ' + escHtml(agentLabel(preferredTool)) + '</span>';
   html += '</div>';
 
-  html += '<div class="launcher-card-actions">';
+  // Disclaimer for a deleted/moved folder — persistent descriptive content, so
+  // role="note" (not a live region: it's present on render, not a transient
+  // status update — the launch-fail case is announced via toast instead).
+  if (!exists) {
+    html += '<div class="launcher-card-warning" role="note">' +
+      '⚠ Folder is missing on disk — it was moved or deleted. ' +
+      (canReclone
+        ? 'Re-clone the latest version from GitHub.'
+        : 'Restore the folder, or remove it from the list.') +
+      '</div>';
+  }
+
+  if (!exists) {
+    // Missing folder: no launch controls. Offer Re-clone (when we have a GitHub
+    // remote) and Remove-from-registry. Only emit the actions row if at least
+    // one control will render, so an edge-case card isn't left with an empty box.
+    var missingActions = '';
+    if (canReclone) {
+      var recloneAria = 'Re-clone ' + projName + ' from GitHub';
+      missingActions += '<button class="git-project-launch-btn primary reclone-btn" ' +
+        'data-proj-id="' + escHtml(projInfo.manualId || '') + '" data-proj-name="' + escHtml(projName) + '" ' +
+        'onclick="recloneProject(this.dataset.projId, this.dataset.projName, this)" ' +
+        'title="' + escHtml('Re-download the latest version from GitHub into ' + projPath) + '" ' +
+        'aria-label="' + escHtml(recloneAria) + '">↓ Re-clone</button>';
+    }
+    if (projInfo.manualId) {
+      missingActions += '<button class="git-project-launch-btn" data-proj-id="' + escHtml(projInfo.manualId) + '" data-proj-name="' + escHtml(projName) + '" onclick="unregisterProject(this.dataset.projId,this.dataset.projName)" title="Remove from registry (does not delete files)" aria-label="Remove ' + escHtml(projName) + ' from the list">× Remove</button>';
+    }
+    if (missingActions) html += '<div class="launcher-card-actions">' + missingActions + '</div>';
+    // Keep History drill-in available even when the folder is gone (sessions
+    // live in the agent history dirs, not the repo).
+    if (totalSessions > 0) {
+      html += '<button class="launcher-card-link" data-proj-key="' + escHtml(projKey) + '" data-proj-name="' + escHtml(projName) + '" onclick="viewProjectInHistory(this.dataset.projKey,this.dataset.projName)">View ' + totalSessions + ' session' + (totalSessions === 1 ? '' : 's') + ' →</button>';
+    }
+    html += '</div>';
+    return html;
+  }
   if (canLaunch && preferredTool) {
     var newAria = 'Start new ' + agentLabel(preferredTool) + ' session in ' + projName;
     var pickerAria = 'Pick a different agent for ' + projName;
@@ -2190,8 +2240,11 @@ function mergeRegistryWithSessions(sessions) {
     byGit[info.key].list.push(s);
   });
   (window.manualProjects || []).forEach(function(p) {
+    // `exists` is undefined for older payloads / session-derived merges — treat
+    // absence as "present" so we never falsely flag a folder as missing.
+    var exists = p.exists !== false;
     if (!byGit[p.path]) {
-      byGit[p.path] = { name: p.name, list: [], path: p.path, source: p.source || 'manual', manualId: p.id, _git: p.git, _lastAdded: p.addedAt };
+      byGit[p.path] = { name: p.name, list: [], path: p.path, source: p.source || 'manual', manualId: p.id, _git: p.git, _lastAdded: p.addedAt, _exists: exists, _remoteUrl: p.remoteUrl || '' };
     } else {
       // When a registry entry overlaps a session-derived entry, the registry's
       // `source` (manual / github-clone / auto) is the authoritative one — only
@@ -2203,7 +2256,7 @@ function mergeRegistryWithSessions(sessions) {
       var resolvedSource = keepRegistrySource
         ? p.source
         : ((!existing.source || existing.source === 'session') ? 'manual' : existing.source);
-      byGit[p.path] = { ...existing, manualId: p.id, source: resolvedSource };
+      byGit[p.path] = { ...existing, manualId: p.id, source: resolvedSource, _exists: exists, _remoteUrl: p.remoteUrl || existing._remoteUrl || '' };
     }
   });
   return byGit;
@@ -2979,7 +3032,13 @@ document.addEventListener('keydown', function(e) {
     return;
   }
   if (e.key === 'Escape') {
-    if (pendingDelete) {
+    // Close the confirm overlay whenever it's on screen — it's shared by the
+    // delete dialog (sets pendingDelete) AND the "project folder is missing"
+    // re-clone dialog (does not), so keying off pendingDelete alone left the
+    // latter undismissable.
+    var confirmOverlay = document.getElementById('confirmOverlay');
+    var confirmOpen = confirmOverlay && confirmOverlay.style.display === 'flex';
+    if (pendingDelete || confirmOpen) {
       closeConfirm();
     } else {
       closeDetail();
@@ -3713,6 +3772,8 @@ async function launchNewProjectSession(projectPath, tool, btn) {
         window.codbashSettings.lastUsedByPath = window.codbashSettings.lastUsedByPath || {};
         window.codbashSettings.lastUsedByPath[projectPath] = t;
       }
+    } else if (data.missing) {
+      handleMissingProjectLaunch(data, projectPath.split('/').pop());
     } else {
       showToast('Launch failed: ' + (data.error || 'unknown'));
     }
@@ -4028,6 +4089,7 @@ async function resumeLastProjectSession(sessionId, tool, projectPath, btn) {
     });
     var data = await resp.json();
     if (data.ok) showToast('Resuming ' + sessionId.slice(0, 8) + '…');
+    else if (data.missing) handleMissingProjectLaunch(data, (projectPath || '').split('/').pop());
     else showToast('Resume failed: ' + (data.error || 'unknown'));
   } catch (e) {
     showToast('Resume failed: ' + e.message);
@@ -4456,6 +4518,71 @@ async function cloneRepoAndAdd(btn) {
     btn.textContent = 'Retry';
     showToast('Clone failed: ' + e.message);
   }
+}
+
+// Re-clone a registered project whose folder was deleted, restoring it at its
+// original path. Driven by the "Re-clone" button on a missing launcher card and
+// by the re-clone confirm offered after a launch hits a missing folder.
+async function recloneProject(id, name, btn) {
+  if (!id) { showToast('Missing project id'); return; }
+  var safeName = name || 'project';
+  if (btn) {
+    btn.disabled = true;
+    btn.setAttribute('aria-busy', 'true');
+    btn.innerHTML = '↓ Cloning…';
+  } else {
+    // Driven from the confirm dialog (no button to relabel) — give immediate
+    // feedback so the multi-second clone isn't silent.
+    showToast('Cloning ' + safeName + ' from GitHub…');
+  }
+  try {
+    var resp = await fetch('/api/projects/reclone', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: id }),
+    });
+    var data = await resp.json();
+    if (data.ok) {
+      showToast(data.alreadyExisted ? 'Folder already present for ' + safeName : 'Re-cloned ' + safeName + ' from GitHub');
+      await loadManualProjects();
+    } else {
+      if (btn) { btn.disabled = false; btn.removeAttribute('aria-busy'); btn.innerHTML = '↓ Retry'; }
+      showToast('Re-clone failed: ' + (data.error || 'unknown'));
+    }
+  } catch (e) {
+    if (btn) { btn.disabled = false; btn.removeAttribute('aria-busy'); btn.innerHTML = '↓ Retry'; }
+    showToast('Re-clone failed: ' + (e && e.message));
+  }
+}
+
+// Shared handler for a launch that failed because the project folder is gone.
+// Refreshes the registry (so the tile flips to its missing state) and, when we
+// know a GitHub remote, offers a one-click re-clone via the confirm overlay.
+function handleMissingProjectLaunch(data, name) {
+  var safeName = String(name || 'This project').replace(/[\r\n\t\x00-\x1f]/g, ' ').slice(0, 200);
+  loadManualProjects();
+  var overlay = document.getElementById('confirmOverlay');
+  var canReclone = data && data.projectId && isGithubRemote(data.remoteUrl);
+  if (!canReclone || !overlay) {
+    // No re-clone possible (or no overlay in the DOM) — a plain toast with the
+    // recovery hint is the fallback.
+    showToast('"' + safeName + '" folder is missing on disk — restore it or remove it from Projects');
+    return;
+  }
+  document.getElementById('confirmTitle').textContent = 'Project folder is missing';
+  document.getElementById('confirmText').textContent =
+    '"' + safeName + '" was moved or deleted from disk. Re-clone the latest version from GitHub?';
+  document.getElementById('confirmId').textContent = '';
+  var btn = document.getElementById('confirmAction');
+  btn.textContent = 'Re-clone';
+  btn.className = 'launch-btn btn-primary';
+  btn.onclick = function() {
+    overlay.style.display = 'none';
+    recloneProject(data.projectId, safeName, null);
+  };
+  overlay.style.display = 'flex';
+  // Move focus into the dialog so keyboard/SR users land on the primary action.
+  setTimeout(function() { if (btn && btn.focus) btn.focus(); }, 0);
 }
 
 // ── Initialization ─────────────────────────────────────────────

--- a/src/frontend/detail.js
+++ b/src/frontend/detail.js
@@ -438,6 +438,11 @@ function launchSession(sessionId, tool, project, flags, resumeTarget) {
     return resp.json();
   }).then(function(data) {
     if (data.ok) showToast('Launched in terminal');
+    // Deleted project folder — surface the same "missing → offer re-clone" flow
+    // the Projects launcher uses, instead of a dead-end error toast.
+    else if (data.missing && typeof handleMissingProjectLaunch === 'function') {
+      handleMissingProjectLaunch(data, (project || '').split('/').pop());
+    }
     else showToast('Launch failed: ' + (data.error || 'unknown'));
   }).catch(function() {
     showToast('Launch failed');

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -276,7 +276,7 @@
     <div class="detail-body" id="detailBody"></div>
 </div>
 
-<div class="confirm-overlay" id="confirmOverlay">
+<div class="confirm-overlay" id="confirmOverlay" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
     <div class="confirm-box">
         <h3 id="confirmTitle">Delete Session?</h3>
         <p id="confirmText">This will permanently delete the session file and remove it from history.</p>

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -4556,6 +4556,32 @@ body[data-view="overview"] .toolbar { display: none; }
     white-space: nowrap;
     flex: 1;
 }
+/* Missing folder — deleted/moved on disk. Dashed warning border + muted name
+   so it reads as "needs attention" without shouting. */
+.launcher-card-missing {
+    border-style: dashed;
+    border-color: var(--accent-red);
+    background: var(--bg-card); /* fallback if color-mix is unsupported */
+    background: color-mix(in srgb, var(--accent-red) 5%, var(--bg-card));
+}
+.launcher-card-missing:hover {
+    border-color: var(--accent-red);
+    transform: none;
+}
+/* Muted (not opacity-dimmed) so contrast stays AA across all three themes. */
+.launcher-card-missing .launcher-card-name { color: var(--text-secondary); }
+.launcher-card-warning {
+    font-size: 11px;
+    line-height: 1.4;
+    /* Body text in a high-contrast token (AA at 11px); the red border, tinted
+       background and ⚠ glyph carry the "warning" semantics without relying on
+       low-contrast red text. */
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--accent-red) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-red) 30%, transparent);
+    border-radius: 6px;
+    padding: 6px 8px;
+}
 .launcher-card-tag {
     font-size: 9px;
     text-transform: uppercase;

--- a/src/projects.js
+++ b/src/projects.js
@@ -101,6 +101,44 @@ function isSafeLaunchPath(p) {
   return true;
 }
 
+// Cheap "does this registered folder still exist on disk?" check. Registry
+// entries persist a path; the user can delete the folder (rm -rf) at any time,
+// so existence is derived per-request, never stored. Follows symlinks (statSync)
+// on purpose — a still-resolvable symlinked directory counts as present; the
+// stricter no-symlink rule only applies when a path is first registered.
+function pathExists(p) {
+  if (!p || typeof p !== 'string') return false;
+  if (p.length > 1024) return false; // match isSafeLaunchPath's cap
+  try {
+    return fs.statSync(normalizePath(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// True when `abs` is the home directory or lives under it.
+function isUnderHome(abs) {
+  return abs === os.homedir() || abs.startsWith(os.homedir() + path.sep);
+}
+
+// Resolve the realpath of the nearest existing ancestor of `abs` (including
+// `abs` itself if it exists). Used to detect a symlinked parent that would
+// redirect a write outside its apparent location. Returns '' if nothing
+// resolves (e.g. an unreadable ancestor).
+function realpathOfNearestAncestor(abs) {
+  let cur = abs;
+  // Walk up until we hit an existing path or the filesystem root.
+  for (let i = 0; i < 4096; i++) {
+    if (fs.existsSync(cur)) {
+      try { return fs.realpathSync(cur); } catch { return ''; }
+    }
+    const parent = path.dirname(cur);
+    if (parent === cur) break; // reached root
+    cur = parent;
+  }
+  return '';
+}
+
 const ALLOWED_SOURCES = new Set(['manual', 'github-clone', 'auto']);
 
 function addProject({ name, path: projectPath, source, remoteUrl, defaultBranch }) {
@@ -226,12 +264,23 @@ function cloneRepo(remoteUrl, destDir) {
     if (!remoteUrl || typeof remoteUrl !== 'string') {
       return reject(new Error('remoteUrl required'));
     }
-    if (!/^(https:\/\/github\.com\/|git@github\.com:)/.test(remoteUrl)) {
+    // Anchor the whole URL (not just the prefix) and forbid control characters
+    // in the suffix — defence-in-depth over the argv-form execFile below.
+    if (!/^(https:\/\/github\.com\/|git@github\.com:)[A-Za-z0-9._/-]+$/.test(remoteUrl)) {
       return reject(new Error('only GitHub remotes are supported'));
     }
     const abs = path.resolve(destDir);
-    if (!abs.startsWith(os.homedir() + path.sep) && abs !== os.homedir()) {
+    if (!isUnderHome(abs)) {
       return reject(new Error('clone destination must be under your home directory'));
+    }
+    // The textual startsWith check above can be defeated if an ANCESTOR of the
+    // (currently-missing) destination is a symlink pointing outside $HOME — the
+    // exact window the re-clone flow opens ("folder is missing"). Resolve the
+    // nearest existing ancestor's realpath and re-assert containment so a
+    // planted symlink can't redirect the clone (and its git write) out of home.
+    const resolvedAncestor = realpathOfNearestAncestor(abs);
+    if (resolvedAncestor && !isUnderHome(resolvedAncestor)) {
+      return reject(new Error('clone destination escapes your home directory via a symlinked parent'));
     }
     ensureDir(path.dirname(abs));
 
@@ -275,4 +324,5 @@ module.exports = {
   suggestCloneDir,
   isSafeRepoName,
   isSafeLaunchPath,
+  pathExists,
 };

--- a/src/server.js
+++ b/src/server.js
@@ -117,6 +117,11 @@ function getValidatedPiResumeTarget(sessionId, resumeTarget, project) {
 const LOG_VERBOSE = process.env.CODEDASH_LOG !== '0';
 const DEFAULT_HOST = '127.0.0.1';
 
+// Project ids with an in-flight re-clone. Guards against a double-click / script
+// piling up concurrent `git clone` subprocesses for the same project (each up to
+// 120s). Zero-dependency, single-process — a plain Set is sufficient.
+const _inFlightReclone = new Set();
+
 function log(tag, msg, data) {
   if (!LOG_VERBOSE && tag !== 'ERROR') return;
   const ts = new Date().toLocaleTimeString('en-GB');
@@ -378,6 +383,19 @@ function startServer(host, port, openBrowser = true) {
             if (fresh && !project) {
               throw new Error('project path required for fresh session');
             }
+            // Distinguish "folder was deleted" from "unsafe path" BEFORE the
+            // generic safety check, so a user who removed a registered repo gets
+            // an actionable "missing" response (with the GitHub remote to
+            // re-clone from) instead of a confusing "invalid or unsafe path".
+            if (project && !projectsApi.pathExists(project)) {
+              const absMissing = projectsApi.normalizePath(project);
+              const reg = projectsApi.loadProjects().find(p => p.path === absMissing);
+              throw Object.assign(new Error('project folder is missing on disk'), {
+                missing: true,
+                remoteUrl: reg && reg.remoteUrl ? reg.remoteUrl : '',
+                projectId: reg ? reg.id : '',
+              });
+            }
             // The project path flows into a shell command string in terminals.js
             // (`cd "..." && claude ...`). Even though JSON.stringify wraps the
             // value in double quotes, bash still expands $() and backticks
@@ -429,7 +447,12 @@ function startServer(host, port, openBrowser = true) {
             json(res, registered ? { ok: true, registered } : { ok: true });
           } catch (e) {
             log('ERROR', `launch failed: ${e.message}`);
-            json(res, { ok: false, error: e.message }, 400);
+            // Pass through the "missing folder" hint so the client can offer a
+            // one-click re-clone instead of a dead-end error toast.
+            const extra = e && e.missing
+              ? { missing: true, remoteUrl: e.remoteUrl || '', projectId: e.projectId || '' }
+              : {};
+            json(res, { ok: false, error: e.message, ...extra }, 400);
           }
         })();
       });
@@ -873,9 +896,14 @@ function startServer(host, port, openBrowser = true) {
     // ── Manual / cloned projects registry ──────────────────────
     else if (req.method === 'GET' && pathname === '/api/projects/manual') {
       // Enrich each with current git info so the UI can render branch/last commit.
+      // `exists` reflects whether the folder is still on disk — a deleted repo
+      // keeps its registry entry, so the launcher needs this to flip the tile
+      // into its "folder missing — re-clone" state. Skip the git probe when the
+      // folder is gone (it would only shell out to fail).
       const list = projectsApi.loadProjects().map(p => {
-        const info = getProjectGitInfo(p.path) || null;
-        return { ...p, git: info };
+        const exists = projectsApi.pathExists(p.path);
+        const info = exists ? (getProjectGitInfo(p.path) || null) : null;
+        return { ...p, exists, git: info };
       });
       json(res, list);
     }
@@ -957,6 +985,45 @@ function startServer(host, port, openBrowser = true) {
         } catch (e) {
           json(res, { ok: false, error: e.message }, 400);
         }
+      });
+    }
+
+    // POST /api/projects/reclone — { id } → re-clone a registered project whose
+    // folder was deleted, restoring it at its ORIGINAL path (not a fresh
+    // ~/code/<repo>). Uses the remoteUrl already recorded in the registry.
+    else if (req.method === 'POST' && pathname === '/api/projects/reclone') {
+      readBody(req, body => {
+        let payload;
+        try { payload = JSON.parse(body || '{}'); }
+        catch { return json(res, { ok: false, error: 'invalid json' }, 400); }
+        const id = String(payload.id || '');
+        if (!/^[a-f0-9]{16}$/.test(id)) {
+          return json(res, { ok: false, error: 'invalid id' }, 400);
+        }
+        const proj = projectsApi.loadProjects().find(p => p.id === id);
+        if (!proj) return json(res, { ok: false, error: 'project not found in registry' }, 404);
+        if (!proj.remoteUrl) {
+          return json(res, { ok: false, error: 'no GitHub remote recorded for this project — cannot re-clone' }, 400);
+        }
+        if (_inFlightReclone.has(id)) {
+          return json(res, { ok: false, error: 'a re-clone for this project is already in progress' }, 409);
+        }
+        _inFlightReclone.add(id);
+        log('CLONE', `reclone ${proj.name} → ${proj.path}`);
+        // cloneRepo enforces GitHub-only remotes + destination-under-$HOME
+        // (incl. the symlinked-ancestor check), and treats an already-present
+        // same-remote clone as success — so a racing restore or a
+        // partially-deleted folder resolves cleanly.
+        projectsApi.cloneRepo(proj.remoteUrl, proj.path)
+          .then(result => {
+            log('CLONE', `reclone done ${proj.name} (${result.alreadyExisted ? 'existed' : 'cloned'})`);
+            json(res, { ok: true, project: proj, alreadyExisted: result.alreadyExisted });
+          })
+          .catch(e => {
+            log('ERROR', `reclone failed: ${e.message}`);
+            json(res, { ok: false, error: e.message }, 400);
+          })
+          .finally(() => { _inFlightReclone.delete(id); });
       });
     }
 

--- a/test/projects-missing.test.js
+++ b/test/projects-missing.test.js
@@ -1,0 +1,115 @@
+// Tests for missing-project detection (pathExists) + re-clone guardrails.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const projects = require('../src/projects');
+
+function mkTmpDir(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+test('pathExists returns true for an existing directory', () => {
+  const dir = mkTmpDir('codbash-exists-');
+  try {
+    assert.equal(projects.pathExists(dir), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('pathExists returns false after the directory is deleted', () => {
+  const dir = mkTmpDir('codbash-gone-');
+  fs.rmSync(dir, { recursive: true, force: true });
+  assert.equal(projects.pathExists(dir), false);
+});
+
+test('pathExists returns false for a regular file (not a directory)', () => {
+  const dir = mkTmpDir('codbash-file-');
+  const file = path.join(dir, 'a.txt');
+  fs.writeFileSync(file, 'x');
+  try {
+    assert.equal(projects.pathExists(file), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('pathExists returns false for empty / non-string input', () => {
+  assert.equal(projects.pathExists(''), false);
+  assert.equal(projects.pathExists(null), false);
+  assert.equal(projects.pathExists(undefined), false);
+  assert.equal(projects.pathExists(42), false);
+});
+
+test('cloneRepo rejects a non-GitHub remote (re-clone guardrail)', async () => {
+  await assert.rejects(
+    () => projects.cloneRepo('https://gitlab.com/me/repo.git', path.join(os.homedir(), 'code', 'x')),
+    /only GitHub remotes/i
+  );
+});
+
+test('cloneRepo rejects a destination outside the home directory', async () => {
+  await assert.rejects(
+    () => projects.cloneRepo('https://github.com/me/repo.git', '/tmp/not-home-target'),
+    /must be under your home directory/i
+  );
+});
+
+test('cloneRepo rejects a destination whose ancestor is a symlink pointing outside home', async (t) => {
+  if (process.platform === 'win32') return; // symlink perms differ on Windows
+  // Plant a symlinked ancestor under $HOME that resolves outside it, then aim a
+  // clone at a (missing) child path — the textual startsWith check passes but the
+  // realpath-of-nearest-ancestor guard must catch the escape.
+  const outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-outside-')));
+  const homeBase = fs.realpathSync(fs.mkdtempSync(path.join(os.homedir(), '.codbash-symlink-test-')));
+  const linkDir = path.join(homeBase, 'link');
+  t.after(() => {
+    fs.rmSync(homeBase, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+  fs.symlinkSync(outside, linkDir);
+  await assert.rejects(
+    () => projects.cloneRepo('https://github.com/me/repo.git', path.join(linkDir, 'repo')),
+    /symlinked parent|home directory/i
+  );
+});
+
+test('cloneRepo rejects a remote with control characters in the suffix', async () => {
+  await assert.rejects(
+    () => projects.cloneRepo('https://github.com/me/repo\n.git', path.join(os.homedir(), 'code', 'x')),
+    /only GitHub remotes/i
+  );
+});
+
+test('pathExists follows a directory symlink (documented behavior)', (t) => {
+  if (process.platform === 'win32') return;
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'codbash-symtgt-')));
+  const target = path.join(base, 'real');
+  const link = path.join(base, 'link');
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+  fs.mkdirSync(target);
+  fs.symlinkSync(target, link);
+  assert.equal(projects.pathExists(link), true);
+});
+
+test('cloneRepo treats an already-present same-remote clone as success (idempotent re-clone)', async () => {
+  // Build a real git repo under $HOME whose origin matches, so cloneRepo takes
+  // the "alreadyExisted" fast path with no network.
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.homedir(), '.codbash-reclone-test-')));
+  const repo = path.join(base, 'repo');
+  const remote = 'https://github.com/me/repo.git';
+  const { execFileSync } = require('child_process');
+  try {
+    fs.mkdirSync(repo, { recursive: true });
+    execFileSync('git', ['-C', repo, 'init', '-q'], { timeout: 5000 });
+    execFileSync('git', ['-C', repo, 'remote', 'add', 'origin', remote], { timeout: 5000 });
+    const result = await projects.cloneRepo(remote, repo);
+    assert.equal(result.alreadyExisted, true);
+    assert.equal(result.path, fs.realpathSync(repo));
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What & why

When you register/clone a project in codbash and later delete that folder from disk (cleaning up your machine), the Projects launcher kept showing the tile, and clicking **New**/**Last** failed with a confusing *"invalid or unsafe project path"*. This adds first-class handling for missing folders.

Note: the new `exists` check already flags real registered projects as missing-on-disk in local testing, so the feature is immediately useful.

## Behaviour

- **On the tile**: a deleted folder gets a dashed-red card + a `role="note"` disclaimer — *"⚠ Folder is missing on disk — it was moved or deleted."* Launch controls are replaced by **↓ Re-clone** (when a GitHub remote is known) and **× Remove**. History drill-in stays available. Local projects with no GitHub remote show *"Restore the folder, or remove it from the list."*
- **On launch**: `/api/launch` returns `{ missing:true, remoteUrl, projectId }` (before the generic safety check), so every launch path — the launcher's New/Last **and** the session-detail **Resume** — pops a one-click re-clone dialog instead of a dead-end toast.
- **Re-clone**: `POST /api/projects/reclone { id }` restores the repo at its **original** path (not a fresh `~/code/<repo>`), reusing `cloneRepo`.

## API

| Route | Change |
|-------|--------|
| `GET /api/projects/manual` | + `exists` per project (skips git probe when the folder is gone) |
| `POST /api/launch` | returns `missing:true` (+ `remoteUrl`, `projectId`) for a deleted folder |
| `POST /api/projects/reclone` | **new** — re-clone a registered project to its original path; per-id in-flight guard → 409 |

## Review (3 agents: code / security / UX — all findings applied)

- **Security MED** — closed a symlinked-parent escape of `cloneRepo`'s home-dir containment (realpath-of-nearest-ancestor check), reachable precisely via the "folder missing" window. Plus: anchored GitHub-remote regex (rejects control chars), `pathExists` length cap, per-id re-clone rate guard, anchored client-side `isGithubRemote()`.
- **Code HIGH** — session-detail **Resume** (`detail.js`) now also handles `missing:true`.
- **UX** — AA-contrast disclaimer text, `role="note"`, confirm-overlay dialog semantics (`role="dialog"`/`aria-modal`/`aria-labelledby`), Escape-to-close, focus-on-open, `aria-busy`, immediate "Cloning…" feedback.

## Deferred (documented in the design doc)
- HTTP-level route tests: `startServer` has no teardown seam (autoSync/heartbeat timers keep the loop alive) — needs a route-extraction refactor. Interim evidence: green end-to-end server smoke + unit tests for `pathExists`/`cloneRepo`.
- Repo-wide CSRF `Origin` check on mutating POST routes — pre-existing/systemic, not introduced here.

## Test plan
- [x] `node --test test/*.test.js` — 216 pass / 0 fail (1 win32-only skip); adds `test/projects-missing.test.js` (10 cases incl. symlink-ancestor + control-char guards)
- [x] End-to-end server smoke — register → delete folder → `exists:false` → launch `missing:true` → reclone guardrails (no-remote 400, invalid-id 400, unknown-id 404) — GREEN; user registry backed up + restored intact
- [x] Headless render check of the real `renderLauncherCard` — missing (GitHub + local) / present cards + anchored `isGithubRemote` — GREEN
- [ ] Manual: delete a cloned repo's folder, confirm the tile disclaimer + one-click re-clone in the browser (browser extension wasn't available in this session)

Docs: `docs/design/missing-project-detection.md`, `specs/missing-project-detection.feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)