### PR TITLE
feat: launch a project (with or without an agent) from the Terminal tab

### DIFF
--- a/docs/design/terminal-project-launcher.md
+++ b/docs/design/terminal-project-launcher.md
@@ -1,0 +1,124 @@
+# Terminal Project Launcher
+
+## Цель
+
+Дать возможность из вкладки **«Терминал» (Workspace)** одним контролом выбрать
+зарегистрированный проект и открыть в его папке in-app терминал — либо чистый
+(без агента), либо с автозапуском последнего/выбранного агента — по той же
+модели, что и лаунчер на вкладке **Projects**.
+
+## Проблема (текущее состояние)
+
+- Новая вкладка терминала открывает pane в **домашней папке** пользователя.
+- Per-pane меню `Launch ▾` (`launchAgentInPane`) запускает агента, но **в текущей
+  папке pane** — то есть для свежей вкладки агент стартует в `~`, а не в проекте
+  (агенты кёйят историю по `cwd`, поэтому диалог «теряется» — известная ловушка,
+  см. `msg.cwdFellBack` guard в `workspace.js`).
+- Чтобы открыть терминал в папке проекта, надо уйти на вкладку **Projects** и
+  использовать select «⊞ Terminal ▾» (`spawnProjectTerminals`) — но он открывает
+  **только чистые** панели, без агента.
+- Единого «выбрать проект + (опц.) запустить агента» прямо в Терминале нет.
+
+## Инвентаризация данных (переиспользуем, ничего нового на бэкенде)
+
+| Источник | Что даёт |
+|----------|----------|
+| `window.manualProjects` (`GET /api/projects/manual`) | реестр проектов: `{id,name,path,source,exists,git,remoteUrl}` |
+| `window.installedAgents` (`GET /api/agents/installed`) | установленные агенты `{id,label}` |
+| `window.codbashSettings` (`GET /api/settings`) | `defaultAgent`, `lastUsedByPath` |
+| `pickPreferredTool(path,null)` (app.js) | last-used → default → первый установленный |
+| `agentLabel(id)` (app.js) | человекочитаемое имя агента |
+| `WORKSPACE_AGENTS` (workspace.js) | команда запуска агента (`claude`, `codex`, …) |
+| `openInWorkspace({name,cwd,cmd})` (workspace.js) | открыть вкладку в папке; `cmd` **авто-запускается** только если папка открылась (иначе fallback в `~` без запуска) |
+
+Все глобальные символы доступны в общем scope (frontend без модулей — app.js и
+workspace.js инлайнятся в одну страницу).
+
+## Карта компонентов
+
+- **Потребитель**: только фронтенд вкладки Workspace (`src/frontend/workspace.js`).
+- **Бэкенд**: изменений нет — запуск идёт через уже существующий in-app pty
+  (`openInWorkspace` → WS `/ws/terminal`).
+- **Покрытие деплоев**: правка чисто во фронте → одинаково работает в npm-CLI
+  (браузер) и в подписанном desktop-app (Electron оборачивает тот же сервер).
+
+## Контракт (внутренние функции workspace.js)
+
+```
+openWorkspaceProjectLauncher(event)          // открыть popover, якорь = кнопка
+filterWorkspaceProjectLauncher(value)        // перерисовать строки по фильтру
+_wsProjectLauncherRowsHtml(filter)           // HTML строк проектов
+wsLaunchProjectTerminal(projPath, projName)  // чистый терминал в папке (без агента)
+wsLaunchProjectAgent(projPath, projName, tool) // терминал в папке + автозапуск агента
+_wsCloseProjectLauncher()                    // закрыть + вернуть фокус
+```
+
+`tool` → команда через lookup в `WORKSPACE_AGENTS` (по `cmd`/`id`); если агента
+нет в списке — используем сам `id` как команду (best-effort, как per-pane launch).
+
+## Поведение выбора агента
+
+- «▶ ‹agent›» использует `pickPreferredTool(projPath, null)` (last-used → default
+  → первый установленный).
+- Select «Agent ▾» — явный выбор из `window.installedAgents`; при выборе обновляем
+  **in-memory** `window.codbashSettings.lastUsedByPath[projPath] = tool`, чтобы
+  метка «▶ ‹agent›» в этой сессии отражала выбор.
+
+  > **assumption**: серверную персистентность last-used для Workspace-запусков не
+  > делаем — `PUT /api/settings` принимает только `defaultAgent`, а `lastUsedByPath`
+  > пишется сервером лишь через `/api/launch` (нативный терминал). In-app запуски
+  > эфемерны. Персистентность — follow-up (потребует расширения `PUT /api/settings`).
+
+## Стыки (какие файлы менять)
+
+- `src/frontend/workspace.js` — кнопка «＋ Project» в тулбаре `.ws-tools`, popover,
+  хендлеры запуска. Переиспользует `openInWorkspace`.
+- `src/frontend/styles.css` — стили popover (переиспользуем токены `.agent-picker`
+  / launcher-карточек для консистентности).
+
+## Риски
+
+| Риск | Митигация |
+|------|-----------|
+| Агент, запущенный в отсутствующей папке, миспишет историю | `openInWorkspace` уже не авто-запускает `cmd` при `cwdFellBack`; отсутствующие проекты (`exists===false`) показываем disabled |
+| Popover перекрывает терминал / не закрывается | Escape + outside-click + close-on-scroll (паттерн `openAgentPicker`) |
+| Много проектов — длинный список | Фильтр по имени/пути + скролл-контейнер |
+| Нет установленных агентов | Прятать ▶/select, оставлять только ⊞ Terminal |
+| XSS через имя/путь проекта | Всё через `escHtml` (как в остальном UI) |
+
+## UX & Accessibility
+
+**Целевой WCAG-уровень**: AA.
+
+**Required UI states**:
+- [x] Loading — данные (`manualProjects`/`installedAgents`) уже загружены при init;
+      если пусто на момент открытия — показываем empty/hint, не спиннер.
+- [x] Empty — нет зарегистрированных проектов → «No projects yet — add them on the
+      Projects tab» + ссылка-переход на Projects.
+- [x] Error — папка проекта отсутствует (`exists===false`) → строка disabled с
+      пометкой «missing»; запуск в fallback-папку не происходит (guard в pty ready).
+- [x] Success — новая вкладка терминала открывается и активируется; агент виден в
+      статус-баре pane.
+- [x] Disabled — нет агентов → только ⊞ Terminal; отсутствующая папка → без действий.
+- [ ] Partial/Stale — N/A (список читается синхронно из уже загруженного стейта).
+- [ ] Optimistic — N/A.
+
+**Клавиатура**:
+- Кнопка «＋ Project» — обычный таб-стоп; открытие по Enter/Space.
+- При открытии фокус уходит в поле фильтра.
+- Tab/Shift+Tab циклит по строкам/кнопкам; Escape закрывает и возвращает фокус на
+  кнопку-якорь.
+- Native `<select>` для выбора агента — доступен с клавиатуры из коробки.
+- Visible focus ring не убираем.
+
+**Screen reader**:
+- Popover — `role="dialog"` `aria-label="Launch in a project"`.
+- Список — `role="list"`, строки — `role="listitem"`.
+- Кнопки запуска имеют `aria-label` вида «Open terminal in ‹project›» / «Launch
+  ‹agent› in ‹project›».
+- Поле фильтра — `<label>`/`aria-label="Filter projects"`.
+
+**Touch targets**: кнопки/строки ≥ 44×44 (используем существующие размеры кнопок).
+
+**Responsive**: popover с `max-width`/`max-height` + внутренний скролл; на узком
+экране клампится к вьюпорту (как `agentPicker`).

--- a/specs/terminal-project-launcher.feature
+++ b/specs/terminal-project-launcher.feature
@@ -1,0 +1,81 @@
+Feature: Launch a project (with or without an agent) from the Terminal tab
+
+  As a user on the Terminal (Workspace) tab
+  I want to pick a registered project and open an in-app terminal in its folder,
+  optionally auto-running the last-used or a chosen agent,
+  So that I don't have to leave the Terminal tab or manually cd into the project.
+
+  Background:
+    Given the Terminal (Workspace) view is open
+    And the "＋ Project" launcher button is visible in the toolbar
+
+  # 1. Happy path — open a plain terminal in a project
+  Scenario: Open a plain terminal in a project folder (no agent)
+    Given at least one registered project whose folder exists
+    When I open the project launcher and click "⊞ Terminal" on that project
+    Then a new terminal tab opens named after the project
+    And the pane's shell starts in the project folder
+    And no agent command is auto-run
+
+  # 1b. Happy path — launch the preferred/last-used agent
+  Scenario: Launch a project with the last-used agent
+    Given a registered project whose folder exists
+    And at least one agent is installed
+    When I open the project launcher and click the "▶ <agent>" button on that project
+    Then a new terminal tab opens in the project folder
+    And the preferred/last-used agent command is auto-run in that folder
+
+  # 1c. Happy path — pick a specific agent
+  Scenario: Launch a project with an explicitly chosen agent
+    Given a registered project whose folder exists
+    And two or more agents are installed
+    When I open the project launcher and choose a specific agent from the "Agent ▾" select on that project
+    Then a new terminal tab opens in the project folder
+    And the chosen agent command is auto-run there
+    And that agent becomes the shown preferred agent for the project this session
+
+  # 2. Empty state
+  Scenario: No registered projects
+    Given the projects registry is empty
+    When I open the project launcher
+    Then it shows an empty-state message inviting me to add projects on the Projects tab
+    And no project rows are rendered
+
+  # 3. Loading / not-yet-ready data
+  Scenario: Agent list not loaded yet
+    Given the installed-agents data has not loaded
+    When I open the project launcher
+    Then each existing project still shows the "⊞ Terminal" action
+    And the agent launch actions are hidden or disabled until agents are known
+
+  # 4. Error state — missing folder
+  Scenario: Project folder was moved or deleted
+    Given a registered project whose folder no longer exists on disk
+    When I open the project launcher
+    Then that project row is shown as disabled with a "missing" note
+    And it offers no launch actions
+    And clicking elsewhere never spawns a terminal in a fallback home folder for it
+
+  # 4b. Error state — no agents installed
+  Scenario: No agent CLI is installed
+    Given no agents are installed
+    When I open the project launcher
+    Then existing projects show only the "⊞ Terminal" action
+    And no agent launch controls are shown
+
+  # 5. Keyboard-only navigation
+  Scenario: Operate the launcher with the keyboard only
+    Given the project launcher is closed
+    When I focus the "＋ Project" button and press Enter
+    Then the launcher opens and focus moves into the filter field
+    And Tab / Shift+Tab cycles through the project rows and their actions
+    And pressing Escape closes the launcher and returns focus to the "＋ Project" button
+
+  # 6. Edge data
+  Scenario: Long project names, many projects, and special characters
+    Given a project whose name is very long and contains "<script>" and emoji
+    And more registered projects than fit on screen
+    When I open the project launcher and type into the filter field
+    Then the list scrolls within the popover without breaking the page layout
+    And the name is rendered as text (escaped), never as markup
+    And the filter narrows the visible rows by name or path

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -4748,6 +4748,106 @@ body[data-view="overview"] .toolbar { display: none; }
     color: var(--text-muted);
 }
 
+/* "+ Project" launcher popover (Terminal/Workspace toolbar) */
+.ws-proj-launcher {
+    position: fixed;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    z-index: 250;
+    display: none;
+    overflow: hidden;
+}
+.ws-proj-launcher.open { display: flex; flex-direction: column; }
+.ws-proj-launcher-head {
+    padding: 8px;
+    border-bottom: 1px solid var(--border);
+}
+.ws-proj-launcher-filter {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    font-size: 13px;
+    color: var(--text-primary);
+    background: var(--bg-input, var(--bg-card-hover));
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+.ws-proj-launcher-filter:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: -1px;
+}
+.ws-proj-launcher-list {
+    flex: 1 1 auto;           /* fill the clamped popover height, scroll within */
+    min-height: 0;
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 4px;
+}
+.ws-proj-launcher-empty {
+    padding: 14px 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-align: center;
+}
+.ws-proj-launcher-empty a { color: var(--accent-blue); }
+.ws-proj-row {
+    display: flex;
+    flex-direction: column;   /* name/path on top, actions below — names stay readable */
+    align-items: stretch;
+    gap: 6px;
+    padding: 7px 8px;
+    border-radius: 6px;
+}
+.ws-proj-row:hover { background: var(--bg-card-hover); }
+.ws-proj-meta {
+    min-width: 0;             /* allow the name/path to truncate at the row width */
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+.ws-proj-name {
+    font-size: 13px;
+    color: var(--text-primary);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ws-proj-path {
+    font-size: 11px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ws-proj-acts {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.ws-proj-acts .toolbar-btn { padding: 4px 8px; font-size: 12px; }
+.ws-proj-acts .ws-proj-run-btn.primary {
+    background: var(--accent-blue);
+    color: #fff;
+    border-color: var(--accent-blue);
+    max-width: 130px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.ws-proj-acts .ws-proj-agent { max-width: 96px; }
+.ws-proj-row-missing { opacity: 0.55; }
+.ws-proj-row-missing .ws-proj-name { text-decoration: line-through; }
+.ws-proj-missing {
+    font-size: 11px;
+    color: var(--accent-red, #f87171);
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
 /* Projects settings modal */
 .projects-settings-box {
     max-width: 440px !important;

--- a/src/frontend/workspace.js
+++ b/src/frontend/workspace.js
@@ -478,6 +478,10 @@ function _wsHolder() {
 // live workspace into the hidden holder instead of destroying it, so panes and
 // their ptys keep running and everything is exactly as left on return.
 function detachWorkspaceIfMounted() {
+  // The "+ Project" popover lives on document.body (not inside _wsRoot) and holds
+  // global capture listeners — close it here so leaving the view can never orphan
+  // it, even via a non-click path (keyboard nav, programmatic setView).
+  if (typeof _wsCloseProjectLauncher === 'function') _wsCloseProjectLauncher();
   if (_wsRoot && _wsRoot.parentNode && _wsRoot.parentNode.id === 'content') {
     _wsHolder().appendChild(_wsRoot);
   }
@@ -486,6 +490,7 @@ function detachWorkspaceIfMounted() {
 // Full teardown — kills every pty and drops all state. Not used on normal view
 // switches (those detach); reserved for an explicit reset.
 function teardownWorkspaceIfActive() {
+  if (typeof _wsCloseProjectLauncher === 'function') _wsCloseProjectLauncher();
   if (_wsTabs.length) _wsTabs.forEach(function (t) { t.panes.forEach(_wsTeardownPane); });
   _wsTabs = []; _wsActiveTabId = null;
   if (_wsRoot) { try { _wsRoot.remove(); } catch (e) {} _wsRoot = null; }
@@ -1557,6 +1562,219 @@ function spawnProjectTerminals(cwd, n) {
   openInWorkspace({ name: _wsProjectBasename(cwd), cwd: cwd, panes: panes });
 }
 
+// ── "+ Project" launcher popover ─────────────────────────────────────────────
+// Pick a registered project and open an in-app terminal in its folder — plain
+// (no agent) or auto-running the last-used / a chosen agent. Same launch model
+// as the Projects tab, but targets the in-app Workspace instead of a native
+// terminal. Reuses openInWorkspace, which only auto-runs `cmd` when the folder
+// actually opened (a missing folder falls back to ~ WITHOUT running the agent),
+// so an agent never misfiles its history into the home directory.
+
+// Fresh-launch command per installed-agent id. Mirrors the server's authoritative
+// mapping in src/terminals.js (buildLaunchCommand, fresh mode) so an agent started
+// from this popover runs the exact entry point a native launch would — including
+// the gh-extension form for Copilot and the cursor-agent CLI for Cursor. `pi`
+// resolves per-machine (pi vs omp) via getPiCommand(); an unknown id yields null
+// and never launches.
+var _WS_AGENT_CMD = {
+  claude: 'claude', codex: 'codex', qwen: 'qwen', opencode: 'opencode',
+  kiro: 'kiro-cli', kilo: 'kilo', cursor: 'cursor-agent',
+  copilot: 'gh copilot suggest', 'copilot-chat': 'gh copilot suggest'
+};
+function _wsAgentCommand(id) {
+  if (id === 'pi') return (typeof getPiCommand === 'function') ? getPiCommand() : 'pi';
+  return (id && _WS_AGENT_CMD[id]) || null;
+}
+
+var _WS_PROJ_LAUNCHER_W = 340;
+var _wsProjLauncherAnchor = null;
+
+// Installed agents we can actually launch in a terminal here.
+function _wsLaunchableAgents() {
+  return (typeof window !== 'undefined' && window.installedAgents ? window.installedAgents : [])
+    .filter(function (a) { return _wsAgentCommand(a.id); });
+}
+
+// The default agent for a project's "▶" button: the app-wide preferred/last-used
+// tool (pickPreferredTool, from app.js) when it's terminal-launchable, else the
+// first launchable installed agent. Read-only — never mutates settings.
+function _wsPreferredAgent(projPath, launchable) {
+  var pref = (typeof pickPreferredTool === 'function') ? pickPreferredTool(projPath, null) : null;
+  if (pref && _wsAgentCommand(pref)) return pref;
+  return (launchable[0] && launchable[0].id) || null;
+}
+
+function _wsProjectLauncherRowsHtml(filter) {
+  var all = (typeof window !== 'undefined' && window.manualProjects) ? window.manualProjects : [];
+  if (!all.length) {
+    return '<div class="ws-proj-launcher-empty">No projects yet — add them on the ' +
+      '<a href="#" onclick="_wsGotoProjects();return false;">Projects</a> tab.</div>';
+  }
+  var projects = all.slice().sort(function (a, b) {
+    return String(a.name || '').toLowerCase().localeCompare(String(b.name || '').toLowerCase());
+  });
+  var f = String(filter || '').trim().toLowerCase();
+  if (f) {
+    projects = projects.filter(function (p) {
+      return (String(p.name || '') + ' ' + String(p.path || '')).toLowerCase().indexOf(f) >= 0;
+    });
+  }
+  if (!projects.length) return '<div class="ws-proj-launcher-empty">No projects match “' + escHtml(filter) + '”.</div>';
+
+  var launchable = _wsLaunchableAgents();
+  return projects.map(function (p) {
+    var exists = p.exists !== false;   // undefined (older payloads) counts as present
+    var name = p.name || _wsProjectBasename(p.path) || 'project';
+    var shortPath = _wsShortCwd(p.path || '');
+    if (!exists) {
+      return '<div class="ws-proj-row ws-proj-row-missing" role="listitem" aria-disabled="true">' +
+        '<div class="ws-proj-meta"><span class="ws-proj-name">' + escHtml(name) + '</span>' +
+        '<span class="ws-proj-path">' + escHtml(shortPath) + '</span></div>' +
+        '<span class="ws-proj-missing" title="Folder is missing on disk — restore it or remove it on the Projects tab">missing</span>' +
+        '</div>';
+    }
+    // Plain terminal in the folder (no agent) — always available.
+    var acts = '<button class="toolbar-btn ws-proj-term-btn" data-path="' + escHtml(p.path) + '" data-name="' + escHtml(name) + '" ' +
+      'title="Open a terminal in ' + escHtml(name) + ' (no agent)" aria-label="Open a terminal in ' + escHtml(name) + '" ' +
+      'onclick="wsLaunchProjectTerminal(this.dataset.path, this.dataset.name)">&#8862; Terminal</button>';
+    if (launchable.length) {
+      var pref = _wsPreferredAgent(p.path, launchable);
+      if (pref) {
+        acts += '<button class="toolbar-btn primary ws-proj-run-btn" data-path="' + escHtml(p.path) + '" data-name="' + escHtml(name) + '" data-tool="' + escHtml(pref) + '" ' +
+          'title="Launch ' + escHtml(agentLabel(pref)) + ' in ' + escHtml(name) + '" aria-label="Launch ' + escHtml(agentLabel(pref)) + ' in ' + escHtml(name) + '" ' +
+          'onclick="wsLaunchProjectAgent(this.dataset.path, this.dataset.name, this.dataset.tool)">&#9654; ' + escHtml(agentLabel(pref)) + '</button>';
+      }
+      var opts = '<option value="">Agent &#9662;</option>' + launchable.map(function (a) {
+        return '<option value="' + escHtml(a.id) + '">' + escHtml(a.label) + '</option>';
+      }).join('');
+      acts += '<select class="ws-pane-launch ws-proj-agent" data-path="' + escHtml(p.path) + '" data-name="' + escHtml(name) + '" ' +
+        'aria-label="Pick an agent to launch in ' + escHtml(name) + '" ' +
+        'onchange="wsLaunchProjectAgent(this.dataset.path, this.dataset.name, this.value); this.selectedIndex=0;">' + opts + '</select>';
+    }
+    return '<div class="ws-proj-row" role="listitem">' +
+      '<div class="ws-proj-meta"><span class="ws-proj-name">' + escHtml(name) + '</span>' +
+      '<span class="ws-proj-path">' + escHtml(shortPath) + '</span></div>' +
+      '<div class="ws-proj-acts">' + acts + '</div></div>';
+  }).join('');
+}
+
+function openWorkspaceProjectLauncher(event) {
+  if (event) { event.preventDefault(); event.stopPropagation(); }
+  // Toggle: a second click on the button closes it.
+  if (document.getElementById('wsProjLauncher')) { _wsCloseProjectLauncher(); return; }
+  var anchor = (event && event.currentTarget) ? event.currentTarget : document.getElementById('wsAddProject');
+  var el = document.createElement('div');
+  el.className = 'ws-proj-launcher open';
+  el.id = 'wsProjLauncher';
+  // role="group" (not "dialog") — this is a transient labeled popover, not a modal;
+  // it deliberately makes no focus-trap claim (matches the app's other lightweight
+  // popovers). Escape + outside-click close it and focus returns to the anchor.
+  el.setAttribute('role', 'group');
+  el.setAttribute('aria-label', 'Launch in a project');
+  el.style.width = _WS_PROJ_LAUNCHER_W + 'px';
+  el.innerHTML =
+    '<div class="ws-proj-launcher-head">' +
+      '<input type="text" class="ws-proj-launcher-filter" id="wsProjLauncherFilter" placeholder="Filter projects…" ' +
+        'aria-label="Filter projects" autocomplete="off" spellcheck="false" oninput="filterWorkspaceProjectLauncher(this.value)">' +
+    '</div>' +
+    '<div class="ws-proj-launcher-list" id="wsProjLauncherList" role="list">' + _wsProjectLauncherRowsHtml('') + '</div>';
+  document.body.appendChild(el);
+  _wsProjLauncherAnchor = anchor || null;
+
+  var rect = anchor ? anchor.getBoundingClientRect() : { bottom: 56, right: _WS_PROJ_LAUNCHER_W + 16 };
+  var vw = document.documentElement.clientWidth;
+  var vh = document.documentElement.clientHeight;
+  var left = Math.max(8, Math.min(vw - _WS_PROJ_LAUNCHER_W - 8, rect.right - _WS_PROJ_LAUNCHER_W));
+  var top = rect.bottom + 4;
+  el.style.top = top + 'px';
+  el.style.left = left + 'px';
+  // Clamp height to the space below the anchor so a short viewport can't push the
+  // list off-screen — the list scrolls internally (mirrors the horizontal clamp).
+  el.style.maxHeight = Math.max(160, vh - top - 8) + 'px';
+  if (anchor && anchor.setAttribute) anchor.setAttribute('aria-expanded', 'true');
+
+  // Escape can never be the same event that opened the popover, so bind it now
+  // (robust even if the user hits Escape in the same tick). The outside-click and
+  // scroll handlers are deferred a tick so the opening click doesn't self-close.
+  document.addEventListener('keydown', _wsProjLauncherEsc, true);
+  setTimeout(function () {
+    var fld = document.getElementById('wsProjLauncherFilter');
+    if (fld && fld.focus) fld.focus();
+    document.addEventListener('click', _wsProjLauncherOutside, true);
+    window.addEventListener('scroll', _wsProjLauncherScroll, { capture: true, passive: true });
+  }, 0);
+}
+
+function _wsCloseProjectLauncher() {
+  var el = document.getElementById('wsProjLauncher');
+  document.removeEventListener('click', _wsProjLauncherOutside, true);
+  document.removeEventListener('keydown', _wsProjLauncherEsc, true);
+  window.removeEventListener('scroll', _wsProjLauncherScroll, true);
+  var anchor = _wsProjLauncherAnchor;
+  _wsProjLauncherAnchor = null;
+  if (el) el.remove();
+  if (anchor && anchor.setAttribute) anchor.setAttribute('aria-expanded', 'false');
+  if (anchor && anchor.focus) { try { anchor.focus(); } catch (e) {} }
+}
+
+function _wsProjLauncherOutside(e) {
+  var el = document.getElementById('wsProjLauncher');
+  if (!el || el.contains(e.target)) return;
+  if (_wsProjLauncherAnchor && _wsProjLauncherAnchor.contains && _wsProjLauncherAnchor.contains(e.target)) return;
+  _wsCloseProjectLauncher();
+}
+function _wsProjLauncherEsc(e) {
+  if (e.key === 'Escape') { e.stopPropagation(); _wsCloseProjectLauncher(); }
+}
+// Close on page scroll, but NOT when scrolling the launcher's own list.
+function _wsProjLauncherScroll(e) {
+  var el = document.getElementById('wsProjLauncher');
+  if (el && el.contains(e.target)) return;
+  _wsCloseProjectLauncher();
+}
+
+function filterWorkspaceProjectLauncher(value) {
+  var list = document.getElementById('wsProjLauncherList');
+  if (list) list.innerHTML = _wsProjectLauncherRowsHtml(value);
+}
+
+// Open a plain in-app terminal in the project folder (no agent).
+function wsLaunchProjectTerminal(projPath, projName) {
+  _wsCloseProjectLauncher();
+  if (!projPath) return;
+  openInWorkspace({ name: projName || _wsProjectBasename(projPath), cwd: projPath });
+}
+
+// Open an in-app terminal in the project folder and auto-run `tool`'s agent.
+function wsLaunchProjectAgent(projPath, projName, tool) {
+  if (!tool) return;                       // the blank "Agent ▾" option
+  _wsCloseProjectLauncher();
+  if (!projPath) return;
+  var cmd = _wsAgentCommand(tool);
+  if (!cmd) {
+    if (typeof showToast === 'function') showToast('“' + agentLabel(tool) + '” can’t be launched as a terminal agent');
+    return;
+  }
+  // Remember the explicit choice for this session so the "▶" default reflects it.
+  // In-memory only — Workspace launches don't hit /api/launch, and PUT /api/settings
+  // won't persist lastUsedByPath (server writes it solely on native launch).
+  try {
+    window.codbashSettings = window.codbashSettings || {};
+    window.codbashSettings.lastUsedByPath = window.codbashSettings.lastUsedByPath || {};
+    // Guard the map key: a folder literally named __proto__/constructor/prototype
+    // must never be used as a bracket key (defense-in-depth against pollution).
+    if (projPath !== '__proto__' && projPath !== 'constructor' && projPath !== 'prototype') {
+      window.codbashSettings.lastUsedByPath[projPath] = tool;
+    }
+  } catch (e) {}
+  openInWorkspace({ name: projName || _wsProjectBasename(projPath), cwd: projPath, cmd: cmd });
+}
+
+function _wsGotoProjects() {
+  _wsCloseProjectLauncher();
+  if (typeof setView === 'function') setView('projects');
+}
+
 function activateWorkspaceTab(id) {
   if (id === _wsActiveTabId) return;
   _wsActiveTabId = id;
@@ -2014,6 +2232,8 @@ async function renderWorkspace(container) {
             '<button class="toolbar-btn ws-layout-btn" id="wsLayout-4" title="4 panes (2×2)" aria-label="4 panes" onclick="setWorkspaceLayout(4)">' + _WS_ICON_4 + '</button>' +
           '</div>' +
           '<button class="toolbar-btn" id="wsAddPane" title="Add a pane to this tab" onclick="addWorkspacePane(null)">+ Pane</button>' +
+          '<button class="toolbar-btn" id="wsAddProject" title="Open a terminal in a project — with or without an agent" ' +
+            'aria-haspopup="dialog" aria-expanded="false" onclick="openWorkspaceProjectLauncher(event)">+ Project &#9662;</button>' +
           '<span class="ws-tools-sep"></span>' +
           '<button class="toolbar-btn ws-icon-btn" title="Terminal settings — font, theme, cursor" aria-label="Terminal settings" onclick="toggleTerminalSettings(event)">' + _WS_ICON_GEAR + '</button>' +
           '<button class="toolbar-btn" title="Manage saved start commands" onclick="openWorkspaceCommands()">Commands</button>' +


### PR DESCRIPTION
@vakovalskii — review please 🙏

## What this is
A new **"+ Project"** control in the **Terminal (Workspace)** toolbar: a popover listing your registered projects (like the Projects tab), but it opens **in-app** terminals. Each existing project offers three actions:

| Action | Behavior |
|---|---|
| **⊞ Terminal** | plain terminal in the project folder — **no agent** |
| **▶ ‹agent›** | terminal in the folder + auto-run the preferred/last-used agent |
| **Agent ▾** | pick a specific installed agent to launch there |

"Just launch an agent without a project" is still available via the per-pane `Launch ▾` (unchanged).

## Why
- Previously a fresh terminal tab opened in `~`, and the per-pane `Launch ▾` ran the agent in the home dir (agents key their history by `cwd`, so the conversation "gets lost"). Now you can pick a project from the Terminal tab and start the agent directly in its folder.
- Reuses `openInWorkspace()`, which **auto-runs the agent only when the folder actually opens** (a missing folder falls back to `~` WITHOUT running the agent, so history is never misfiled).
- Agent launch commands mirror the server's `buildLaunchCommand` (`src/terminals.js`): Copilot → `gh copilot suggest`, Cursor → `cursor-agent`, `pi` resolves per-machine (`pi`/`omp`) via `getPiCommand()`.

## Deployment coverage
Pure frontend (`workspace.js` + `styles.css`), **no backend changes** → works identically in the npm CLI (web UI) and the desktop app from one codebase.

## UI states
Missing folders shown disabled with a "missing" note (degrades gracefully when the backend has no `exists` field yet); filter; empty-state linking to the Projects tab; close on Escape / outside-click / toggle; popover teardown on view-detach; height clamp; light+dark theming; keyboard support.

## Review (pre-PR)
Ran code-reviewer + security-reviewer and fixed **all** severities:
- **2 HIGH** — wrong launch commands for Copilot and Pi/OhMyPi (ran a nonexistent binary) → now mirror the server.
- **1 MEDIUM** — popover and its global listeners weren't torn down on view detach → added teardown.
- **5 LOW** + **1 security LOW** (`--danger`→`--accent-red`, `role="dialog"`→`role="group"`, dead `gemini` entry, comment accuracy, vertical height clamp, `__proto__` key guard for `lastUsedByPath`).

## Artifacts
- SDD: `docs/design/terminal-project-launcher.md`
- BDD: `specs/terminal-project-launcher.feature`

## Test plan
- [x] Launcher functions exercised in a browser against real data: correct commands for all agents, XSS-escaping (a hostile `<script>` name is escaped, 0 injected tags), filter/empty-state, Escape/outside-click/toggle/inner-scroll, teardown, 0 console errors, renders in dark+light.
- [ ] ⚠️ `@lydell/node-pty` is not installed in my checkout, so the pty terminal itself wasn't brought up live — a full click-through in the mounted toolbar should be run where node-pty is present.